### PR TITLE
Dialogue partials

### DIFF
--- a/_sass/epub.scss
+++ b/_sass/epub.scss
@@ -102,6 +102,7 @@ $epub-bibliographies: true !default; //
 $epub-boxes: true !default; // 
 $epub-buttons: true !default; // 
 $epub-code: true !default; // 
+$epub-dialogue: true !default; // 
 $epub-figures: true !default; // 
 $epub-glossaries: true !default; //
 $epub-highlighter: true !default; //
@@ -155,6 +156,7 @@ $epub-reset-sequences: true !default; //
 @import "partials/epub-boxes"; // 
 @import "partials/epub-buttons"; // 
 @import "partials/epub-code"; // 
+@import "partials/epub-dialogue"; // 
 @import "partials/epub-figures"; // 
 @import "partials/epub-glossaries"; //
 @import "partials/epub-highlighter"; //

--- a/_sass/partials/_epub-dialogue.scss
+++ b/_sass/partials/_epub-dialogue.scss
@@ -1,0 +1,22 @@
+$epub-dialogue: true !default;
+@if $epub-dialogue {
+
+    // Dialogue
+    // Using definition list element, dl
+
+    dl.dialogue {
+        dt {
+            clear: both;
+            float: left;
+            min-width: $line-height-default * 2;
+            padding-right: ($line-height-default * 0.25);
+            &:after {
+                content: ": "
+            }
+        }
+        dd {
+            margin: 0 0 0 ($line-height-default * 2.25); // match width + padding of dt
+        }
+    }
+
+}

--- a/_sass/partials/_print-dialogue.scss
+++ b/_sass/partials/_print-dialogue.scss
@@ -1,0 +1,22 @@
+$print-dialogue: true !default;
+@if $print-dialogue {
+
+    // Dialogue
+    // Using definition list element, dl
+
+    dl.dialogue {
+        dt {
+            clear: both;
+            float: left;
+            min-width: $line-height-default * 2;
+            padding-right: ($line-height-default * 0.25);
+            &:after {
+                content: ": "
+            }
+        }
+        dd {
+            margin: 0 0 0 ($line-height-default * 2.25); // match width + padding of dt
+        }
+    }
+
+}

--- a/_sass/partials/_web-dialogue.scss
+++ b/_sass/partials/_web-dialogue.scss
@@ -1,0 +1,22 @@
+$web-dialogue: true !default;
+@if $web-dialogue {
+
+    // Dialogue
+    // Using definition list element, dl
+
+    dl.dialogue {
+        dt {
+            clear: both;
+            float: left;
+            min-width: $line-height-default * 2;
+            padding-right: ($line-height-default * 0.25);
+            &:after {
+                content: ": "
+            }
+        }
+        dd {
+            margin: 0 0 0 ($line-height-default * 2.25); // match width + padding of dt
+        }
+    }
+
+}

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -202,6 +202,7 @@ $print-base-typography: true !default; // Default typography for HTML elements
 $print-buttons: true !default;
 $print-verse: true !default; // Default typography for verse, poetry, lyrics
 $print-bibliographies: true !default;
+$print-dialogue: true !default; // 
 $print-epigraphs: true !default; // 
 $print-dedications: true !default; // 
 $print-glossaries: true !default; // Including .glossary
@@ -258,6 +259,7 @@ $print-page-headers-footers-style: true !default; // Sets styling for headers an
 @import "partials/print-buttons";
 @import "partials/print-verse"; // Default typography for verse, poetry, lyrics
 @import "partials/print-bibliographies";
+@import "partials/print-dialogue"; // 
 @import "partials/print-epigraphs"; // 
 @import "partials/print-dedications"; // 
 @import "partials/print-glossaries"; // Including .glossary

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -202,6 +202,7 @@ $print-base-typography: true !default; // Default typography for HTML elements
 $print-buttons: true !default;
 $print-verse: true !default; // Default typography for verse, poetry, lyrics
 $print-bibliographies: true !default;
+$print-dialogue: true !default; // 
 $print-epigraphs: true !default; // 
 $print-dedications: true !default; // 
 $print-glossaries: true !default; // Including .glossary
@@ -260,6 +261,7 @@ $print-page-headers-footers-style: true !default; // Sets styling for headers an
 @import "partials/print-bibliographies";
 @import "partials/print-epigraphs"; // 
 @import "partials/print-dedications"; // 
+@import "partials/print-dialogue"; // 
 @import "partials/print-glossaries"; // Including .glossary
 @import "partials/print-highlighter"; //
 @import "partials/print-pullquotes"; // Supports .pullquote

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -150,6 +150,7 @@ $web-bibliographies: true !default;
 $web-boxes: true !default;
 $web-buttons: true !default;
 $web-code: true !default;
+$web-dialogue: true !default;
 $web-figures: true !default;
 $web-highlighter: true !default;
 $web-glossaries: true !default;
@@ -210,6 +211,7 @@ $web-reset-sequences: true !default; // This should stay last in the @import lis
 @import "partials/web-boxes";
 @import "partials/web-buttons";
 @import "partials/web-code";
+@import "partials/web-dialogue";
 @import "partials/web-figures";
 @import "partials/web-glossaries";
 @import "partials/web-highlighter";

--- a/book/styles/epub.scss
+++ b/book/styles/epub.scss
@@ -106,6 +106,7 @@ $epub-bibliographies: true; //
 $epub-boxes: true; // 
 $epub-buttons: true; // 
 $epub-code: true; // 
+$epub-dialogue: true; // 
 $epub-figures: true; // 
 $epub-glossaries: true; //
 $epub-highlighter: true; //

--- a/book/styles/print-pdf.scss
+++ b/book/styles/print-pdf.scss
@@ -208,6 +208,7 @@ $print-verse: true; // Default typography for verse, poetry, lyrics
 $print-bibliographies: true;
 $print-epigraphs: true; // 
 $print-dedications: true; // 
+$print-dialogue: true; // 
 $print-glossaries: true; // Including .glossary
 $print-highlighter: true;
 $print-pullquotes: true; // Supports .pullquote

--- a/book/styles/screen-pdf.scss
+++ b/book/styles/screen-pdf.scss
@@ -206,6 +206,7 @@ $print-base-typography: true; // Default typography for HTML elements
 $print-buttons: true;
 $print-verse: true; // Default typography for verse, poetry, lyrics
 $print-bibliographies: true;
+$print-dialogue: true; // 
 $print-epigraphs: true; // 
 $print-dedications: true; // 
 $print-glossaries: true; // Including .glossary

--- a/book/styles/web.scss
+++ b/book/styles/web.scss
@@ -154,6 +154,7 @@ $web-bibliographies: true;
 $web-boxes: true;
 $web-buttons: true;
 $web-code: true;
+$web-dialogue: true;
 $web-figures: true;
 $web-highlighter: true;
 $web-glossaries: true;


### PR DESCRIPTION
In a few books recently I've had to create sections of dialogue in playscript-like style. I believe this is a common-enough need that it should be supported in the EBT.

I've looked around for ways to mark up playscript dialogue in HTML, and the best of a bad lot of options seems to be the `dl`. It's relatively close semantically to what we need, and is easy to create in markdown.

The styles I've created here as defaults are as unopinionated as I can make them. (Depending on available fonts in any given book, the designer might choose to make `dt` small-caps in custom styles.)

If/when we merge this, it should be added to the docs in the section on supported classes, and some sample text added to the typography book.

@SteveBarnett Do you want to give this a glance?