### PR TITLE
Add missing underscore to config help

### DIFF
--- a/_config.epub.yml
+++ b/_config.epub.yml
@@ -1,4 +1,4 @@
 # Addon config the sets layout to epub for epub-compatible-HTML output
 # To run from command line:
-# jekyll build -c _config.yml,config.epub.yml
+# jekyll build -c _config.yml,_config.epub.yml
 output: "epub"

--- a/_config.print-pdf.yml
+++ b/_config.print-pdf.yml
@@ -1,4 +1,4 @@
 # Addon config that sets site.output to print-pdf
 # To run from command line:
-# jekyll build -c _config.yml,config.print-pdf.yml
+# jekyll build -c _config.yml,_config.print-pdf.yml
 output: "print-pdf"

--- a/_config.web.yml
+++ b/_config.web.yml
@@ -1,4 +1,4 @@
 # Addon config that sets site.output to web
 # To run from command line:
-# jekyll build -c _config.yml,config.web.yml
+# jekyll build -c _config.yml,_config.web.yml
 output: "web"


### PR DESCRIPTION
When running the command in the help text in the header of the additional config files, Jekyll returns

```
Configuration file: _config.yml
             Fatal: The configuration file 'config.print.yml' could not be found.
```

because the second config file is missing an underscore.