### PR TITLE
Epub-sensitive figure

### DIFF
--- a/_includes/figure
+++ b/_includes/figure
@@ -22,7 +22,7 @@ We have to do funky remove: '<p>' | remove: '</p>' | strip_newlines
 because https://github.com/jekyll/jekyll/issues/2248.
 {% endcomment %}
 
-<blockquote class="figure{% if include.class %} {{ include.class }}{% endif %}"{% if include.reference %} id="{{ include.reference | slugify }}"{% else %} id="{{ images[0] | replace: ".", " " | truncatewords: 1, "" }}"{% endif %}>
+<blockquote class="figure{% if include.class %} {{ include.class }}{% endif %}"{% if include.reference %} id="{{ include.reference | slugify }}"{% endif %}>
 
 <div class="figure-body">
 

--- a/_includes/figure
+++ b/_includes/figure
@@ -28,9 +28,9 @@ because https://github.com/jekyll/jekyll/issues/2248.
 
 <div class="figure-images contains-{{ number-of-images }}{% if include.image-height != nil %} height-{{ include.image-height }}{% endif %}">
     {%for image in images %}
-        {% if include.link %}<a href="{{ include.link }}">{% else %}<a href="{{ path-to-book-directory }}/{{ site.image-set }}/{{ image }}">{% endif %}
+        {% if include.link %}<a href="{{ include.link }}">{% elsif site.output == "web" %}<a href="{{ path-to-book-directory }}/{{ site.image-set }}/{{ image }}">{% else %}{% endif %}
             <img src="{{ path-to-book-directory }}/{{ site.image-set }}/{{ image }}" alt="{% if include.title %}{{ include.title }}: {% endif %}{% if include.description %}{{ include.description }}{% else %}{{ include.caption }}{% endif %}" />
-        </a>
+        {% if include.link or site.output == "web" %}</a>{% endif %}
     {% endfor %}
 </div>
 


### PR DESCRIPTION
EPUB2 cannot have a link pointing to an internal image file, because the file is not in the spine. A link to an image file in EPUB will break validation.

Also, we don't need figures linking to their image files in PDF. We only need this for web output.

So, now, images in figures only link if a link is specified or if `site.output == "web"`.

I've also removed a silly idea that created an ID from the image filename.