### PR TITLE
Fix text color of links of active parents

### DIFF
--- a/_sass/partials/_web-nav-bar.scss
+++ b/_sass/partials/_web-nav-bar.scss
@@ -135,6 +135,11 @@ $web-nav-bar: true !default;
                         a {
                             color: $nav-bar-child-text-hover-color;
                         }
+                        li {
+                            a {
+                                color: $nav-bar-child-text-color;
+                            }
+                        }
                     }
                 } // li
                 // Child navigation, after the parent, the rest of the nav-list


### PR DESCRIPTION
Before, children of `.active` parent links inherited `$nav-bar-child-text-hover-color`. This change retains their `$nav-bar-child-text-color` until they are themselves `.active` or `:hover`ed.

@SteveBarnett Found this while working on CORE. Can you have a quick look, please?