### PR TITLE
Change _html back to _site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 _site/
-_html/
 .sass-cache/
 .jekyll-metadata
 

--- a/_config.yml
+++ b/_config.yml
@@ -54,10 +54,6 @@ mathjax-enabled: false
 # CHANGE THESE SETTINGS ONLY IF/WHEN NECESSARY
 # --------------------------------------------
 
-# By default Jekyll puts generated HTML in a _site folder. 
-# For Electric Book purposes, we prefer to call this '_html'
-destination: ./_html
-
 # Output different HTML structures based on intent.
 # You can change these here, or rather override by loading two config files at the command line, e.g.:
 # jekyll build -c _config.yml,_config.epub.yml

--- a/_prose.yml
+++ b/_prose.yml
@@ -18,7 +18,6 @@ prose:
     - /_layouts
     - /_includes
     - /_site
-    - /_html
     - /_sass
     - search.md
     - /*/search.md

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -51,8 +51,8 @@ If not, just hit return."
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML
 			bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,$config"
-			# Navigate into the book's folder in _html output
-			cd _html/$bookfolder/text
+			# Navigate into the book's folder in _site output
+			cd _site/$bookfolder/text
 			# Let the user know we're now going to make the PDF
 			echo Creating PDF...
 			# Run prince, showing progress (-v), printing the docs in file-list
@@ -99,8 +99,8 @@ If not, just hit return."
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML
 			bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,$config"
-			# Navigate into the book's folder in _html output
-			cd _html/$bookfolder/text
+			# Navigate into the book's folder in _site output
+			cd _site/$bookfolder/text
 			# Let the user know we're now going to make the PDF
 			echo Creating PDF...
 			# Run prince, showing progress (-v), printing the docs in file-list
@@ -199,8 +199,8 @@ If not, just hit return."
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML
 			bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,$config"
-			# Navigate into the book's folder in _html output
-			cd _html/$bookfolder/text
+			# Navigate into the book's folder in _site output
+			cd _site/$bookfolder/text
 			# Navigate back to where we began.
 			cd $location
 			# Navigate to the _output folder...
@@ -213,7 +213,7 @@ If not, just hit return."
 			# Navigate back to where we began.
 			cd $location
 			# Got into HTML-output folder
-			cd _html/$bookfolder
+			cd _site/$bookfolder
 		    # Open file browser to see epub-ready HTML files
 		    xdg-open .
 		    # Navigate back to where we started

--- a/run-mac.command
+++ b/run-mac.command
@@ -53,8 +53,8 @@ If not, just hit return."
             echo "Generating HTML..."
             # ...and run Jekyll to build new HTML
             bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,$config"
-            # Navigate into the book's folder in _html output
-            cd _html/$bookfolder/text
+            # Navigate into the book's folder in _site output
+            cd _site/$bookfolder/text
             # Let the user know we're now going to make the PDF
             echo Creating PDF...
             # Run prince, showing progress (-v), printing the docs in file-list
@@ -101,8 +101,8 @@ If not, just hit return."
             echo "Generating HTML..."
             # ...and run Jekyll to build new HTML
             bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,$config"
-            # Navigate into the book's folder in _html output
-            cd _html/$bookfolder/text
+            # Navigate into the book's folder in _site output
+            cd _site/$bookfolder/text
             # Let the user know we're now going to make the PDF
             echo Creating PDF...
             # Run prince, showing progress (-v), printing the docs in file-list
@@ -201,8 +201,8 @@ If not, just hit return."
             echo "Generating HTML..."
             # ...and run Jekyll to build new HTML
             bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,$config"
-            # Navigate into the book's folder in _html output
-            cd _html/$bookfolder/text
+            # Navigate into the book's folder in _site output
+            cd _site/$bookfolder/text
             # Navigate back to where we began.
             cd $location
             # Navigate to the _output folder...
@@ -215,7 +215,7 @@ If not, just hit return."
             # Navigate back to where we began.
             cd $location
             # Got into HTML-output folder
-            cd _html/$bookfolder
+            cd _site/$bookfolder
             # Open file browser to see epub-ready HTML files
             open .
             # Navigate back to where we started

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -71,8 +71,8 @@ SET /p process=Enter a number and hit return.
     ECHO Generating HTML...
     :: ...and run Jekyll to build new HTML
     CALL bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,_configs/_config.image-set.print-pdf.yml,%config%"
-    :: Navigate into the book's folder in _html output
-    CD _html\%bookfolder%\text\"%subdirectory%"
+    :: Navigate into the book's folder in _site output
+    CD _site\%bookfolder%\text\"%subdirectory%"
     :: Let the user know we're now going to make the PDF
     ECHO Creating PDF...
     :: Check if the _output folder exists, or create it if not.
@@ -136,8 +136,8 @@ SET /p process=Enter a number and hit return.
     ECHO Generating HTML...
     :: ...and run Jekyll to build new HTML
     CALL bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,_configs/_config.image-set.screen-pdf.yml,%config%"
-    :: Navigate into the book's folder in _html output
-    CD _html\%bookfolder%\text\"%subdirectory%"
+    :: Navigate into the book's folder in _site output
+    CD _site\%bookfolder%\text\"%subdirectory%"
     :: Let the user know we're now going to make the PDF
     ECHO Creating PDF...
     :: Run prince, showing progress (-v), printing the docs in file-list
@@ -260,8 +260,8 @@ SET /p process=Enter a number and hit return.
     ECHO Generating HTML...
     :: ...and run Jekyll to build new HTML
     CALL bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.image-set.epub.yml,%config%"
-    :: Navigate into the book's folder in _html output
-    CD _html\%bookfolder%\text\"%subdirectory%"
+    :: Navigate into the book's folder in _site output
+    CD _site\%bookfolder%\text\"%subdirectory%"
     :: Let the user know we're now going to open Sigil
     ECHO Opening Sigil...
     :: Temporarily put Sigil in the PATH, whether x86 or not
@@ -269,7 +269,7 @@ SET /p process=Enter a number and hit return.
     :: and open the cover HTML file in it, to load metadata into Sigil
     START "" sigil.exe "%firstfile%.html"
     :: Open file explorer to make it easy to see the HTML to assemble
-    %SystemRoot%\explorer.exe "%location%_html\%bookfolder%\%subdirectory%"
+    %SystemRoot%\explorer.exe "%location%_site\%bookfolder%\%subdirectory%"
     :: Navigate back to where we began
     CD "%location%"
     :: Tell the user we're done
@@ -324,7 +324,7 @@ SET /p process=Enter a number and hit return.
     :: ...and run Jekyll to build new HTML
     CALL bundle exec jekyll build --config="_config.yml,_configs/_config.%fromformat%.yml,_configs/_config.image-set.%fromformat%.yml,%config%"
     :: Navigate to the HTML we just generated
-    CD _html\%bookfolder%\text
+    CD _site\%bookfolder%\text
     :: What're we doing?
     ECHO Converting %bookfolder% HTML to Word...
     :: Loop through the list of files in file-list
@@ -348,7 +348,7 @@ SET /p process=Enter a number and hit return.
     :: Whassup?
     ECHO Done, opening folder...
     :: Open file explorer to show the docx files.
-    %SystemRoot%\explorer.exe "%location%_html\%bookfolder%\text"
+    %SystemRoot%\explorer.exe "%location%_site\%bookfolder%\text"
     :: Navigate back to where we began
     CD "%location%"
     :: Let the user easily run that again


### PR DESCRIPTION
Overriding this Jekyll default was a silly idea of mine. So I'm changing Jekyll's output-destination folder back to `_site` rather than `_html`. I originally thought it would be easier for non-technical people to think of Jekyll's output as HTML rather than as a website, given that we're making books here as well as websites. But really I was just introducing complexity.