### PR TITLE
Cover as include

### DIFF
--- a/_includes/cover
+++ b/_includes/cover
@@ -1,0 +1,32 @@
+{% include metadata %}
+
+{% comment %}Let the user specify a different image file{% endcomment %}
+{% if include.image %}
+    {% capture image %}{{ include.image }}{% endcapture %}
+{% else %}
+    {% capture image %}cover.jpg{% endcapture %}
+{% endif %}
+
+{% comment %}
+Adjust HTML based on output format.
+* For web, link the cover to the start page.
+* For epub, use Sigil's file path structure.
+* For other outputs (screen-pdf and print-pdf) use just the image.
+{% endcomment %}
+
+{% if site.output == "web" %}
+
+[![Cover]({{ path-to-book-directory }}{{ site.image-set }}/{{ image }}){:.cover}]({{ web-start-page }})
+{:.cover}
+
+{% elsif site.output == "epub" %}
+
+![Cover](../Images/{{ image }}){:.cover}
+{:.cover}
+
+{% else %}
+
+![Cover]({{ path-to-book-directory }}{{ site.image-set }}/{{ image }}){:.cover}
+{:.cover}
+
+{% endif %}

--- a/book/text/0-0-cover.md
+++ b/book/text/0-0-cover.md
@@ -3,7 +3,4 @@ title: Cover
 style: cover
 ---
 
-{% include metadata %}
-
-![Cover]({{ path-to-book-directory }}{{ site.image-set }}/cover.jpg){:.cover}
-{:.cover}
+{% include cover %}

--- a/book/text/index.md
+++ b/book/text/index.md
@@ -3,7 +3,4 @@ title: Cover
 style: cover
 ---
 
-{% include metadata %}
-
-[![Cover]({{ path-to-book-directory }}{{ site.image-set }}/cover.jpg){:.cover}]({{ web-start-page }})
-{:.cover}
+{% include cover %}

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -154,10 +154,10 @@ SET /p process=Enter a number and hit return.
     :: ...and run Jekyll to build new HTML
     :: with MathJax enabled if necessary
     IF "%screen-pdf-mathjax%"=="" GOTO screenpdfnomathjax
-    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,_configs/_config.image-set.print-pdf.yml,_configs/_config.mathjax-enabled.yml,%config%"
+    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,_configs/_config.image-set.screen-pdf.yml,_configs/_config.mathjax-enabled.yml,%config%"
     GOTO screenpdfjekylldone
     :screenpdfnomathjax
-    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,_configs/_config.image-set.print-pdf.yml,%config%"
+    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,_configs/_config.image-set.screen-pdf.yml,%config%"
     :screenpdfjekylldone
     :: Skip PhantomJS if we're not using MathJax.
     IF "%screen-pdf-mathjax%"=="" GOTO screenpdfafterphantom


### PR DESCRIPTION
This adds a `cover` include that creates HTML better suited for each output format:

* on the web, the cover links to the web-start-page; and
* in epub, the path to the cover uses the Sigil file structure, making epub assembly more efficient.

And the markdown for adding a cover is simpler.
