### PR TITLE
Prose.io exclude /_output and /assets

### DIFF
--- a/_prose.yml
+++ b/_prose.yml
@@ -19,6 +19,8 @@ prose:
     - /_includes
     - /_site
     - /_sass
+    - /_output
+    - /assets
     - search.md
     - /*/search.md
     - /*/.gitattributes


### PR DESCRIPTION
@SteveBarnett Added a couple of exclusions to our default prose.io config. I don't think non-technical users should see these folders.