### PR TITLE
Apply height- class to image, not figure

### DIFF
--- a/_includes/figure
+++ b/_includes/figure
@@ -26,10 +26,10 @@ because https://github.com/jekyll/jekyll/issues/2248.
 
 <div class="figure-body">
 
-<div class="figure-images contains-{{ number-of-images }}{% if include.image-height != nil %} height-{{ include.image-height }}{% endif %}">
+<div class="figure-images contains-{{ number-of-images }}{% endif %}">
     {%for image in images %}
         {% if include.link %}<a href="{{ include.link }}">{% elsif site.output == "web" %}<a href="{{ path-to-book-directory }}/{{ site.image-set }}/{{ image }}">{% else %}{% endif %}
-            <img src="{{ path-to-book-directory }}/{{ site.image-set }}/{{ image }}" alt="{% if include.title %}{{ include.title }}: {% endif %}{% if include.description %}{{ include.description }}{% else %}{{ include.caption }}{% endif %}" />
+            <img src="{{ path-to-book-directory }}/{{ site.image-set }}/{{ image }}" alt="{% if include.title %}{{ include.title }}: {% endif %}{% if include.description %}{{ include.description }}{% else %}{{ include.caption }}{% endif %}{% if include.image-height != nil %} height-{{ include.image-height }}" />
         {% if include.link or site.output == "web" %}</a>{% endif %}
     {% endfor %}
 </div>


### PR DESCRIPTION
The `height` class is for managing image size in print: sometimes you want to force an image to be a specific number of lines high, so that the page's baseline grid is consistent (i.e. all lines match a grid defined by the default line height, e.g. 15pt). An image that is, say 10.3 lines high will throw out a page's baseline grid by 0.3 lines. Our template Sass partials support a `height-x` class [here](https://github.com/electricbookworks/electric-book/blob/master/_sass/partials/_print-fitting.scss). 

But we should be applying that class to the `img`, right, not the `div`, hence this fix.

Thanks for spotting weirdness here before @SteveBarnett. Does this make sense now?