### PR TITLE
Fix print-source layout

### DIFF
--- a/_sass/partials/_print-sources.scss
+++ b/_sass/partials/_print-sources.scss
@@ -8,9 +8,15 @@ $print-sources: true !default;
         margin: 0 $line-height-default $line-height-default $line-height-default;
         text-indent: 0;
     	page-break-before: avoid;
+        em {
+            font-style: normal;
+        }
+        + p {
+            text-indent: 0;
+        }
     }
     em.source,
-    strong.strong,
+    strong.source,
     span.source {
         display: block;
         page-break-before: avoid;


### PR DESCRIPTION
@SteveBarnett Fixing issues in our `.source` layout for print.

- em inside should not also be italic;
- following para should be flush left
- fix typo