### PR TITLE
For translated covers, go to correct images subfolder

### DIFF
--- a/_includes/cover
+++ b/_includes/cover
@@ -1,20 +1,17 @@
 {% include metadata %}
 
+{% comment %}Assign the default image filename to image{% endcomment %}
+{% assign image = "cover.jpg" %}
+
 {% comment %}Let the user specify a different image file{% endcomment %}
 {% if include.image %}
     {% capture image %}{{ include.image }}{% endcapture %}
-{% else %}
-    {% capture image %}cover.jpg{% endcapture %}
 {% endif %}
 
-{% comment %}If this is a default cover image, i.e. assuming cover.jpg
-and it's being used in a translation, add the language code as a path
-to the image of the translated cover. This depends on the user
-saving cover.jpg to images/languagecode/{% endcomment %}
-{% if image == "cover.jpg" %}
-    {% if is-translation %}
-        {% capture image %}{{ language }}/cover.jpg{% endcapture %}
-    {% endif %}
+{% comment %}If it's being used in a translation, add the language code 
+as a path to the image of the translated cover.{% endcomment %}
+{% if is-translation %}
+    {% capture image %}{{ language }}/{{ image }}{% endcapture %}
 {% endif %}
 
 {% comment %}

--- a/_includes/cover
+++ b/_includes/cover
@@ -7,6 +7,16 @@
     {% capture image %}cover.jpg{% endcapture %}
 {% endif %}
 
+{% comment %}If this is a default cover image, i.e. assuming cover.jpg
+and it's being used in a translation, add the language code as a path
+to the image of the translated cover. This depends on the user
+saving cover.jpg to images/languagecode/{% endcomment %}
+{% if image == "cover.jpg" %}
+    {% if is-translation %}
+        {% capture image %}{{ language }}/cover.jpg{% endcapture %}
+    {% endif %}
+{% endif %}
+
 {% comment %}
 Adjust HTML based on output format.
 * For web, link the cover to the start page.

--- a/_includes/cover
+++ b/_includes/cover
@@ -26,11 +26,6 @@ Adjust HTML based on output format.
 [![{{ title }}]({{ path-to-book-directory }}{{ site.image-set }}/{{ image }}){:.cover}]({{ web-start-page }})
 {:.cover}
 
-{% elsif site.output == "epub" %}
-
-![{{ title }}](../Images/{{ image }}){:.cover}
-{:.cover}
-
 {% else %}
 
 ![{{ title }}]({{ path-to-book-directory }}{{ site.image-set }}/{{ image }}){:.cover}

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -292,7 +292,8 @@ SET /p process=Enter a number and hit return.
     SET /p firstfile=
     IF "%firstfile%"=="" SET firstfile=0-0-cover
     :: Ask if we're outputting the files from a subdirectory
-    SET /p subdirectory=If you're outputting files in a subdirectory (e.g. a translation), type its name. Otherwise, hit enter. 
+    ECHO If you're outputting files in a subdirectory (e.g. a translation), type its name. Otherwise, hit enter. 
+    SET /p subdirectory=
     :epub-otherconfigs
     :: Ask the user to add any extra Jekyll config files, e.g. _config.images.print-pdf.yml
     ECHO.
@@ -332,7 +333,7 @@ SET /p process=Enter a number and hit return.
     :: and open the cover HTML file in it, to load metadata into Sigil
     START "" sigil.exe "%firstfile%.html"
     :: Open file explorer to make it easy to see the HTML to assemble
-    %SystemRoot%\explorer.exe "%location%_site\%bookfolder%\%subdirectory%"
+    %SystemRoot%\explorer.exe "%location%_site\%bookfolder%\text\%subdirectory%"
     :: Navigate back to where we began
     CD "%location%"
     :: Tell the user we're done


### PR DESCRIPTION
When working with translations, normally images that are translated could just have different filenames, referenced in the translation text. And the image files can then live alongside the master language's images in `book/images`. However, our `cover` include always uses `cover.jpg`.

This PR's change looks for cover.jpg in a subfolder of `book/images` named for the language, so that each language can have its own images folder containing `cover.jpg`.

@SteveBarnett This is pretty simple I think. Wanna have a quick look?