### PR TITLE
Better fallback for screen-pdf TOC

### DIFF
--- a/_includes/toc
+++ b/_includes/toc
@@ -34,6 +34,8 @@ Fall back to print-pdf toc, then web nav list, then print file list.
         {% assign toc = work.products.print-pdf.toc %}
     {% elsif work.products.web.nav != nil %}
         {% assign toc = work.products.web.nav %}
+    {% else %}
+        Please define a TOC or web nav in meta.yml.
     {% endif %}
 
 {% elsif site.output == "epub" %}
@@ -41,6 +43,10 @@ Fall back to print-pdf toc, then web nav list, then print file list.
         {% assign toc = work.products.epub.toc %}
     {% else %}
         {% assign toc = work.products.print-pdf.toc %}
+    {% elsif work.products.web.nav != nil %}
+        {% assign toc = work.products.web.nav %}
+    {% else %}
+        Please define a TOC or web nav in meta.yml.
     {% endif %}
 
 {% elsif site.output == "web" %}
@@ -50,6 +56,8 @@ Fall back to print-pdf toc, then web nav list, then print file list.
         {% assign toc = work.products.web.nav %}
     {% else %}
         {% assign toc = work.products.print-pdf.toc %}
+    {% else %}
+        Please define a TOC or web nav in meta.yml.
     {% endif %}
 
 {% else %}

--- a/_includes/toc
+++ b/_includes/toc
@@ -30,8 +30,10 @@ Fall back to print-pdf toc, then web nav list, then print file list.
 {% elsif site.output == "screen-pdf" %}
     {% if work.products.screen-pdf.toc != nil %}
         {% assign toc = work.products.screen-pdf.toc %}
-    {% else %}
+    {% elsif work.products.print-pdf.toc != nil %}
         {% assign toc = work.products.print-pdf.toc %}
+    {% elsif work.products.web.nav != nil %}
+        {% assign toc = work.products.web.nav %}
     {% endif %}
 
 {% elsif site.output == "epub" %}


### PR DESCRIPTION
After testing on another book, realised we need a smarter fallback for screen-pdf TOCs based on what meta a user is likely to create in `meta.yml`.

Quick glance, @SteveBarnett?
