### PR TITLE
Combine output and image-set configs

### DIFF
--- a/_configs/_config.epub.yml
+++ b/_configs/_config.epub.yml
@@ -1,4 +1,4 @@
-# Addon config the sets layout to epub for epub-compatible-HTML output
-# To run from command line:
-# jekyll build -c _config.yml,_config.epub.yml
+# Set site.output == "epub"
 output: "epub"
+# Set site.image-set == "images/epub"
+image-set: "images/epub"

--- a/_configs/_config.image-set.epub.yml
+++ b/_configs/_config.image-set.epub.yml
@@ -1,2 +1,0 @@
-# Addon config that sets site.image-set to images/epub
-image-set: "images/epub"

--- a/_configs/_config.image-set.print-pdf.yml
+++ b/_configs/_config.image-set.print-pdf.yml
@@ -1,2 +1,0 @@
-# Addon config that sets site.image-set to images/print-pdf
-image-set: "images/print-pdf"

--- a/_configs/_config.image-set.screen-pdf.yml
+++ b/_configs/_config.image-set.screen-pdf.yml
@@ -1,2 +1,0 @@
-# Addon config that sets site.image-set to images/screen-pdf
-image-set: "images/screen-pdf"

--- a/_configs/_config.image-set.web.yml
+++ b/_configs/_config.image-set.web.yml
@@ -1,2 +1,0 @@
-# Addon config that sets site.image-set to images/web
-image-set: "images/web"

--- a/_configs/_config.mathjax-enabled.yml
+++ b/_configs/_config.mathjax-enabled.yml
@@ -1,3 +1,2 @@
 # Addon config that enables MathJax
 mathjax-enabled: true
-

--- a/_configs/_config.print-pdf.yml
+++ b/_configs/_config.print-pdf.yml
@@ -1,4 +1,4 @@
-# Addon config that sets site.output to print-pdf
-# To run from command line:
-# jekyll build -c _config.yml,_config.print-pdf.yml
+# Set site.output == "print-pdf"
 output: "print-pdf"
+# Set site.image-set == "images/print-pdf"
+image-set: "images/print-pdf"

--- a/_configs/_config.screen-pdf.yml
+++ b/_configs/_config.screen-pdf.yml
@@ -1,2 +1,4 @@
-# Addon config that sets output to screen-pdf
+# Set site.output == "screen-pdf"
 output: "screen-pdf"
+# Set site.image-set == "images/screen-pdf"
+image-set: "images/screen-pdf"

--- a/_configs/_config.web.yml
+++ b/_configs/_config.web.yml
@@ -1,4 +1,4 @@
-# Addon config that sets site.output to web
-# To run from command line:
-# jekyll build -c _config.yml,_config.web.yml
+# Set site.output == "web"
 output: "web"
+# Set site.image-set == "images/web"
+image-set: "images/web"

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -236,9 +236,9 @@ You may need to reload the web page once this server is running."
 			# ...and run Jekyll
 			if [ "$baseurl" = "" ]
 				then
-				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,_configs/_config.image-set.web.yml,$config" --baseurl=""
+				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,$config" --baseurl=""
 			else
-				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,_configs/_config.image-set.web.yml,$config" --baseurl="/$baseurl"
+				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,$config" --baseurl="/$baseurl"
 			fi
 			# Ask the user if they want to rebuild the site
 			# TO DO: Not sure this works because Jekyll owns the terminal and Ctrl+C will kill it entirely?
@@ -292,9 +292,9 @@ If not, just hit return."
 			# ...and run Jekyll to build new HTML, enabling MathJax if necessary
 			if [ "$epubmathjax" = "" ]
 				then
-				bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.image-set.epub.yml,$config"
+				bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,$config"
 			else
-				bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.image-set.epub.yml,_configs/_config.mathjax-enabled.yml,$config"
+				bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.mathjax-enabled.yml,$config"
 			fi
 			# Navigate to the relevant text folder...
 			if [ "$epubsubdirectory" = "" ]

--- a/run-mac.command
+++ b/run-mac.command
@@ -238,9 +238,9 @@ You may need to reload the web page once this server is running."
 			# ...and run Jekyll
 			if [ "$baseurl" = "" ]
 				then
-				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,_configs/_config.image-set.web.yml,$config" --baseurl=""
+				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,$config" --baseurl=""
 			else
-				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,_configs/_config.image-set.web.yml,$config" --baseurl="/$baseurl"
+				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,$config" --baseurl="/$baseurl"
 			fi
 			# Ask the user if they want to rebuild the site
 			# TO DO: Not sure this works because Jekyll owns the terminal and Ctrl+C will kill it entirely?
@@ -294,9 +294,9 @@ If not, just hit return."
 			# ...and run Jekyll to build new HTML, enabling MathJax if necessary
 			if [ "$epubmathjax" = "" ]
 				then
-				bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.image-set.epub.yml,$config"
+				bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,$config"
 			else
-				bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.image-set.epub.yml,_configs/_config.mathjax-enabled.yml,$config"
+				bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.mathjax-enabled.yml,$config"
 			fi
 			# Navigate to the relevant text folder...
 			if [ "$epubsubdirectory" = "" ]

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -75,10 +75,10 @@ SET /p process=Enter a number and hit return.
     :: ...and run Jekyll to build new HTML
     :: with MathJax enabled if necessary
     IF "%print-pdf-mathjax%"=="" GOTO printpdfnomathjax
-    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,_configs/_config.image-set.print-pdf.yml,_configs/_config.mathjax-enabled.yml,%config%"
+    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,_configs/_config.mathjax-enabled.yml,%config%"
     GOTO printpdfjekylldone
     :printpdfnomathjax
-    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,_configs/_config.image-set.print-pdf.yml,%config%"
+    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,%config%"
     :printpdfjekylldone
     :: Skip PhantomJS if we're not using MathJax.
     IF "%print-pdf-mathjax%"=="" GOTO printpdfafterphantom
@@ -158,10 +158,10 @@ SET /p process=Enter a number and hit return.
     :: ...and run Jekyll to build new HTML
     :: with MathJax enabled if necessary
     IF "%screen-pdf-mathjax%"=="" GOTO screenpdfnomathjax
-    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,_configs/_config.image-set.screen-pdf.yml,_configs/_config.mathjax-enabled.yml,%config%"
+    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,_configs/_config.mathjax-enabled.yml,%config%"
     GOTO screenpdfjekylldone
     :screenpdfnomathjax
-    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,_configs/_config.image-set.screen-pdf.yml,%config%"
+    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,%config%"
     :screenpdfjekylldone
     :: Skip PhantomJS if we're not using MathJax.
     IF "%screen-pdf-mathjax%"=="" GOTO screenpdfafterphantom
@@ -239,10 +239,10 @@ SET /p process=Enter a number and hit return.
         START "" "http://127.0.0.1:4000/%baseurl%/"
         :: Run Jekyll, with MathJax enabled if necessary
         IF "%webmathjax%"=="" GOTO webnomathjax
-        CALL bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,_configs/_config.image-set.web.yml,_configs/_config.mathjax-enabled.yml,%config%" --baseurl="/%baseurl%"
+        CALL bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,_configs/_config.mathjax-enabled.yml,%config%" --baseurl="/%baseurl%"
         GOTO webjekyllserved
         :webnomathjax
-        CALL bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,_configs/_config.image-set.web.yml,%config%" --baseurl="/%baseurl%"
+        CALL bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,%config%" --baseurl="/%baseurl%"
         :webjekyllserved
         :: And we're done here
         GOTO websiterepeat
@@ -253,10 +253,10 @@ SET /p process=Enter a number and hit return.
         START "" "http://127.0.0.1:4000/"
         :: Run Jekyll, with MathJax enabled if necessary
         IF "%webmathjax%"=="" GOTO webnomathjax
-        CALL bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,_configs/_config.image-set.web.yml,_configs/_config.mathjax-enabled.yml,%config%" --baseurl=""
+        CALL bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,_configs/_config.mathjax-enabled.yml,%config%" --baseurl=""
         GOTO webjekyllserved
         :webnomathjax
-        CALL bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,_configs/_config.image-set.web.yml,%config%" --baseurl=""
+        CALL bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,%config%" --baseurl=""
         :webjekyllserved
     :: Let the user rebuild and restart
     :: 
@@ -314,10 +314,10 @@ SET /p process=Enter a number and hit return.
     :: ...and run Jekyll to build new HTML
     :: with MathJax enabled if necessary
     IF "%epub-mathjax%"=="" GOTO epubnomathjax
-    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.image-set.epub.yml,_configs/_config.mathjax-enabled.yml,%config%"
+    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.mathjax-enabled.yml,%config%"
     GOTO epubjekylldone
     :epubnomathjax
-    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.image-set.epub.yml,%config%"
+    CALL bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,%config%"
     :epubjekylldone
     :: Skip PhantomJS if we're not using MathJax.
     IF "%epub-mathjax%"=="" GOTO epubafterphantom


### PR DESCRIPTION
Our output scripts use these extra configs to set `site.output` and `site.image-set` per format. After several months of using this, I can't see any good reason we should have separate config files for setting `site.output` and `site.image-set`. So, to simplify output and file structure, I've consolidated these configs.

This will make the consolidated Ruby output script that @craigmj is creating a *tiny* bit simpler.

@SteveBarnett Can you think of any reason this might be a bad idea?