### PR TITLE
Hyphenation dictionaries

### DIFF
--- a/_sass/partials/_print-hyphenation.scss
+++ b/_sass/partials/_print-hyphenation.scss
@@ -40,7 +40,7 @@ $hyphenation-custom: add !default;
     :lang(sl),
     :lang(sv) {
         @if $hyphenation-custom == "replace" {
-            prince-hyphenate-patterns: url("#{$hyphenation-dictionary}");
+            prince-hyphenate-patterns: url("");
         }
     }
 

--- a/_sass/partials/_print-hyphenation.scss
+++ b/_sass/partials/_print-hyphenation.scss
@@ -1,4 +1,5 @@
 $print-hyphenation: true !default;
+$hyphenation-custom: add !default;
 @if $print-hyphenation {
 
     // Hyphenation
@@ -16,6 +17,29 @@ $print-hyphenation: true !default;
     p, ul, ol, dl {
         @if $hyphenation-dictionary == "" {}
         @else {
+            prince-hyphenate-patterns: url("#{$hyphenation-dictionary}");
+        }
+    }
+
+    // In addition, if we want a custom dictionary to override all Prince
+    // built-in dictionaries, override its :root style.
+    :root,
+    :lang(da),
+    :lang(de),
+    :lang(en),
+    :lang(en-US),
+    :lang(es),
+    :lang(fi),
+    :lang(fr),
+    :lang(is),
+    :lang(it),
+    :lang(lt),
+    :lang(pl),
+    :lang(pt),
+    :lang(ru),
+    :lang(sl),
+    :lang(sv) {
+        @if $hyphenation-custom == "replace" {
             prince-hyphenate-patterns: url("#{$hyphenation-dictionary}");
         }
     }

--- a/_sass/partials/_print-hyphenation.scss
+++ b/_sass/partials/_print-hyphenation.scss
@@ -40,7 +40,7 @@ $hyphenation-custom: add !default;
     :lang(sl),
     :lang(sv) {
         @if $hyphenation-custom == "replace" {
-            prince-hyphenate-patterns: url("");
+            prince-hyphenate-patterns: url("#{$hyphenation-dictionary}");
         }
     }
 

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -86,6 +86,7 @@ $button-border-radius: 0.1em !default; // Roundness of button corners.
 // Variables here apply to p, ul, ol, dl
 $hyphenation: auto !default; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)
 $hyphenation-dictionary: "" !default; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
+$hyphenation-custom: add !default; // add or replace. Whether your dictionary adds to or replaces the built-in Prince dictionaries
 $hyphenate-after: 3 !default; // Minimum letters on new line after hyphen
 $hyphenate-before: 3 !default; // Minimum letters at end of line before hyphen
 $hyphenate-lines: 2 !default; // Preferred maximum number of consecutive lines ending with hyphens

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -86,6 +86,7 @@ $button-border-radius: 0.1em !default; // Roundness of button corners.
 // Variables here apply to p, ul, ol, dl
 $hyphenation: auto !default; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)
 $hyphenation-dictionary: "" !default; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
+$hyphenation-custom: add !default; // add or replace. Whether your dictionary adds to or replaces the built-in Prince dictionaries
 $hyphenate-after: 3 !default; // Minimum letters on new line after hyphen
 $hyphenate-before: 3 !default; // Minimum letters at end of line before hyphen
 $hyphenate-lines: 2 !default; // Preferred maximum number of consecutive lines ending with hyphens

--- a/book/styles/print-pdf.scss
+++ b/book/styles/print-pdf.scss
@@ -89,7 +89,8 @@ $button-border-radius: 0.1em; // Roundness of button corners.
 // Hyphenation
 // Variables here apply to p, ul, ol, dl
 $hyphenation: auto; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)
-$hyphenation-dictionary: ""; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
+$hyphenation-dictionary: "" !default; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
+$hyphenation-custom: add !default; // add or replace. Whether your dictionary adds to or replaces the built-in Prince dictionaries
 $hyphenate-after: 3; // Minimum letters on new line after hyphen
 $hyphenate-before: 3; // Minimum letters at end of line before hyphen
 $hyphenate-lines: 2; // Preferred maximum number of consecutive lines ending with hyphens

--- a/book/styles/screen-pdf.scss
+++ b/book/styles/screen-pdf.scss
@@ -89,7 +89,8 @@ $button-border-radius: 0.1em; // Roundness of button corners.
 // Hyphenation
 // Variables here apply to p, ul, ol, dl
 $hyphenation: auto; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)
-$hyphenation-dictionary: ""; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
+$hyphenation-dictionary: "" !default; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
+$hyphenation-custom: add !default; // add or replace. Whether your dictionary adds to or replaces the built-in Prince dictionaries
 $hyphenate-after: 3; // Minimum letters on new line after hyphen
 $hyphenate-before: 3; // Minimum letters at end of line before hyphen
 $hyphenate-lines: 2; // Preferred maximum number of consecutive lines ending with hyphens


### PR DESCRIPTION
Let's users use a custom hyphenation dictionary, and choose whether it should add to or replace the Prince built-in hyphenation dictionaries.

We had this feature already, but it wasn't working as expected. I think this fixes the issue.

This is especially useful in books where you *don't* want hyphenation by default, but there are some long words for which you do want to consistently allow automatic hyphenation. Simply create a hyphenation dictionary file in `styles` and add the filename at `$hyphenation-dictionary: ""`.

For the record, short hyphenation dictionaries can be simple to create. [This guide](http://docs.translatehouse.org/projects/localization-guide/en/latest/guide/hyphenation.html#by-hand) explains:

> Patterns are specified which describe patterns where hyphenation can occur and where hyphenation cannot occur. The priorities of breaking or non-breaking points are set by numbers (about 1-6). Odd numbers (1,3,5) indicate places where hyphenation can occur. Even numbers (2,4,6) indicate places where hyphenation are not allowed. All patterns that match a particular word are applied to a word. Higher numbers overrule the lower numbers. The places with odd numbers left indicate possible hyphenation points. A full stop can be used to indicate a word boundary (either beginning or end).