### PR TITLE
Remove darken on hover, only use box-shadow on hover

### DIFF
--- a/_sass/partials/_web-buttons.scss
+++ b/_sass/partials/_web-buttons.scss
@@ -3,86 +3,84 @@ $web-buttons: true !default;
 
 	// Buttons
 
-    // Applied to inline elements
-    a.button,
-    em.button,
-    strong.button,
-    span.button, {
-        display: inline-block;
+	// Applied to inline elements
+	a.button,
+	em.button,
+	strong.button,
+	span.button, {
+		display: inline-block;
 		font-family: $font-text-secondary;
 		color: $color-background;
 		line-height: 100%;
-        text-decoration: none;
+		text-decoration: none;
 		background-color: $color-buttons;
 		padding: 0.2em 0.4em;
 		margin: 0;
 		text-align: center;
-        text-indent: 0;
+		text-indent: 0;
 		border-radius: $button-border-radius;
-		box-shadow: 0.02em 0.02em 0.02em 0.02em $color-buttons;
 		cursor: pointer;
 		&:hover {
-			background-color: darken( $color-buttons, 5% );
-		}
-    }
-
-    // Applied to block-level elements
-    p.button,
-    ol.button,
-    ul.button,
-    li.button,
-    blockquote.button,
-    table.button,
-    div.button,
-    h1.button,
-    h2.button,
-    h3.button,
-    h4.button,
-    h5.button,
-    h6.button, {
-        text-indent: 0;
-        a {
-            display: inline-block;
-            font-family: $font-text-secondary;
-            color: $color-background;
-            background-color: $color-buttons;
-            padding: 0.5em;
-            margin: $line-height-default 0;
-            line-height: 1;
-			text-align: center;
-            text-decoration: none;
-            border-radius: $button-border-radius;
 			box-shadow: 0.02em 0.02em 0.02em 0.02em $color-buttons;
+		}
+	}
+
+	// Applied to block-level elements
+	p.button,
+	ol.button,
+	ul.button,
+	li.button,
+	blockquote.button,
+	table.button,
+	div.button,
+	h1.button,
+	h2.button,
+	h3.button,
+	h4.button,
+	h5.button,
+	h6.button, {
+		text-indent: 0;
+		a {
+			display: inline-block;
+			font-family: $font-text-secondary;
+			color: $color-background;
+			background-color: $color-buttons;
+			padding: 0.5em;
+			margin: $line-height-default 0;
+			line-height: 1;
+			text-align: center;
+			text-decoration: none;
+			border-radius: $button-border-radius;
 			cursor: pointer;
 			&:hover {
-				background-color: darken( $color-buttons, 5% );
+				box-shadow: 0.02em 0.02em 0.02em 0.02em $color-buttons;
 			}
-        }
-        & + p {
-            text-indent: 0;
-        }
-    }
+		}
+		& + p {
+			text-indent: 0;
+		}
+	}
 
-    // An option to change the default text-indented paragraphs
-    // and close-up lists etc. to have space-between instead.
-    @if $spaced-paras {
-        p.button,
-        ol.button,
-        ul.button,
-        li.button,
-        blockquote.button,
-        table.button,
-        div.button,
-        h1.button,
-        h2.button,
-        h3.button,
-        h4.button,
-        h5.button,
-        h6.button, {
-            a {
-                margin: 0;
-            }
-        }
-    }
-    
+	// An option to change the default text-indented paragraphs
+	// and close-up lists etc. to have space-between instead.
+	@if $spaced-paras {
+		p.button,
+		ol.button,
+		ul.button,
+		li.button,
+		blockquote.button,
+		table.button,
+		div.button,
+		h1.button,
+		h2.button,
+		h3.button,
+		h4.button,
+		h5.button,
+		h6.button, {
+			a {
+				margin: 0;
+			}
+		}
+	}
+	
 }

--- a/_sass/partials/_web-buttons.scss
+++ b/_sass/partials/_web-buttons.scss
@@ -21,7 +21,7 @@ $web-buttons: true !default;
 		border-radius: $button-border-radius;
 		cursor: pointer;
 		&:hover {
-			box-shadow: 0.02em 0.02em 0.02em 0.02em $color-buttons;
+			background-color: $color-buttons-hover;
 		}
 	}
 
@@ -53,7 +53,7 @@ $web-buttons: true !default;
 			border-radius: $button-border-radius;
 			cursor: pointer;
 			&:hover {
-				box-shadow: 0.02em 0.02em 0.02em 0.02em $color-buttons;
+				background-color: $color-buttons-hover;
 			}
 		}
 		& + p {

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -58,6 +58,7 @@ $color-mid: #9c9c9c !default;
 $color-accent: #000000 !default;
 $color-links: #5f738c !default;
 $color-buttons: #5f738c !default;
+$color-buttons-hover: darken( $color-buttons, 20% ) !default;
 $color-highlight: #ffd54d !default;
 
 // Some features rearrange at certain screen sizes.

--- a/book/styles/web.scss
+++ b/book/styles/web.scss
@@ -62,6 +62,7 @@ $color-mid: #9c9c9c;
 $color-accent: #000000;
 $color-links: #5f738c;
 $color-buttons: #5f738c;
+$color-buttons-hover: darken( $color-buttons, 20% );
 $color-highlight: #ffd54d;
 
 // Some features rearrange at certain screen sizes.


### PR DESCRIPTION
Minor tweak to default button styling. Should take you about five seconds to glance through, @SteveBarnett?

No idea why the diff is showing indentation changes.