### PR TITLE
Neater epigraph sass, fix metadata paths

### DIFF
--- a/_includes/metadata
+++ b/_includes/metadata
@@ -268,9 +268,7 @@ the first book-directory listed in meta.yml{% endcomment %}
         {% capture path-to-book-directory %}../{% endcapture %}
     {% else %}
         {% capture path-to-book-directory %}
-            {% for i in (2..folder-depth) %}
-                ../
-            {% endfor %}
+            {% for i in (2..folder-depth) %}../{% endfor %}
         {% endcapture %}
     {% endif %}
 
@@ -280,8 +278,6 @@ the first book-directory listed in meta.yml{% endcomment %}
 {% comment %}Then set a path to the root directory.{% endcomment %}
 
 {% capture path-to-root-directory %}
-    {% for i in (1..folder-depth) %}
-        ../
-    {% endfor %}
+    {% for i in (1..folder-depth) %}../{% endfor %}
 {% endcapture %}
 {% capture path-to-root-directory %}{{ path-to-root-directory | strip_newlines }}{% endcapture %}

--- a/_sass/partials/_epub-epigraphs.scss
+++ b/_sass/partials/_epub-epigraphs.scss
@@ -6,11 +6,11 @@ $epub-epigraphs: true !default;
     .epigraph-page {
     	margin-top: $start-depth;
     }
-    p.epigraph {
+    .epigraph {
     	text-indent: 0;
     	padding: 0 ($line-height-default * 2);
     }
-    p.epigraph-source {
+    .epigraph-source {
     	text-indent: 0;
     	padding: 0 ($line-height-default * 2);
         page-break-before: avoid;

--- a/_sass/partials/_print-epigraphs.scss
+++ b/_sass/partials/_print-epigraphs.scss
@@ -6,11 +6,11 @@ $print-epigraphs: true !default;
     .epigraph-page {
     	margin-top: $start-depth;
     }
-    p.epigraph {
+    .epigraph {
     	text-indent: 0;
     	padding: 0 ($line-height-default * 2);
     }
-    p.epigraph-source {
+    .epigraph-source {
     	text-indent: 0;
     	padding: 0 ($line-height-default * 2);
     	page-break-before: avoid;

--- a/_sass/partials/_web-epigraphs.scss
+++ b/_sass/partials/_web-epigraphs.scss
@@ -9,11 +9,11 @@ $web-epigraphs: true !default;
         }
     }
     
-    p.epigraph {
+    .epigraph {
     	text-indent: 0;
     	padding: 0 ($line-height-default * 2);
     }
-    p.epigraph-source {
+    .epigraph-source {
     	text-indent: 0;
     	padding: 0 ($line-height-default * 2);
         text-align: right;


### PR DESCRIPTION
@SteveBarnett Neatened Sass for epigraphs. Applying only to `p` elements was complicating overrides in custom CSS by making inherited CSS rules overly specific.

By my branching mistake this PR includes the same change to paths as #122.