### PR TITLE
Create short tag for path to images

### DIFF
--- a/_includes/figure
+++ b/_includes/figure
@@ -13,8 +13,8 @@ Then get the total number of images in the array.
 {% endcomment %}
 {% capture image-list %}{{ include.image | remove: " " }}{% if include.image and include.images %},{% endif %}{{ include.images | remove: " " }}{% endcapture %}
 
-{% assign images = image-list | split: "," %}
-{% assign number-of-images = images | size %}
+{% assign figure-images = image-list | split: "," %}
+{% assign number-of-images = figure-images | size %}
 
 {% comment %}
 Then create our figure, using multiple images if necessary.
@@ -29,7 +29,7 @@ because https://github.com/jekyll/jekyll/issues/2248.
 
 {% if include.image or include.images %}
 <div class="figure-images contains-{{ number-of-images }}">
-    {%for image in images %}
+    {%for image in figure-images %}
         {% if include.link %}<a href="{{ include.link }}">{% elsif site.output == "web" %}<a href="{{ path-to-book-directory }}/{{ site.image-set }}/{{ image }}">{% endif %}
             <img src="{{ path-to-book-directory }}/{{ site.image-set }}/{{ image }}" alt="{% if include.title %}{{ include.title }}: {% endif %}{% if include.description %}{{ include.description }}{% else %}{{ include.caption }}{% endif %}{% if include.image-height != nil %} height-{{ include.image-height }}{% endif %}" />
         {% if include.link or site.output == "web" %}</a>{% endif %}

--- a/_includes/metadata
+++ b/_includes/metadata
@@ -281,3 +281,6 @@ the first book-directory listed in meta.yml{% endcomment %}
     {% for i in (1..folder-depth) %}../{% endfor %}
 {% endcapture %}
 {% capture path-to-root-directory %}{{ path-to-root-directory | strip_newlines }}{% endcapture %}
+
+{% comment %}Create a short tag for the path to images.{% endcomment %}
+{% capture images %}{{ path-to-book-directory }}{{ site.image-set }}{% endcapture %}


### PR DESCRIPTION
@SteveBarnett I've created a short tag to make it easier to add images.

Once upon a time, we used explicit paths: `![](../images/dog.jpg)`

Then we added image sets: `![](../{{ site.image-set }}/dog.jpg)`

Then we added a path tag that works in subfolders (e.g. translations): `![]({{ path-to-book-directory }}{{ site.image-set }}/dog.jpg)`, which requires `{% include metadata %}` earlier in the document.

Now this is shorter: `![]({{ images }}/dog.jpg)`, which also requires `{% include metadata %}`.

Does this work for you?