### PR TITLE
Fix broken and inconsistent blockquote margins

### DIFF
--- a/_sass/partials/_epub-base-typography.scss
+++ b/_sass/partials/_epub-base-typography.scss
@@ -75,18 +75,14 @@ $epub-base-typography: true !default;
     // Blockquotes
 
     blockquote {
-        margin: $line-height-default 0 $line-height-default 0;
+        margin: $line-height-default 0;
         padding: 0 $line-height-default;
-    }
-    // Suspect this isn't necessary. To remove after testing.
-    // blockquote p {
-    //  line-height: $line-height-default;
-    // }
-    blockquote p:first-of-type {
-        text-indent: 0;
-    }
-    blockquote p:last-of-type, blockquote ol, blockquote ul {
-        margin: 0 0 $line-height-default 0;
+        p:first-of-type {
+            text-indent: 0;
+        }
+        p:last-child, & ol:last-child, & ul:last-child {
+            margin-bottom: 0;
+        }
     }
 
     // Definition lists

--- a/_sass/partials/_print-base-typography.scss
+++ b/_sass/partials/_print-base-typography.scss
@@ -117,24 +117,24 @@ $print-base-typography: true !default;
 		page-break-before:avoid;
 	}
 
-	// Blockquotes
+    // Blockquotes
 
-	blockquote {
-		margin: $line-height-default 0 0 0;
-		padding: 0 $line-height-default;
-	}
-	blockquote p {
-		margin: 0;
-		padding: 0;
-	}
-	blockquote p:first-of-type {
-		text-indent: 0;
-	}
-	blockquote p:last-of-type, blockquote ol, blockquote ul {
-		margin: 0 0 $line-height-default 0;
-	}
+    blockquote {
+        margin: $line-height-default 0;
+        padding: 0 $line-height-default;
+		p {
+			margin: 0;
+			padding: 0;
+		}
+        p:first-of-type {
+            text-indent: 0;
+        }
+        p:last-child, & ol:last-child, & ul:last-child {
+            margin-bottom: 0;
+        }
+    }
 
-	/* Definition lists */
+	// Definition lists
 
 	dl {
 		margin: $line-height-default 0;

--- a/_sass/partials/_web-base-typography.scss
+++ b/_sass/partials/_web-base-typography.scss
@@ -73,22 +73,17 @@ $web-base-typography: true !default;
         list-style-type: lower-alpha;
     }
 
-
     // Blockquotes
 
     blockquote {
-        margin: $line-height-default 0 $line-height-default 0;
+        margin: $line-height-default 0;
         padding: 0 $line-height-default;
-    }
-    // Suspect this isn't necessary. To remove after testing.
-    // blockquote p {
-    //  line-height: $line-height-default;
-    // }
-    blockquote p:first-of-type {
-        text-indent: 0;
-    }
-    blockquote p:last-of-type, blockquote ol, blockquote ul {
-        margin: 0 0 $line-height-default 0;
+        p:first-of-type {
+            text-indent: 0;
+        }
+        p:last-child, & ol:last-child, & ul:last-child {
+            margin-bottom: 0;
+        }
     }
 
     // Definition lists


### PR DESCRIPTION
@SteveBarnett While working on another project, I found some strange old CSS for blockquotes. I've fixed it up here and have tested it on our `typography` content from the Guide.

Want to have a quick peek? I think this should be in for v0.7.0.