### PR TITLE
Variant outputs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -111,7 +111,7 @@ compress_html:
 # ----------------------------
 
 # Version of this Electric Book template
-version: "0.7.1"
+version: "0.8.0"
 
 # Leave this unchanged as http://localhost:4000 unless you really know what you're doing here. This is the URL that Jekyll will run at by default locally.
 url: http://localhost:4000

--- a/_config.yml
+++ b/_config.yml
@@ -146,7 +146,3 @@ defaults:
     values:
       layout: "default"
       style: "chapter"
-      stylesheet-print-pdf: "print-pdf.css"
-      stylesheet-screen-pdf: "screen-pdf.css"
-      stylesheet-web: "web.css"
-      stylesheet-epub: "epub.css"

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -132,3 +132,9 @@ works:
           - "0-3-contents"
           - "01"
           - "02"
+    # variants:
+    #   - variant: myvariant
+    #     identifier: ""
+    #     products:
+    #       print-pdf:
+    #         identifier: ""

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -1,19 +1,28 @@
 # Electric Book settings
 
-# ----------------------------------------------------------
 # Electric Book Manager settings
 # ----------------------------------------------------------
 electric-book-manager: enable
 electric-book-manager-key: ""
 # ----------------------------------------------------------
 
-# ----------------------------------------------------------
 # Variant settings
 # Set a variant of the work to output.
-# Variant names must be one word, lowercase. Hyphens are allowed.
-# A variant lets you override metadata and can be used in text docs,
+# A variant lets you override metadata and stylesheets and can be used,
 # where `include metadata` has been used, in if statements like
 # {% if variant == "somename" %}Variant text!{% endif %}
+# Variant names must be one word, lowercase. Hyphens are allowed.
+# Add variant book metadata to meta.yml, and output settings here.
 # ----------------------------------------------------------
-# variant: myvariant
+# Select the active variant:
+# active-variant: myvariant
+# ----------------------------------------------------------
+# Store settings for each variant
+variants:
+  - variant: myvariant
+    print-pdf-stylesheet: "print-pdf-variant.css"
+    screen-pdf-stylesheet: ""
+    web-stylesheet: "web-variant.css"
+    epub-stylesheet: ""
+  - variant: yourvariant
 # ----------------------------------------------------------

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -1,0 +1,19 @@
+# Electric Book settings
+
+# ----------------------------------------------------------
+# Electric Book Manager settings
+# ----------------------------------------------------------
+electric-book-manager: enable
+electric-book-manager-key: ""
+# ----------------------------------------------------------
+
+# ----------------------------------------------------------
+# Variant settings
+# Set a variant of the work to output.
+# Variant names must be one word, lowercase. Hyphens are allowed.
+# A variant lets you override metadata and can be used in text docs,
+# where `include metadata` has been used, in if statements like
+# {% if variant == "somename" %}Variant text!{% endif %}
+# ----------------------------------------------------------
+# variant: myvariant
+# ----------------------------------------------------------

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
     {% endif %}
     </title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-    <link rel="stylesheet" type="text/css" href="{{ path-to-book-directory }}Styles/{{ page.stylesheet-epub }}" />
+    <link rel="stylesheet" type="text/css" href="{{ path-to-book-directory }}Styles/{{ epub-stylesheet }}" />
     
     <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/" />
         <meta name="DC.Title" content="{{ title }}" />
@@ -43,7 +43,7 @@
     </title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="{{ path-to-book-directory }}styles/{{ page.stylesheet-screen-pdf }}" />
+    <link rel="stylesheet" type="text/css" href="{{ path-to-book-directory }}styles/{{ screen-pdf-stylesheet }}" />
 
     {% include head-elements %}
 
@@ -64,7 +64,7 @@
     </title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="{{ path-to-book-directory }}styles/{{ page.stylesheet-print-pdf }}" />
+    <link rel="stylesheet" type="text/css" href="{{ path-to-book-directory }}styles/{{ print-pdf-stylesheet }}" />
 
     {% include head-elements %}
 
@@ -113,12 +113,12 @@
 
     {% if is-homepage == true or is-series-search == true %}
     {% for book in site.data.meta.works %}
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ site.baseurl }}/{{ book.directory }}/styles/{{ page.stylesheet-web }}" />
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ site.baseurl }}/{{ book.directory }}/styles/{{ web-stylesheet }}" />
     <link rel="stylesheet" type="text/css" media="print" href="{{ site.baseurl }}/{{ book.directory }}/styles/{{ page.stylesheet-screen-pdf }}" />
     {% endfor %}
     {% else %}
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ path-to-book-directory }}styles/{{ page.stylesheet-web }}" />
-    <link rel="stylesheet" type="text/css" media="print" href="{{ path-to-book-directory }}styles/{{ page.stylesheet-screen-pdf }}" />
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ path-to-book-directory }}styles/{{ web-stylesheet }}" />
+    <link rel="stylesheet" type="text/css" media="print" href="{{ path-to-book-directory }}styles/{{ screen-pdf-stylesheet }}" />
     {% endif %}
 
     {% include head-elements %}

--- a/_includes/metadata
+++ b/_includes/metadata
@@ -62,6 +62,12 @@ Get the current file's name
 
 {% capture current-file %}{{ page.url | remove_first: ".html" | replace: "/", " " | split, " " | last }}{% endcapture %}
 
+{% comment %}Set default stylesheets{% endcomment %}
+{% capture print-pdf-stylesheet %}print-pdf.css{% endcapture %}
+{% capture screen-pdf-stylesheet %}screen-pdf.css{% endcapture %}
+{% capture web-stylesheet %}web.css{% endcapture %}
+{% capture epub-stylesheet %}epub.css{% endcapture %}
+
 {% comment %}
 From meta.yml, get only the values where the work.directory matches the current book-directory
 {% endcomment %}
@@ -220,9 +226,9 @@ override any metadata set for that variant.{% endcomment %}
 {% comment %}First, though, set variant-toc to false as default{% endcomment %}
 {% assign variant-toc = false %}
 
-{% if site.data.settings.variant and site.data.settings.variant != "" %}
+{% if site.data.settings.active-variant and site.data.settings.active-variant != "" %}
 
-    {% capture variant %}{{ site.data.settings.variant }}{% endcapture %}
+    {% capture variant %}{{ site.data.settings.active-variant }}{% endcapture %}
 
     {% for data in variants %}
 
@@ -302,6 +308,15 @@ override any metadata set for that variant.{% endcomment %}
 
         {% endif %}
 
+    {% endfor %}
+
+    {% comment %}Get variant settings from settings{% endcomment %}
+    {% assign variant-settings = site.data.settings.variants | where: "variant", variant %}
+    {% for setting in variant-settings %}
+        {% capture print-pdf-stylesheet %}{{ setting.print-pdf-stylesheet }}{% endcapture %}
+        {% capture screen-pdf-stylesheet %}{{ setting.screen-pdf-stylesheet }}{% endcapture %}
+        {% capture web-stylesheet %}{{ setting.web-stylesheet }}{% endcapture %}
+        {% capture epub-stylesheet %}{{ setting.epub-stylesheet }}{% endcapture %}
     {% endfor %}
 
 {% endif %}

--- a/_includes/metadata
+++ b/_includes/metadata
@@ -100,6 +100,7 @@ and book content as a Liquid output tag e.g. {{ title }}
     {% capture print-pdf-identifier %}{{ work.products.print-pdf.identifier }}{% endcapture %}
     {% capture print-pdf-image %}{{ work.products.print-pdf.image }}{% endcapture %}
     {% assign print-pdf-file-list = work.products.print-pdf.files %}
+    {% assign print-pdf-toc = work.products.print-pdf.toc %}
 
     {% capture web-date %}{{ work.products.web.date }}{% endcapture %}
     {% capture web-format %}{{ work.products.web.format }}{% endcapture %}
@@ -110,18 +111,23 @@ and book content as a Liquid output tag e.g. {{ title }}
     {% capture web-contents-page %}{{ work.products.web.contents-page }}{% endcapture %}
     {% assign web-file-list = work.products.web.files %}
     {% assign web-nav-tree = work.products.web.nav %}
+    {% assign web-toc = work.products.web.toc %}
 
     {% capture epub-date %}{{ work.products.epub.date }}{% endcapture %}
     {% capture epub-format %}{{ work.products.epub.format }}{% endcapture %}
     {% capture epub-identifier %}{{ work.products.epub.identifier }}{% endcapture %}
     {% capture epub-image %}{{ work.products.epub.image }}{% endcapture %}
     {% assign epub-file-list = work.products.epub.files %}
+    {% assign epub-toc = work.products.epub.toc %}
 
     {% capture screen-pdf-date %}{{ work.products.screen-pdf.date }}{% endcapture %}
     {% capture screen-pdf-format %}{{ work.products.screen-pdf.format }}{% endcapture %}
     {% capture screen-pdf-identifier %}{{ work.products.screen-pdf.identifier }}{% endcapture %}
     {% capture screen-pdf-image %}{{ work.products.screen-pdf.image }}{% endcapture %}
     {% assign screen-pdf-file-list = work.products.screen-pdf.files %}
+    {% assign screen-pdf-toc = work.products.screen-pdf.toc %}
+
+    {% assign variants = work.variants %}
 
     {% assign translations = work.translations %}
 
@@ -197,6 +203,102 @@ defined in meta.yml for the given translation.
             {% if work.products.screen-pdf.identifier %}{% capture screen-pdf-identifier %}{{ work.products.screen-pdf.identifier }}{% endcapture %}{% endif %}
             {% if work.products.screen-pdf.image %}{% capture screen-pdf-image %}{{ work.products.screen-pdf.image }}{% endcapture %}{% endif %}
             {% if work.products.screen-pdf.files %}{% assign screen-pdf-file-list = work.products.screen-pdf.files %}{% endif %}
+
+            {% if work.variants %}
+                {% assign variants = work.variants %}
+            {% endif %}
+
+        {% endif %}
+
+    {% endfor %}
+
+{% endif %}
+
+{% comment %}If a variant is enabled in settings,
+override any metadata set for that variant.{% endcomment %}
+
+{% comment %}First, though, set variant-toc to false as default{% endcomment %}
+{% assign variant-toc = false %}
+
+{% if site.data.settings.variant and site.data.settings.variant != "" %}
+
+    {% capture variant %}{{ site.data.settings.variant }}{% endcapture %}
+
+    {% for data in variants %}
+
+        {% if data.variant == variant %}
+
+              {% if data.directory %}{% capture book-directory %}{{ data.directory }}{% endcapture %}{% endif %}
+              {% if data.title %}{% capture title %}{{ data.title }}{% endcapture %}{% endif %}
+              {% if data.subtitle %}{% capture subtitle %}{{ data.subtitle }}{% endcapture %}{% endif %}
+              {% if data.creator %}{% capture creator %}{{ data.creator }}{% endcapture %}{% endif %}
+              {% if data.contributor %}{% capture contributor %}{{ data.contributor }}{% endcapture %}{% endif %}
+              {% if data.subject %}{% capture subject %}{{ data.subject }}{% endcapture %}{% endif %}
+              {% if data.description %}{% capture description %}{{ data.description }}{% endcapture %}{% endif %}
+              {% if data.publisher %}{% capture publisher %}{{ data.publisher }}{% endcapture %}{% endif %}
+              {% if data.publisher-url %}{% capture publisher-url %}{{ data.publisher-url }}{% endcapture %}{% endif %}
+              {% if data.date %}{% capture date %}{{ data.date }}{% endcapture %}{% endif %}
+              {% if data.modified %}{% capture modified %}{{ data.modified }}{% endcapture %}{% endif %}
+              {% if data.type %}{% capture type %}{{ data.type }}{% endcapture %}{% endif %}
+              {% if data.identifier %}{% capture identifier %}{{ data.identifier }}{% endcapture %}{% endif %}
+              {% if data.source %}{% capture source %}{{ data.source }}{% endcapture %}{% endif %}
+              {% if data.language %}{% capture language %}{{ data.language }}{% endcapture %}{% endif %}
+              {% if data.relation %}{% capture relation %}{{ data.relation }}{% endcapture %}{% endif %}
+              {% if data.coverage %}{% capture coverage %}{{ data.coverage }}{% endcapture %}{% endif %}
+              {% if data.rights %}{% capture rights %}{{ data.rights }}{% endcapture %}{% endif %}
+              {% if data.image %}{% capture image %}{{ data.image }}{% endcapture %}{% endif %}
+
+              {% if data.products.print-pdf.date %}{% capture print-pdf-date %}{{ data.products.print-pdf.date }}{% endcapture %}{% endif %}
+              {% if data.products.print-pdf.format %}{% capture print-pdf-format %}{{ data.products.print-pdf.format }}{% endcapture %}{% endif %}
+              {% if data.products.print-pdf.identifier %}{% capture print-pdf-identifier %}{{ data.products.print-pdf.identifier }}{% endcapture %}{% endif %}
+              {% if data.products.print-pdf.image %}{% capture print-pdf-image %}{{ data.products.print-pdf.image }}{% endcapture %}{% endif %}
+              {% if data.products.print-pdf.files %}{% assign print-pdf-file-list = data.products.print-pdf.files %}{% endif %}
+              {% if data.products.print-pdf.toc %}
+                {% assign print-pdf-toc = data.products.print-pdf.toc %}
+                {% if site.output == "print-pdf" %}
+                  {% assign variant-toc = true %}
+                {% endif %}
+              {% endif %}
+
+              {% if data.products.web.date %}{% capture web-date %}{{ data.products.web.date }}{% endcapture %}{% endif %}
+              {% if data.products.web.format %}{% capture web-format %}{{ data.products.web.format }}{% endcapture %}{% endif %}
+              {% if data.products.web.identifier %}{% capture web-identifier %}{{ data.products.web.identifier }}{% endcapture %}{% endif %}
+              {% if data.products.web.image %}{% capture web-image %}{{ data.products.web.image }}{% endcapture %}{% endif %}
+              {% if data.products.web.footer %}{% capture web-footer %}{{ data.products.web.footer }}{% endcapture %}{% endif %}
+              {% if data.products.web.start-page %}{% capture web-start-page %}{{ data.products.web.start-page }}{% endcapture %}{% endif %}
+              {% if data.products.web.contents-page %}{% capture web-contents-page %}{{ data.products.web.contents-page }}{% endcapture %}{% endif %}
+              {% if data.products.web.files %}{% assign web-file-list = data.products.web.files %}{% endif %}
+              {% if data.products.web.nav %}{% assign web-nav-tree = data.products.web.nav %}{% endif %}
+              {% if data.products.web.toc %}
+                {% assign web-toc = data.products.web.toc %}
+                {% if site.output == "web" %}
+                  {% assign variant-toc = true %}
+                {% endif %}
+              {% endif %}
+
+              {% if data.products.epub.date %}{% capture epub-date %}{{ data.products.epub.date }}{% endcapture %}{% endif %}
+              {% if data.products.epub.format %}{% capture epub-format %}{{ data.products.epub.format }}{% endcapture %}{% endif %}
+              {% if data.products.epub.identifier %}{% capture epub-identifier %}{{ data.products.epub.identifier }}{% endcapture %}{% endif %}
+              {% if data.products.epub.image %}{% capture epub-image %}{{ data.products.epub.image }}{% endcapture %}{% endif %}
+              {% if data.products.epub.files %}{% assign epub-file-list = data.products.epub.files %}{% endif %}
+              {% if data.products.epub.toc %}
+                {% assign epub-toc = data.products.epub.toc %}
+                {% if site.output == "epub" %}
+                  {% assign variant-toc = true %}
+                {% endif %}
+              {% endif %}
+
+              {% if data.products.screen-pdf.date %}{% capture screen-pdf-date %}{{ data.products.screen-pdf.date }}{% endcapture %}{% endif %}
+              {% if data.products.screen-pdf.format %}{% capture screen-pdf-format %}{{ data.products.screen-pdf.format }}{% endcapture %}{% endif %}
+              {% if data.products.screen-pdf.identifier %}{% capture screen-pdf-identifier %}{{ data.products.screen-pdf.identifier }}{% endcapture %}{% endif %}
+              {% if data.products.screen-pdf.image %}{% capture screen-pdf-image %}{{ data.products.screen-pdf.image }}{% endcapture %}{% endif %}
+              {% if data.products.screen-pdf.files %}{% assign screen-pdf-file-list = data.products.screen-pdf.files %}{% endif %}
+              {% if data.products.screen-pdf.toc %}
+                {% assign screen-pdf-toc = data.products.screen-pdf.toc %}
+                {% if site.output == "screen-pdf" %}
+                  {% assign variant-toc = true %}
+                {% endif %}
+              {% endif %}
 
         {% endif %}
 

--- a/_includes/toc
+++ b/_includes/toc
@@ -1,82 +1,65 @@
 {% comment %}
-Get the current book directory.
+Get the file metadata.
 {% endcomment %}
-
-{% capture book-directory %}{{ page.path | replace: "/", " " | truncatewords: 1, "" }}{% endcapture %}
-
-{% comment %}
-From meta.yml, get only the works from the current book, that is
-where the directory for a work in meta.yml matches the current directory.
-{% endcomment %}
-
-{% assign works = site.data.meta.works | where: "directory", book-directory %}
+{% include metadata %}
 
 {% comment %}
 Now check which output format we're creating, and capture its toc.
-Fall back to print-pdf toc, then web nav list, then print file list.
+Fall back to print-pdf toc, then web nav list.
 {% endcomment %}
 
-{% for work in works %}
-
 {% if site.output == "print-pdf" %}
-    {% if work.products.print-pdf.toc != nil %}
-        {% assign toc = work.products.print-pdf.toc %}
-    {% elsif work.products.web.nav != nil %}
-        {% assign toc = work.products.web.nav %}
+    {% if print-pdf-toc != nil %}
+        {% assign toc = print-pdf-toc %}
+    {% elsif web-nav != nil %}
+        {% assign toc = web-nav %}
     {% else %}
         Please define a TOC or web nav in meta.yml.
     {% endif %}
 
 {% elsif site.output == "screen-pdf" %}
-    {% if work.products.screen-pdf.toc != nil %}
-        {% assign toc = work.products.screen-pdf.toc %}
-    {% elsif work.products.print-pdf.toc != nil %}
-        {% assign toc = work.products.print-pdf.toc %}
-    {% elsif work.products.web.nav != nil %}
-        {% assign toc = work.products.web.nav %}
+    {% if screen-pdf-toc != nil %}
+        {% assign toc = screen-pdf-toc %}
+    {% elsif print-pdf-toc != nil %}
+        {% assign toc = print-pdf-toc %}
+    {% elsif web-nav != nil %}
+        {% assign toc = web-nav %}
     {% else %}
         Please define a TOC or web nav in meta.yml.
     {% endif %}
 
 {% elsif site.output == "epub" %}
-    {% if work.products.epub.toc != nil %}
-        {% assign toc = work.products.epub.toc %}
-    {% else %}
-        {% assign toc = work.products.print-pdf.toc %}
-    {% elsif work.products.web.nav != nil %}
-        {% assign toc = work.products.web.nav %}
+    {% if epub-toc != nil %}
+        {% assign toc = epub-toc %}
+    {% elsif print-pdf-toc != nil %}
+        {% assign toc = print-pdf-toc %}
+    {% elsif web-nav != nil %}
+        {% assign toc = web-nav %}
     {% else %}
         Please define a TOC or web nav in meta.yml.
     {% endif %}
 
 {% elsif site.output == "web" %}
-    {% if work.products.web.toc != nil %}
-        {% assign toc = work.products.web.toc %}
-    {% else %}
-        {% assign toc = work.products.web.nav %}
-    {% else %}
-        {% assign toc = work.products.print-pdf.toc %}
+    {% if web-toc != nil %}
+        {% assign toc = web-toc %}
+    {% elsif web-nav != nil %}
+        {% assign toc = web-nav %}
+    {% elsif print-pdf-toc != nil %}
+        {% assign toc = print-pdf-toc %}
     {% else %}
         Please define a TOC or web nav in meta.yml.
     {% endif %}
 
 {% else %}
-    {% if work.products.web.nav != nil %}
-        {% assign toc = work.products.web.nav %}
+    {% if web-nav != nil %}
+        {% assign toc = web-nav %}
+    {% elsif print-pdf-toc != nil %}
+        {% assign toc = print-pdf-toc %}
     {% else %}
         Please define a TOC or web nav in meta.yml.
     {% endif %}
 
 {% endif %}
-
-{% endfor %}
-
-{% comment %}
-Get the current file, so we can check stuff, e.g.:
-when this list is on the page that includes it.
-{% endcomment %}
-
-{% capture current-file %}{{ page.url | remove_first: ".html" | replace: "/", " " | split, " " | last }}{% endcapture %}
 
 {% comment %}
 If the file that called this include didn't specify a start parameter, then
@@ -88,7 +71,7 @@ Otherwise, the toc-branch should be the children called by this include recursiv
 {% assign toc-branch = include.start %}
 
 {% if toc-branch == nil %}
-{% assign toc-branch = toc %}
+    {% assign toc-branch = toc %}
 {% endif %}
 
 {% comment %}
@@ -97,14 +80,41 @@ Now we'll use all that to output the toc list.
 
 <ol class="toc-list {% if toc-branch contains current-file %}active{% endif %}">
 {% for item in toc-branch | sort: "order" %}
-    <li class="toc-entry-title{% if page.url contains item.file %} active{% endif %}{% if item.class != nil %} {{ item.class }}{% endif %}">
-        {% if item.file != nil %}<a href="{{ base.url}}{{ item.file }}.html{% if item.id != nil %}#{{ item.id }}{% endif %}"
-           {% if page.url contains item.file %}class="active"{% endif %}>{% endif %}
-            <span class="toc-entry-text">{{ item.label | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}</span>
-        {% if item.file != nil %}</a>{% endif %}
-        {% if item.children != nil %}
-            {% include toc start=item.children %}
-        {% endif %}
-    </li>
+
+    {% comment %}Assume we will use every item in the toc-branch{% endcomment %}
+    {% assign include-in-toc = true %}
+
+    {% comment %}If we're outputting a variant, check if a variant toc
+    has been specified. If it has, then it replaced the default toc tree.
+    If we are outputting a variant, and a variant toc is not specified,
+    check which variants, if any, this particular TOC item has specified.
+    Include the item in the TOC only if it is specified in the TOC item's
+    variants list.{% endcomment %}
+    {% if variant and variant-toc == false %}
+        {% assign toc-variants = item.variants | remove: " " | split: "," %}
+        {% for toc-variant in toc-variants %}
+            {% if toc-variant == variant %}
+                {% assign include-in-toc = true %}
+                {% break %}
+            {% else %}
+                {% assign include-in-toc = false %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+
+    {% if include-in-toc == true %}
+
+        <li class="toc-entry-title{% if page.url contains item.file %} active{% endif %}{% if item.class != nil %} {{ item.class }}{% endif %}">
+            {% if item.file != nil %}<a href="{{ base.url}}{{ item.file }}.html{% if item.id != nil %}#{{ item.id }}{% endif %}"
+               {% if page.url contains item.file %}class="active"{% endif %}>{% endif %}
+                <span class="toc-entry-text">{{ item.label | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}</span>
+            {% if item.file != nil %}</a>{% endif %}
+            {% if item.children != nil %}
+                {% include toc start=item.children %}
+            {% endif %}
+        </li>
+
+    {% endif %}
+
 {% endfor %}
 </ol>


### PR DESCRIPTION
This is a fairly large update because it adds support for variant output. 

For most books, our four main outputs (`print-pdf`, `screen-pdf`, `web` and `epub`) are sufficient. But sometimes you need a variation on one or more of these. For instance, you might be producing two versions of a printed book with different designs (e.g. for schools and for trade) with different selections of chapters. Or you may be white-labelling a website, and need to output various versions with different colours or logos. Variants make that possible.

To activate a variant, put its name as the `active-variant` in `settings.yml`. Make sure you deactivate it, for instance by commenting it out, to get your default output back.

You can create new stylesheets in addition to our standard four, and specify these in the new `_data/settings.yml` files. And you can set variant-specific metadata in `_data/meta.yml` in the same way you'd create metadata for a translation, by creating a `variants` node in a `work` containing all the same metadata you would for the `work`; except instead of setting a `directory`, you set a `variant`, which matches the name of the variant you created in `settings.yml`. This can include things like `identifier`s, `files` lists, and `toc` and `nav` nodes. 

For TOCs, you can also change the TOC output for a variant by adding the names of the variants in which a TOC item should appear to the item's node as 'variants', e.g.:

```
toc:
  label: "Study tips"
  file: "05-study-tips"
  variants: school, varsity
```

When an `active-variant` is set, and the default `toc` or `nav` are output, any items that do not include the `active-variant`'s name in its `variants` list here will not be output.

This can be easier to maintain than creating a whole new `toc` node to the variant's metadata, which would mostly be a straight duplication of the default output.