### PR TITLE
Refine configs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -93,8 +93,7 @@ image-set: "images/web"
 # Once your CSS is stable, exclude `css` here and keep it below under `keep_files`.
 # Include the file extension too. E.g. book/text/01.md
 exclude:
-# - css
-# - book
+# Build tools
 - run-linux.sh
 - run-mac.command
 - run-windows.bat
@@ -103,13 +102,20 @@ exclude:
 - README*
 - LICENSE*
 - CHANGELOG*
+- node_modules
+- eslint.json
+- gulpfile.js
+- package.json
+- package-lock.json
+# Books
+# - book
 
 # Can be useful to stop Jekyll overwriting files in _site.
 # E.g. generate CSS once, then exclude above but keep here
 # to make content regeneration faster.
 # The file path is relative to the site.output directory.
 keep_files:
-# - css
+# - book
 
 # Configure HTML compression
 # See https://github.com/penibelst/jekyll-compress-html

--- a/_configs/_config.print-pdf.yml
+++ b/_configs/_config.print-pdf.yml
@@ -2,3 +2,7 @@
 output: "print-pdf"
 # Set site.image-set == "images/print-pdf"
 image-set: "images/print-pdf"
+# Turn off documentation
+collections:
+  docs:
+    output: false

--- a/_configs/_config.screen-pdf.yml
+++ b/_configs/_config.screen-pdf.yml
@@ -2,3 +2,7 @@
 output: "screen-pdf"
 # Set site.image-set == "images/screen-pdf"
 image-set: "images/screen-pdf"
+# Turn off documentation
+collections:
+  docs:
+    output: false


### PR DESCRIPTION
Small but important refinement to configs, excluding build tools from Jekyll and not building the docs when doing PDF outputs.