### PR TITLE
Don't start new prince-page-group on h1 by default

### DIFF
--- a/_sass/partials/_print-page-headers-footers-content.scss
+++ b/_sass/partials/_print-page-headers-footers-content.scss
@@ -123,7 +123,7 @@ $print-page-headers-footers-content: true !default;
   }
 
   // No headers on first pages of chapters
-  .chapter, h1 {
+  .chapter {
     prince-page-group: start;
   }
   @page chapter:first {


### PR DESCRIPTION
The cases where it's useful seem fewer than the cases where it's a problem, e.g. in a poetry collection where the h1 is a child of blockquote, and is not the first element on the page, starting a new page group creates an unwanted page break before.

I think I originally included it for books where several 'chapters' were in one file, and only distinguished by their starting with an h1, in which case you would want each h1 to start a new prince-page-group (mainly so that running heads are not included on that first page of the prince-page-group). 

I've only used that one-file structure where I've needed consecutively numbered endnotes for all chapters gathered at the end of a book (i.e. in the same markdown file), which is a rare case usually created by overly particular client requirements. Should that case arise in future, it's easier to put `h1 { prince-page-group: start; }` in custom CSS.