### PR TITLE
Remove redundant media="print" in print-output stylesheet link

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -43,7 +43,7 @@
     </title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" media="print" href="{{ path-to-book-directory }}styles/{{ page.stylesheet-screen-pdf }}" />
+    <link rel="stylesheet" type="text/css" href="{{ path-to-book-directory }}styles/{{ page.stylesheet-screen-pdf }}" />
 
     {% include head-elements %}
 
@@ -64,7 +64,7 @@
     </title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" media="print" href="{{ path-to-book-directory }}styles/{{ page.stylesheet-print-pdf }}" />
+    <link rel="stylesheet" type="text/css" href="{{ path-to-book-directory }}styles/{{ page.stylesheet-print-pdf }}" />
 
     {% include head-elements %}
 


### PR DESCRIPTION
@SteveBarnett as raised in another project recently: this change makes it quicker to debug print CSS in a browser.

In print output, we only link to one stylesheet anyway, so specifying `media="print"` is redundant. By removing it, when we open a file in the browser after `print-pdf` output, we can inspect the CSS without having to manually turn off `media="print"`.

Does that make sense to you, too, or am I missing something?