### PR TITLE
Fix default nav position to not `fixed`

### DIFF
--- a/_sass/partials/_web-nav-bar.scss
+++ b/_sass/partials/_web-nav-bar.scss
@@ -21,7 +21,7 @@ $web-nav-bar: true !default;
         }
     }
     // Reset position to fixed if $nav-bar-fixed: true
-    $nav-bar-fixed: true !default;
+    $nav-bar-fixed: false !default;
     @if $nav-bar-fixed {
         [href="#nav"] {
             position: fixed;
@@ -39,7 +39,7 @@ $web-nav-bar: true !default;
         width: 1px;
     }
     // Reset position to fixed if $nav-bar-fixed: true
-    $nav-bar-fixed: true !default;
+    $nav-bar-fixed: false !default;
     @if $nav-bar-fixed {
         .visuallyhidden {
             position: fixed;
@@ -73,7 +73,7 @@ $web-nav-bar: true !default;
             left: 0;
         }
         // Reset position to fixed if $nav-bar-fixed: true
-        $nav-bar-fixed: true !default;
+        $nav-bar-fixed: false !default;
         @if $nav-bar-fixed {
             .js-nav & {
                 position: fixed;


### PR DESCRIPTION
@SteveBarnett After eyeballing the [merged navigation PR](https://github.com/electricbookworks/electric-book/pull/36) I see I missed changing the default `$nav-bar-fixed` where it appeared inside the partial. 