### PR TITLE
JS-powered navigation

### DIFF
--- a/_includes/end-elements
+++ b/_includes/end-elements
@@ -15,6 +15,7 @@ https://markjs.io/
 <script src="{{ site.baseurl }}/assets/js/mark.min.js"></script>
 <script src="{{ site.baseurl }}/assets/js/search.js"></script>
 <script src="{{ site.baseurl }}/assets/js/mark-search-terms.js"></script>
+<script src="{{ site.baseurl }}/assets/js/nav.js" async defer></script>
 {% endif %}
 
 {% comment %}

--- a/_includes/nav-button.html
+++ b/_includes/nav-button.html
@@ -1,0 +1,1 @@
+<a href="#nav">Contents &darr;</a>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -4,7 +4,9 @@
 
     <div class="nav-wrapper">
         <div id="nav" class="non-printing">
-        
+
+            <h2>Contents</h2>
+
             <div class="search">
                 {% include search %}
             </div><!--.search-->
@@ -66,6 +68,9 @@
 
     <div class="nav-wrapper">
         <div id="nav" class="non-printing">
+
+            <h2>Contents</h2>
+
             <div class="nav-list">
                 <ul>
                     {% comment %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,8 +2,7 @@
 
 {% if site.nav-source == "nav" %}
 
-    <div class="nav-wrapper">
-        <div id="nav" class="non-printing">
+    <div id="nav" class="non-printing">
 
             <h2>Contents</h2>
 
@@ -62,12 +61,10 @@
             </div><!--.widgets-->
 
         </div><!--#nav-->
-    </div><!--.nav-wrapper-->
 
 {% else %}
 
-    <div class="nav-wrapper">
-        <div id="nav" class="non-printing">
+    <div id="nav" class="non-printing">
 
             <h2>Contents</h2>
 
@@ -93,6 +90,5 @@
                 </ul>
             </div><!--.nav-list-->
         </div><!--#nav-->
-    </div><!--.nav-wrapper-->
 
 {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,10 +16,11 @@
 
 {% include head.html %}
 {% include masthead.html %}
-{% include nav.html %}
+{% include nav-button.html %}
 {% include start-content.html %}
 {{ content }}
 {% include close-content.html %}
+{% include nav.html %}
 {% include footer.html %}
 {% include close-body.html %}
 

--- a/_sass/partials/_web-nav-bar.scss
+++ b/_sass/partials/_web-nav-bar.scss
@@ -92,8 +92,17 @@ $web-nav-bar: true !default;
                     padding: 0; // debugging
                     width: 100%; // Use full width of li area
                     // Indicator that a list item has children
-                    &.has-children a:after {
+                    &.has-children {
+                      a:after {
+                        position: absolute;
+                        right: 1em;
                         content: $nav-bar-children-prompt;
+                      }
+                    }
+                    &.showing-children {
+                      > a:after {
+                        content: $nav-bar-children-prompt-hide;
+                      }
                     }
                     // but don't inherit that if there are no children
                     &.no-children a:after {

--- a/_sass/partials/_web-nav-bar.scss
+++ b/_sass/partials/_web-nav-bar.scss
@@ -2,7 +2,17 @@ $web-nav-bar: true !default;
 @if $web-nav-bar {
 
     // Navigation
-     
+
+    [href="#nav"] {
+      font-family: $font-text-secondary;
+      font-size: $nav-bar-text-size;
+      color: #9c9c9c;
+      padding: 0.5em 1em;
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
+
     .nav-wrapper {
         @if $nav-bar-scrollbar == true {
             overflow: visible;
@@ -10,12 +20,6 @@ $web-nav-bar: true !default;
         @else {
             overflow: hidden;
         }
-        // position: fixed;
-        // top: 0;
-        // bottom: 0;
-        float: left;
-        width: $nav-bar-width;
-        margin-right: 2em; // prevents overlaps with .content
     }
     // For Webkit, this is the easy way to remove the scrollbar
     // #nav::-webkit-scrollbar {
@@ -29,7 +33,7 @@ $web-nav-bar: true !default;
         overflow-x: hidden; // Hides horizontal scrollbar
         overflow-y: auto; // Must let this div scroll; we'll hide the scrollbar elsewhere
         background-color: $nav-bar-background-color;
-        border-right: 1px solid $nav-bar-border-color;
+        border-top: 1px solid $nav-bar-border-color;
         padding-right: 17px; // Hides scroll bar
 
         // Search
@@ -162,90 +166,13 @@ $web-nav-bar: true !default;
         } // .nav-list
         .widgets {
             margin: 0 -17px 0 0; // Fills width of container-with-hidden-scrollbar
-            min-height: 10em;
             } // .widgets
+
+        h2 {
+          padding-left: 0.4em;
+        }
+
     } // #nav
 
-    // Optionally, hide sidebar behind menu icon
-    // till menu is hovered or tapped
-    $nav-bar-hide: true !default;
-    @if $nav-bar-hide {
-        .nav-wrapper {
-            #nav {
-                max-width: 0;
-                max-height: 0;
-                // transition: max-width 0.5s; // Disabled because of flickering problem
-                padding-right: 0;
-            }
-            &:before {
-                content: $nav-bar-prompt;
-                font-family: $font-text-secondary;
-                color: $nav-bar-prompt-text-color;
-                display: block;
-                position: fixed;
-                left: 0;
-                top: 0;
-                padding: 0.5em 1em;
-                cursor: pointer;
-            }
-            &:hover, &:active, &.focus {
-                #nav {
-                    max-width: $nav-bar-width;
-                    max-height: none;
-                    // transition: max-width 0.5s; // Disabled because of flickering problem
-                    position: fixed;
-                    top: 0;
-                }
-                &:before {
-                    display: none;
-                }
-            }
-        }
-    }
-
-    // On small screens, hide sidebar behind menu icon
-    // till menu is hovered or tapped
-    @media only screen 
-    and (max-width: $break-point-width) {
-        .nav-wrapper {
-            &:before {
-                // Repeat many of these in case nav-bar-hide is false,
-                // in which case they will not be around to be inherited.
-                content: $nav-bar-prompt;
-                font-family: $font-text-secondary;
-                color: $nav-bar-prompt-text-color;
-                display: block;
-                position: fixed;
-                top: 0;
-                left: 0;
-                width: 100%;
-                background-color: $nav-bar-background-color;
-                padding: 0.5em;
-                border-top: 1px solid $nav-bar-border-color;
-                border-right: 1px solid $nav-bar-border-color;
-                border-bottom: 1px solid $nav-bar-border-color;
-                cursor: pointer;
-            }
-            // Hide menu on small screens even if nav-bar-hide is false
-            #nav {
-                max-width: 0;
-                max-height: 0;
-                // transition: max-width 0.5s; // Disabled because of flickering problem
-                padding-right: 0;
-            }
-            &:hover, &:active, &.focus {
-                #nav {
-                    max-width: $nav-bar-width;
-                    max-height: none;
-                    // transition: max-width 0.5s; // Disabled because of flickering problem
-                    position: fixed;
-                    top: 0;
-                }
-                &:before {
-                    display: none;
-                }
-            }
-        }
-    }
 
 }

--- a/_sass/partials/_web-nav-bar.scss
+++ b/_sass/partials/_web-nav-bar.scss
@@ -39,14 +39,16 @@ $web-nav-bar: true !default;
         width: 100%;
         height: 100%;
         overflow-x: hidden; // Hides horizontal scrollbar
-        overflow-y: auto; // Must let this div scroll; we'll hide the scrollbar elsewhere
         background-color: $nav-bar-background-color;
         border-top: 1px solid $nav-bar-border-color;
         padding-right: 17px; // Hides scroll bar
 
+        .js-nav-open & {
+          overflow-y: auto; // Must let this div scroll; we'll hide the scrollbar elsewhere
+        }
+
         .js-nav & {
           width: $nav-bar-width;
-          margin-right: 2em; // prevents overlaps with .content
           border-top: none;
           border-right: 1px solid $nav-bar-border-color;
           position: absolute;

--- a/_sass/partials/_web-nav-bar.scss
+++ b/_sass/partials/_web-nav-bar.scss
@@ -11,16 +11,24 @@ $web-nav-bar: true !default;
       position: absolute;
       top: 0;
       left: 0;
+      .js-nav-open & {
+        right: 0;
+        bottom: 0;
+        background-color: rgba(0,0,0,0.5);
+      }
     }
 
-    .nav-wrapper {
-        @if $nav-bar-scrollbar == true {
-            overflow: visible;
-        }
-        @else {
-            overflow: hidden;
-        }
+    .visuallyhidden {
+        border: 0;
+        clip: rect(0 0 0 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
     }
+
     // For Webkit, this is the easy way to remove the scrollbar
     // #nav::-webkit-scrollbar {
     //     display: none;
@@ -35,6 +43,16 @@ $web-nav-bar: true !default;
         background-color: $nav-bar-background-color;
         border-top: 1px solid $nav-bar-border-color;
         padding-right: 17px; // Hides scroll bar
+
+        .js-nav & {
+          width: $nav-bar-width;
+          margin-right: 2em; // prevents overlaps with .content
+          border-top: none;
+          border-right: 1px solid $nav-bar-border-color;
+          position: absolute;
+          top: 0;
+          left: 0;
+        }
 
         // Search
         $search-enabled: true !default;

--- a/_sass/partials/_web-nav-bar.scss
+++ b/_sass/partials/_web-nav-bar.scss
@@ -91,23 +91,6 @@ $web-nav-bar: true !default;
                     // padding: 0.25em 0.75em; // debugging
                     padding: 0; // debugging
                     width: 100%; // Use full width of li area
-                    // Indicator that a list item has children
-                    &.has-children {
-                      a:after {
-                        position: absolute;
-                        right: 1em;
-                        content: $nav-bar-children-prompt;
-                      }
-                    }
-                    &.showing-children {
-                      > a:after {
-                        content: $nav-bar-children-prompt-hide;
-                      }
-                    }
-                    // but don't inherit that if there are no children
-                    &.no-children a:after {
-                        content: normal;
-                    }
                     a { // Make link fill entire li area
                         display: block;
                         // width: 100%;
@@ -203,5 +186,30 @@ $web-nav-bar: true !default;
 
     } // #nav
 
+  .has-children {
+    position: relative;
+  }
+
+  [data-toggle-nav] {
+    position: absolute;
+    top: 0;
+    right: 0;
+    background-color: transparent;
+    border: none;
+    color: $nav-bar-child-text-hover-color;
+    font-size: 1.25em;
+    padding: 0 0.5em;
+    &:focus {
+      outline: none;
+    }
+    &:after {
+      content: "+";
+    }
+    &.show-children {
+      &:after {
+        content: "-";
+      }
+    }
+  }
 
 }

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -92,6 +92,7 @@ $masthead-border-color: $color-light !default;
 $nav-bar-text-size: 0.8em !default;
 $nav-bar-item-collapse: false !default; // Does the nav list fully expand, or collapse until mouseover?
 $nav-bar-children-prompt: normal !default; // \2026 is an ellipsis (…)
+$nav-bar-children-prompt-hide: normal !default;
 $nav-bar-scrollbar: true !default;
 $nav-bar-width: 15em !default;
 $nav-bar-border-color: $color-light !default;

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -90,8 +90,6 @@ $masthead-border-color: $color-light !default;
 
 // Website sidebar/navigation
 $nav-bar-text-size: 0.8em !default;
-$nav-bar-hide: true !default;
-$nav-bar-prompt: "Contents" !default;
 $nav-bar-item-collapse: false !default; // Does the nav list fully expand, or collapse until mouseover?
 $nav-bar-children-prompt: normal !default; // \2026 is an ellipsis (…)
 $nav-bar-scrollbar: true !default;

--- a/assets/js/get-query-variable.js
+++ b/assets/js/get-query-variable.js
@@ -18,7 +18,7 @@ var searchTerm = getQueryVariable('query'),
 
 if (searchTerm && searchBox) {
   // show the just-searched-term
-  for (i = 0; i < searchBox.length; ++i) {
-    searchBox[i].setAttribute("value", searchTerm);
+  for (var j = 0; j < searchBox.length; ++j) {
+    searchBox[j].setAttribute("value", searchTerm);
   }
 }

--- a/assets/js/mark-search-terms.js
+++ b/assets/js/mark-search-terms.js
@@ -1,3 +1,5 @@
 // set up for mark.js to do its thing
 var markInstance = new Mark(document.querySelector("#wrapper"));
-markInstance.unmark().mark(searchTerm);
+if (searchTerm) {
+  markInstance.unmark().mark(searchTerm);
+}

--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -20,10 +20,12 @@
       // hide the menu until we click the link
       menu.classList.add("visuallyhidden");
 
-      // hide the children
-      var subMenus = document.querySelectorAll('#nav .has-children ol, #nav .has-children ul');
+      // hide the children and add the button for toggling
+      var subMenus = document.querySelectorAll('#nav .has-children, #nav .has-children');
+      var showChildrenButton = '<button data-toggle-nav><span class="visuallyhidden">Toggle children</button>';
       for (var i = 0; i < subMenus.length; i++) {
-        subMenus[i].classList.add('visuallyhidden');
+        subMenus[i].querySelector('ol, ul').classList.add('visuallyhidden');
+        subMenus[i].querySelector('a').insertAdjacentHTML('afterend', showChildrenButton);
       }
 
       // show the menu when we click the link
@@ -35,9 +37,9 @@
 
       // show the children when we click a .has-children
       menu.addEventListener("click", function(ev) {
-        if (!ev.target.hasAttribute("href")) {
+        if (ev.target.hasAttribute("data-toggle-nav")) {
           ev.preventDefault();
-          ev.target.parentNode.classList.toggle('showing-children');
+          ev.target.classList.toggle('show-children');
           ev.target.nextElementSibling.classList.toggle('visuallyhidden');
         }
       }, true)

--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -1,0 +1,34 @@
+ "use strict";
+
+(function () {
+
+  // let Opera Mini use the footer-anchor pattern
+  if (navigator.userAgent.indexOf('Opera Mini') === - 1) {
+
+    // let newer browsers use js-powered menu
+    if('querySelector' in document &&
+       'addEventListener' in window &&
+       document.documentElement.classList) {
+
+      // set js nav class
+      document.documentElement.classList.add('js-nav');
+
+      // set up the variables
+      var menuLink = document.querySelector('[href="#nav"]');
+      var menu = document.querySelector('#nav');
+
+      // hide the menu until we click the link
+      menu.classList.add("visuallyhidden");
+
+      // show the menu when we click the link
+      menuLink.addEventListener("click", function(ev) {
+        ev.preventDefault();
+        menu.classList.toggle("visuallyhidden");
+        document.documentElement.classList.toggle('js-nav-open');
+      }, true);
+
+    }
+
+  }
+
+}());

--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -20,12 +20,27 @@
       // hide the menu until we click the link
       menu.classList.add("visuallyhidden");
 
+      // hide the children
+      var subMenus = document.querySelectorAll('#nav .has-children ol, #nav .has-children ul');
+      for (var i = 0; i < subMenus.length; i++) {
+        subMenus[i].classList.add('visuallyhidden');
+      }
+
       // show the menu when we click the link
       menuLink.addEventListener("click", function(ev) {
         ev.preventDefault();
         menu.classList.toggle("visuallyhidden");
         document.documentElement.classList.toggle('js-nav-open');
       }, true);
+
+      // show the children when we click a .has-children
+      menu.addEventListener("click", function(ev) {
+        if (!ev.target.hasAttribute("href")) {
+          ev.preventDefault();
+          ev.target.parentNode.classList.toggle('showing-children');
+          ev.target.nextElementSibling.classList.toggle('visuallyhidden');
+        }
+      }, true)
 
     }
 

--- a/book/styles/web.scss
+++ b/book/styles/web.scss
@@ -94,9 +94,6 @@ $masthead-border-color: $color-light;
 
 // Website sidebar/navigation
 $nav-bar-text-size: 0.8em;
-$nav-bar-hide: true;
-$nav-bar-prompt: "Contents";
-$nav-bar-prompt-text-color: $color-mid;
 $nav-bar-item-collapse: false; // Does the nav list fully expand, or collapse until mouseover?
 $nav-bar-children-prompt: ""; // \2026 is an ellipsis (…)
 $nav-bar-scrollbar: true;

--- a/book/styles/web.scss
+++ b/book/styles/web.scss
@@ -95,7 +95,8 @@ $masthead-border-color: $color-light;
 // Website sidebar/navigation
 $nav-bar-text-size: 0.8em;
 $nav-bar-item-collapse: false; // Does the nav list fully expand, or collapse until mouseover?
-$nav-bar-children-prompt: ""; // \2026 is an ellipsis (…)
+$nav-bar-children-prompt: "+"; // \2026 is an ellipsis (…)
+$nav-bar-children-prompt-hide: "-";
 $nav-bar-scrollbar: true;
 $nav-bar-width: 15em;
 $nav-bar-border-color: $color-light;


### PR DESCRIPTION
This PR makes the showing and hiding of the nav powered by JS rather than CSS. By default, the nav appears at the bottom of the page, full width.

If JS is on and the browser supports the features we want to use (`querySelector`, `addEventListener`, and `classList`), we hide the menu by adding the new `visuallyhidden` class and hide the submenus the same way.

On clicking the menu button:

- the button itself expands page-wide under the menu (using absolute positioning. Clicking that toggles the `visuallyhidden` class);
- the menu is shown by toggling the `visuallyhidden` class.

If a submenu link is clicked, we show the submenu by by toggling the `visuallyhidden` class, and the new `showing-children` class to update the little icon.