### PR TITLE
Change term `series` to `project`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.10.0
 
 * Keep build tools in `_tools`
+* Change term `series` to broader `project`
 
 ## 0.9.0
 

--- a/_app/config.xml
+++ b/_app/config.xml
@@ -5,13 +5,13 @@ layout: min
 {% include metadata %}
 
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="{{ series-app-id }}" version="{{ series-version }}" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
-    <name>{{ series-name }}</name>
+<widget id="{{ project-app-id }}" version="{{ project-version }}" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+    <name>{{ project-name }}</name>
     <description>
-        {{ series-description }}
+        {{ project-description }}
     </description>
     <author email="team@fireandlion.com" href="https://fireandlion.com/">
-        {{ series-organisation }}
+        {{ project-organisation }}
     </author>
     <content src="index.html" />
     <icon src="res/icon.png" />

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@
 # UPDATE THESE SETTINGS ON SETUP
 # ------------------------------
 
-# The primary language used in this series. You can set the language for each book individually below at 'defaults'. 
+# The primary language used in this project. You can set the language for each book individually below at 'defaults'. 
 # To understand what language tags to use, read: http://www.w3.org/International/articles/language-tags/ 
 # For the registry of tags: http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry 
 # Useful lookup tool: http://r12a.github.io/apps/subtags/
@@ -48,7 +48,7 @@ nav-source: nav
 # so this is off (false) by default. Change to true to load MathJax.
 # See http://docs.mathjax.org/en/latest/configuration.html for details.
 # MathJax scripts are loaded by mathjax-config include, where you can also
-# configure MathJax for your series. For MathJax font choices, see
+# configure MathJax for your project. For MathJax font choices, see
 # http://docs.mathjax.org/en/latest/font-support.html
 # This font can be overridden per page by adding mathjax-font: "" to page frontmatter YAML.
 # To use MathJax in PDF output, you must have PhantomJS installed: http://phantomjs.org
@@ -58,6 +58,8 @@ mathjax-font: "Gyre-Pagella"
 # Documentation is built into the Electric Book template.
 # These docs build along with your books, so they are available
 # as you work. To turn off the docs, change output to false.
+# The app and epub collections are off by default, and
+# turned on by those formats' _config files.
 collections:
   docs:
     output: true
@@ -161,7 +163,7 @@ sass:
 # Store only site configurations here, and book metadata (title, author, ISBNs) in _data/meta.yml
 defaults: 
   -
-    scope: # Sets default page frontmatter for all files in this series (an empty string "" for path means all files).
+    scope: # Sets default page frontmatter for all files in this project (an empty string "" for path means all files).
       path: ""
     values:
       layout: "default"

--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -1,27 +1,27 @@
-########
-# SERIES
-########
+#########
+# PROJECT
+#########
 
-# Replace the values here with your series information.
-series:
-  # The name of the organisation or entity that owns this series
+# Replace the values here with your project` information.
+project:
+  # The name of the organisation or entity that owns this project
   organisation: "Electric Book Works"
   # A live web address for the organisation
   url: "http://electricbook.works/"
   # The default contact email address
   email: "support@electricbook.works"
-  # The name of the series of books in this folder.
+  # The name of the project of books in this folder.
   name: "Electric Book"
-  # A one-liner about this series. Useful for Open Graph metadata.
+  # A one-liner about this project. Useful for Open Graph metadata.
   description: "Books created with the Electric Book workflow"
-  # An image in /assets that stands for the series
+  # An image in /assets that stands for the project
   image: "publisher-logo.jpg"
-  # For web navigation, the label for links to  the series homepage
+  # For web navigation, the label for links to the project homepage
   # For English sites, you can leave this as "Home".
   home-label: "Home"
   # For web navigation, the label for the navigation menu
   nav-label: "Contents"
-  # Footer text for the series
+  # Footer text for the project
   footer: "Built with the [Electric Book](http://electricbook.works)"
   # For web search, the "placeholder" text while the search is running
   search-placeholder: "Searching..."

--- a/_docs/javascript.md
+++ b/_docs/javascript.md
@@ -13,7 +13,7 @@ To add them just before the `</body>` tag, add `<script>` tags to `_includes/end
 
 You can also link to remote scripts here, without the need to place the actual scripts in the `js` folder.
 
-Keep in mind that anything you add to `head-elements` will be added to all books in the series folder, and to all their formats.
+Keep in mind that anything you add to `head-elements` will be added to all books in the project folder, and to all their formats.
 
 ## Limiting scripts by book or format
 

--- a/_docs/quick-start.md
+++ b/_docs/quick-start.md
@@ -8,7 +8,7 @@ categories: setup
 This quick setup assumes you already have [Jekyll](http://jekyllrb.com/) (verson 3.3 or higher) and [Prince](http://www.princexml.com/) installed and working on your computer. There is more detail, and lots of more advanced guidance, in [this guide](http://electricbook.works).
 
 1. Download the [Jekyll template](https://github.com/electricbookworks/electric-book).
-2. Open `_data/meta.yml` and replace the sample book information there with your series and book information.
+2. Open `_data/meta.yml` and replace the sample book information there with your project and book information.
 3. In the `book` folder edit or remove the sample files, and add your book's content.
 4. To modify the design, edit the `.scss` files for each output format in `book/styles`.
 5. Run the `run-` script for your operating system. (On OSX and Linux, you need to [give it permission](http://stackoverflow.com/a/5126052/1781075).)

--- a/_docs/setting-up.md
+++ b/_docs/setting-up.md
@@ -35,25 +35,22 @@ To use the workflow on your own machine, you must have the following software in
 
 ## Folder (repo) structure
 
-A workflow folder (often tracked in Git as a repo) usually contains a series of related books. Its folders and files follow the [standard Jekyll structure](http://jekyllrb.com/docs/structure/). We then put each book's content in its own folder. In the template, the first book folder is simply called `book`.
-
-> Pro tip: You could also store several series in one repo, each series with its own set of Jekyll files, and a single `_prose.yml` configuration in the root folder for all series subfolders. This is only useful if you don't need a live staging site or previews with GitHub Pages, since each Jekyll setup must be in its own repo for GitHub Pages to work out of the box.
-{:.box}
+A workflow folder (often tracked in Git as a repo) usually contains a set of related books. Its folders and files follow the [standard Jekyll structure](http://jekyllrb.com/docs/structure/). We then put each book's content in its own folder. In the template, the first book folder is simply called `book`.
 
 ## Using the template
 
-The Electric Book repo (folder) is ready to use for a series of one or more books. In short, to get up and running, see the [Quick Start guide](0-9-quick-start.html).
+The Electric Book repo (folder) is ready to use for a set of one or more books. In short, to get up and running, see the [Quick Start guide](0-9-quick-start.html).
 
-Now, let's get into some more detail about how it all works. There are several folders and files in the series template repo:
+Now, let's get into some more detail about how it all works. There are several folders and files in the Electric Book template, including:
 
 *   `_config.yml`: a file for setting configuration options for Jekyll, which will compile your book for output. There are several other smaller config files you can ignore. They are for changing specific config settings on output.
 *   `_prose.yml`: configuration settings for using [prose.io](http://prose.io) for online book editing (generally, you won't have to edit this file).
-*   `book`: a folder for a book's content, stored here in a series of markdown files
+*   `book`: a folder for a book's content, stored in markdown files
 *   `_data`: a folder for information about your books (aka metadata).
 *   `_includes`: snippets of HTML for Jekyll (you won't have to open this folder).
 *   `_site`: where Jekyll will generate the HTML versions of your books.
 *   `_output`: the folder where our output scripts will save your PDFs.
-*   `index.md`: the home page of your series when served as a website.
+*   `index.md`: the home page of your project when served as a website.
 *   various `.bat`, `.command` and `.sh` scripts for quickly generating books in different formats on various operating systems.
 
 Let's explain some of these in more detail.
@@ -69,15 +66,15 @@ That gem provides the basic design of your books. A theme is a collection of fil
 
 The process of setting up a new book is covered briefly in our [quick-start section](0-9-quick-start.html#quick-new-book-setup). Here is more detail.
 
-To create a new book in a new series:
+To create a new book in a new project:
 
-1. The repo (or series folder) can hold one book or many, like a series of books that share similar metadata or features (e.g. they're all by the same author). Make a copy of the folder and, if you like, rename it for your series. E.g. `my-sci-fi`.
+1. The repo (or project folder) can hold one book or many, like a series of books that share similar metadata or features (e.g. they're all by the same author). Make a copy of the folder and, if you like, rename it for your project. E.g. `my-sci-fi`.
 1. Inside `my-sci-fi`, open and edit these three files:
     *   `_config.yml`: Edit the values there for your Jekyll setup. The comments will guide you.
     *   `index.md`: Replace our template text with your own. Usually, a link to each book is useful, e.g. `[Space Potatoes](space-potatoes)`.
-    *   `README.md`: Replace our template text with any notes your collaborators might need to know about your series. (The README file is usually only read in the context of editing the files in your folder/repo.)
+    *   `README.md`: Replace our template text with any notes your collaborators might need to know about your project. (The README file is usually only read in the context of editing the files in your folder/repo.)
 1.  Optionally, rename the `book` folder with a one-word, lowercase version of your book's title (e.g. `space-potatoes`). Use only lowercase letters and no spaces. If you're creating more than one book, make a folder for each book.
-1.	In `_data`, edit the `meta.yml` file, filling in your series info and info about at least your first book.
+1.	In `_data`, edit the `meta.yml` file, filling in your project info and info about at least your first book.
 1.  Inside a book's `text` folder, add a markdown file for each piece of your book, e.g. one file per chapter. Our template contains files we consider minimum requirements for most books: a cover, a title page, a copyright page, a contents page, and a chapter.
 1.  Inside each book's folder, store images in the `images` folder. Add a `cover.jpg` image of your book's front cover there, too.
 1. In each book's `styles` folder, edit the values in `print-pdf.scss`, `screen-pdf.scss`, `web.scss` and `epub.scss`.
@@ -183,6 +180,6 @@ Name each book's markdown files in perfectly alphabetical order. We recommend us
 
 Alongside the content files in a book's folder is an `images` folder, for images that belong to that book only.
 
-A book's folder should only ever need to contain markdown files and images. If you're embedding other kinds of media you could add folders for that alongside `images`. We don't recommend sharing images or media between books, in case you want to move a book from one series to another later. (So, for example, copy the publisher logo into each book's `images` folder separately.)
+A book's folder should only ever need to contain markdown files and images. If you're embedding other kinds of media you could add folders for that alongside `images`. We don't recommend sharing images or media between books, in case you want to move a book from one project to another later. (So, for example, copy the publisher logo into each book's `images` folder separately.)
 
-If your series home page requires images, you will need to create an `images` folder for that in the main series folder.
+If your project home page requires images, keep those in `/assets/images`, so that you can link to them from any page.

--- a/_docs/translations.md
+++ b/_docs/translations.md
@@ -13,14 +13,14 @@ This structure assumes that the translation and its parent will be kept in sync 
 
 If the translating team works independently, and especially if they want to make content changes that diverge from the parent, their translation is actually an adaptation. For instance, adding a new image or page-design feature, or changing design elements like fonts and colours.
 
-An adaptation should be a completely separate repository, which starts out as copy of the parent book (or series, for multi-work repos), but from that point on is treated as a new book, overwriting the original files in the repository with the new language.
+An adaptation should be a completely separate repository, which starts out as copy of the parent project, but from that point on is treated as a new project, overwriting the original files in the repository with the new language.
 
 ## Setting up a translation
 
 To make a translation:
 
 - Add a `translations` node to the `meta.yml` with `directory` and `language`. They can optionally include their own work-level metadata such as `title`. Any metadata not added to a translation will be inherited from the original language. See [Metadata](#metadata) below.
-- Add the files in a new folder inside `book/text`, named for the translation language code. (Remember sometimes `book` has been renamed for each book in a series).
+- Add the files in a new folder inside `book/text`, named for the translation language code. (Remember sometimes `book` has been renamed for each book in a project).
 
 ## Text
 

--- a/_includes/contact-form
+++ b/_includes/contact-form
@@ -5,7 +5,7 @@ See https://formspree.io for how to initialise.
 
 {% include metadata %}
 
-<form action="https://formspree.io/{{ series-email }}"
+<form action="https://formspree.io/{{ project-email }}"
       method="POST">
     <input type="text" name="name" placeholder="Name">
     <input type="email" name="_replyto" placeholder="Email address">

--- a/_includes/end-elements
+++ b/_includes/end-elements
@@ -12,7 +12,7 @@ https://markjs.io/
 {% endcomment %}
 {% if site.output == "web" or site.output == "app" %}
 <script src="{{ path-to-root-directory }}assets/js/bundle.js"></script>
-    {% if is-series-search or is-book-search %}
+    {% if is-project-search or is-book-search %}
     <script src="{{ path-to-root-directory }}assets/js/bundle-search.js"></script>
     {% endif %}
 {% endif %}

--- a/_includes/epub-package
+++ b/_includes/epub-package
@@ -19,9 +19,9 @@
         <dc:title id="subtitle">{{ subtitle }}</dc:title>
         <meta refines="#subtitle" property="title-type">subtitle</meta>
     {% endif %}
-    {% if series-name and series-name != "" %}
-        <dc:title id="series-name">{{ series-name }}</dc:title>
-        <meta refines="#series-name" property="title-type">collection</meta>
+    {% if project-name and project-name != "" %}
+        <dc:title id="project-name">{{ project-name }}</dc:title>
+        <meta refines="#project-name" property="title-type">collection</meta>
     {% endif %}
     {% if publisher and publisher != "" %}
         <dc:publisher>{{ publisher }}</dc:publisher>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,9 +3,9 @@
     <div id="footer">
         <div class="footer-content">
 
-            {% if series-footer and series-footer != "" %}
+            {% if project-footer and project-footer != "" %}
                 <p>
-                    {{ series-footer | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}
+                    {{ project-footer | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}
                 </p>
             {% endif %}
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
     {% if title %}
     {{ title }}{% if page.title %}: {{ page.title }}{% endif %}
     {% else %}
-    {{ series-name }}{% if page.title %}: {{ page.title }}{% endif %}
+    {{ project-name }}{% if page.title %}: {{ page.title }}{% endif %}
     {% endif %}
     </title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
@@ -30,7 +30,7 @@
     {% if title %}
     {{ title }}{% if page.title %}: {{ page.title }}{% endif %}
     {% else %}
-    {{ series-name }}{% if page.title %}: {{ page.title }}{% endif %}
+    {{ project-name }}{% if page.title %}: {{ page.title }}{% endif %}
     {% endif %}
     </title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
@@ -54,14 +54,14 @@
     {% if title %}
     {{ title }}{% if page.title %}: {{ page.title }}{% endif %}
     {% else %}
-    {{ series-name }}{% if page.title %}: {{ page.title }}{% endif %}
+    {{ project-name }}{% if page.title %}: {{ page.title }}{% endif %}
     {% endif %}
     </title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <link rel="stylesheet" type="text/css" href="{{ path-to-styles-directory }}/{{ epub-stylesheet }}" />
     
     {% comment %}Metadata defined in page frontmatter overrides
-    series metadata, which is the default from meta.yml.{% endcomment %}
+    project metadata, which is the default from meta.yml.{% endcomment %}
     {% if page.title %}{% capture title %}{{ page.title }}{% endcapture %}{% endif %}
     {% if page.language %}{% capture language %}{{ page.language }}{% endcapture %}{% endif %}
     {% if page.creator %}{% capture creator %}{{ page.creator }}{% endcapture %}{% endif %}
@@ -96,7 +96,7 @@
     {% if title %}
     {{ title }}{% if page.title %}: {{ page.title }}{% endif %}
     {% else %}
-    {{ series-name }}{% if page.title %}: {{ page.title }}{% endif %}
+    {{ project-name }}{% if page.title %}: {{ page.title }}{% endif %}
     {% endif %}
     </title>
 
@@ -118,7 +118,7 @@
 
     {% comment %}If we're not in a book subdirectory, load the first book's stylesheets.
     Otherwise, load the styles for this book. {% endcomment %}
-    {% if is-homepage == true or is-series-search == true or page.collection == "docs" %}
+    {% if is-homepage == true or is-project-search == true or page.collection == "docs" %}
     {% for book in site.data.meta.works %}
         <link rel="stylesheet" type="text/css" media="all" href="{{ path-to-root-directory }}{{ book.directory }}/styles/{{ app-stylesheet }}" />
         {% break %}
@@ -130,7 +130,7 @@
     {% include head-elements %}
 
     </head>
-    <body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}{% if is-search == true %} search-page{% endif %}{% if is-series-search == true %} series-search-page{% endif %}{% if is-book-search == true %} book-search-page{% endif %}">
+    <body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}{% if is-search == true %} search-page{% endif %}{% if is-project-search == true %} project-search-page{% endif %}{% if is-book-search == true %} book-search-page{% endif %}">
         <div id="wrapper">
 
 
@@ -142,7 +142,7 @@
     {% if title %}
     {{ title }}{% if page.title %}: {{ page.title }}{% endif %}
     {% else %}
-    {{ series-name }}{% if page.title %}: {{ page.title }}{% endif %}
+    {{ project-name }}{% if page.title %}: {{ page.title }}{% endif %}
     {% endif %}
     </title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
@@ -155,25 +155,25 @@
     <meta property="og:description" content="{{ page.description }}" />
     {% endif %}
     {% if page.image %}
-        {% if is-homepage == true or is-series-search == true %}
-            {% comment %}If a page.image is specified on the home page, we still use the series image{% endcomment %}
-            <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/assets/{{ series-image }}" />
+        {% if is-homepage == true or is-project-search == true %}
+            {% comment %}If a page.image is specified on the home page, we still use the project image{% endcomment %}
+            <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/assets/{{ project-image }}" />
         {% else %}
             <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/{{ book-directory }}/{{ site.image-set }}/{{ page.image }}" />
         {% endif %}
-    {% elsif is-homepage == true or is-series-search == true %}
-    <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/assets/{{ series-image }}" />
+    {% elsif is-homepage == true or is-project-search == true %}
+    <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/assets/{{ project-image }}" />
     {% elsif web-image != "" %}
     <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/{{ book-directory }}/{{ site.image-set }}/{{ web-image }}" />
     {% elsif image != "" %}
     <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/{{ book-directory }}/{{ site.image-set }}/{{ image }}" />
     {% else %}
-    <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/assets/{{ series-image }}" />
+    <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/assets/{{ project-image }}" />
     {% endif %}
 
     {% comment %}If we're not in a book subdirectory, load the first book's stylesheets.
     Otherwise, load the styles for this book. {% endcomment %}
-    {% if is-homepage == true or is-series-search == true or page.collection == "docs" %}
+    {% if is-homepage == true or is-project-search == true or page.collection == "docs" %}
     {% for book in site.data.meta.works %}
         <link rel="stylesheet" type="text/css" media="all" href="{{ site.baseurl }}/{{ book.directory }}/styles/{{ web-stylesheet }}" />
         {% break %}
@@ -185,7 +185,7 @@
     {% include head-elements %}
 
 </head>
-<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}{% if is-search == true %} search-page{% endif %}{% if is-series-search == true %} series-search-page{% endif %}{% if is-book-search == true %} book-search-page{% endif %}">
+<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}{% if is-search == true %} search-page{% endif %}{% if is-project-search == true %} project-search-page{% endif %}{% if is-book-search == true %} book-search-page{% endif %}">
 <div id="wrapper">
 
 {% endif %}

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -2,7 +2,7 @@
 
 {% if is-book-subdirectory != true %}
     <ul>
-        <li class="masthead-series-name"><a href="{{ path-to-root-directory }}index.html">{{ series-name | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}</a></li>
+        <li class="masthead-project-name"><a href="{{ path-to-root-directory }}index.html">{{ project-name | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}</a></li>
 
         {% if is-docs-page %}
         <li class="masthead-docs-index"><a href="{{ path-to-root-directory }}/docs/">Docs</a></li>
@@ -18,7 +18,7 @@
             <li class="masthead-book-title"><a href="{{ path-to-root-directory }}index.html">{{ title | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}</a></li>
             {% include breadcrumbs breadcrumb-tree=web-nav-tree %}
         {% else %}
-            <li class="masthead-series-name"><a href="{{ path-to-root-directory }}index.html">{{ series-name | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}</a></li>
+            <li class="masthead-project-name"><a href="{{ path-to-root-directory }}index.html">{{ project-name | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}</a></li>
             <li class="masthead-book-title"><a href="{{ web-contents-page }}{% unless web-contents-page contains '.html' %}.html{% endunless %}">{{ title | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}</a></li>
             {% include breadcrumbs breadcrumb-tree=web-nav-tree %}
         {% endif %}

--- a/_includes/metadata
+++ b/_includes/metadata
@@ -1,29 +1,31 @@
 {% comment %}
-Loop through meta.yml and return this book's metadata as a series of Liquid variables
-that we can use on the page as output variables, e.g. {{ title }} for the current book's title.
+Loop through meta.yml and return this book's metadata
+as a set of Liquid variables that we can use on pages
+as output tags, e.g. {{ title }} for the current
+book's title.
 {% endcomment %}
 
 {% capture output-format %}{{ site.output }}{% endcapture %}
 
 {% comment %}
-Assign series information to variables. This is the same for all books in the series.
+Assign project information to variables. This is the same for all books in the project.
 {% endcomment %}
 
-{% capture series-organisation %}{{ site.data.meta.series.organisation }}{% endcapture %}
-{% capture series-url %}{{ site.data.meta.series.url }}{% endcapture %}
-{% capture series-email %}{{ site.data.meta.series.email }}{% endcapture %}
-{% capture series-name %}{{ site.data.meta.series.name }}{% endcapture %}
-{% capture series-description %}{{ site.data.meta.series.description }}{% endcapture %}
-{% capture series-image %}{{ site.data.meta.series.image }}{% endcapture %}
-{% capture series-home-label %}{{ site.data.meta.series.home-label }}{% endcapture %}
-{% capture series-nav-label %}{{ site.data.meta.series.nav-label }}{% endcapture %}
-{% capture series-footer %}{{ site.data.meta.series.footer }}{% endcapture %}
-{% capture series-search-placeholder %}{{ site.data.meta.series.search-placeholder }}{% endcapture %}
-{% capture series-app-id %}{{ site.data.meta.series.app-id }}{% endcapture %}
-{% capture series-version %}{{ site.data.meta.series.version }}{% endcapture %}
+{% capture project-organisation %}{{ site.data.meta.project.organisation }}{% endcapture %}
+{% capture project-url %}{{ site.data.meta.project.url }}{% endcapture %}
+{% capture project-email %}{{ site.data.meta.project.email }}{% endcapture %}
+{% capture project-name %}{{ site.data.meta.project.name }}{% endcapture %}
+{% capture project-description %}{{ site.data.meta.project.description }}{% endcapture %}
+{% capture project-image %}{{ site.data.meta.project.image }}{% endcapture %}
+{% capture project-home-label %}{{ site.data.meta.project.home-label }}{% endcapture %}
+{% capture project-nav-label %}{{ site.data.meta.project.nav-label }}{% endcapture %}
+{% capture project-footer %}{{ site.data.meta.project.footer }}{% endcapture %}
+{% capture project-search-placeholder %}{{ site.data.meta.project.search-placeholder }}{% endcapture %}
+{% capture project-app-id %}{{ site.data.meta.project.app-id }}{% endcapture %}
+{% capture project-version %}{{ site.data.meta.project.version }}{% endcapture %}
 
 {% comment %}
-It's useful to know how many books are in this series
+It's useful to know how many books are in this project
 {% endcomment %}
 
 {% assign number-of-works = site.data.meta.works | size %}
@@ -443,11 +445,11 @@ override any metadata set for that variant.{% endcomment %}
 {% endif %}
 
 {% comment %}
-Check if we're on the series homepage:
+Check if we're on the project homepage:
 * Get a slugified version of the page URL, without hyphens, to compare to
   a slugified version of the baseurl. We slugify to remove slashes, which
   may differ between the two.
-* Then we can compare them to test if we're on the series home page.
+* Then we can compare them to test if we're on the project home page.
 * If we are, they will match. Hopefully.
 {% endcomment %}
 {% capture pageurl-slug %}{{ site.baseurl | slugify | remove: "-" }}{{ page.url | slugify | remove: "-" }}{% endcapture %}
@@ -461,11 +463,11 @@ Check if we're on the series homepage:
 {% comment %}
 Check if we're on the search pages.
 {% endcomment %}
-{% capture series-search-url %}{{ site.baseurl }}/search.html{% endcapture %}
+{% capture project-search-url %}{{ site.baseurl }}/search.html{% endcapture %}
 {% unless is-homepage %}
     {% capture book-search-url %}{{ site.baseurl }}/{{ book-directory }}/text/search.html{% endcapture %}
 {% endunless %}
-{% capture series-search-url-slug %}{{ series-search-url | slugify | remove: "-" }}{% endcapture %}
+{% capture project-search-url-slug %}{{ project-search-url | slugify | remove: "-" }}{% endcapture %}
 {% capture book-search-url-slug %}{{ book-search-url | slugify | remove: "-" }}{% endcapture %}
 
 {% assign is-search = false %}
@@ -473,9 +475,9 @@ Check if we're on the search pages.
     {% assign is-search = true %}
 {% endif %}
 
-{% assign is-series-search = false %}
-{% if pageurl-slug == series-search-url-slug %}
-    {% assign is-series-search = true %}
+{% assign is-project-search = false %}
+{% if pageurl-slug == project-search-url-slug %}
+    {% assign is-project-search = true %}
 {% endif %}
 
 {% assign is-book-search = false %}
@@ -484,11 +486,11 @@ Check if we're on the search pages.
 {% endif %}
 
 {% comment %}
-On homepage and series-search we are not in a book-directory,
+On homepage and project-search we are not in a book-directory,
 so make the book-directory variable nil. If we don't,
 then on these pages any links that use {{ book-directory }} will be broken
 {% endcomment %}
-{% if is-homepage == true or is-series-search == true %}
+{% if is-homepage == true or is-project-search == true %}
     {% assign book-directory = nil %}
 {% endif %}
 

--- a/_includes/nav-button.html
+++ b/_includes/nav-button.html
@@ -1,1 +1,1 @@
-<a href="#nav">{{ series-nav-label }}</a>
+<a href="#nav">{{ project-nav-label }}</a>

--- a/_includes/nav-list
+++ b/_includes/nav-list
@@ -14,7 +14,7 @@ https://christianspecht.de/2014/06/18/building-a-pseudo-dynamic-tree-menu-with-j
 {% include metadata %}
 
 {% comment %}If this is neither a text directory (i.e. in a book) nor a docs page,
-such as the home page or series search page...{% endcomment %}
+such as the home page or project search page...{% endcomment %}
 {% if is-book-subdirectory != true and is-docs-page != true %}
 
   {% comment %}Get a list of all the pages we've output to check against{% endcomment %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,9 +3,9 @@
     <div id="nav" class="non-printing">
 
             {% comment %}If we're neither in a book or a docs page,
-            show the series name.{% endcomment %}
+            show the project name.{% endcomment %}
             {% if is-book-subdirectory != true and is-docs-page != true %}
-            <h2>{{ series-name }}</h2>
+            <h2>{{ project-name }}</h2>
 
             {% comment %}If docs are generating, and we're on a docs page
             show a docs heading and version number{% endcomment %}
@@ -28,8 +28,8 @@
                 {% comment %}If this is not the homepage,
                 include a link to the homepage.{% endcomment %}
                 {% if is-homepage != true %}
-                    <ol class="nav-series-home">
-                        <li><a href="{{ path-to-root-directory }}index.html">{{ series-home-label }}</a></li>
+                    <ol class="nav-project-home">
+                        <li><a href="{{ path-to-root-directory }}index.html">{{ project-home-label }}</a></li>
                     </ol>
                 {% endif %}
 
@@ -44,7 +44,7 @@
                 {% endif %}
 
                 {% comment %}If this is any non-book, non-docs page,
-                such as the home page or series search...{% endcomment %}
+                such as the home page or project search...{% endcomment %}
                 {% if is-book-subdirectory != true and is-docs-page != true %}
 
                     {% comment %}If there is only one book, don't include its title{% endcomment %}
@@ -98,7 +98,7 @@
 
             {% comment %}If we're neither in a book or a docs page{% endcomment %}
             {% if is-book-subdirectory != true and is-docs-page != true %}
-            <h2>{{ series-name }}</h2>
+            <h2>{{ project-name }}</h2>
 
             {% comment %}If docs are generating, and we're on a docs page{% endcomment %}
             {% elsif output-docs == "true" and is-docs-page == true %}

--- a/_includes/page-info
+++ b/_includes/page-info
@@ -10,23 +10,23 @@ See all the metadata gathered for a given page.
 
 |      Description      |         Source        |       Output tag      |       Current result      |  Type  |
 |-----------------------|-----------------------|-----------------------|---------------------------|--------|
-| Series organisation   | Defined in `meta.yml` | `series-organisation` | {{ series-organisation }} | String |
-| Series URL            | Defined in `meta.yml` | `series-url`          | {{ series-url }}          | String |
-| Series email          | Defined in `meta.yml` | `series-email`        | {{ series-email }}        | String |
-| Series name           | Defined in `meta.yml` | `series-name`         | {{ series-name }}         | String |
-| Series description    | Defined in `meta.yml` | `series-description`  | {{ series-description }}  | String |
-| Series image          | Defined in `meta.yml` | `series-image`        | {{ series-image }}        | String |
-| Series app bundle ID  | Defined in `meta.yml` | `series-app-id`       | {{ series-app-id }}       | String |
-| Series version number | Defined in `meta.yml` | `series-version`      | {{ series-version }}      | String |
+| Project organisation   | Defined in `meta.yml` | `project-organisation` | {{ project-organisation }} | String |
+| Project URL            | Defined in `meta.yml` | `project-url`          | {{ project-url }}          | String |
+| Project email          | Defined in `meta.yml` | `project-email`        | {{ project-email }}        | String |
+| Project name           | Defined in `meta.yml` | `project-name`         | {{ project-name }}         | String |
+| Project description    | Defined in `meta.yml` | `project-description`  | {{ project-description }}  | String |
+| Project image          | Defined in `meta.yml` | `project-image`        | {{ project-image }}        | String |
+| Project app bundle ID  | Defined in `meta.yml` | `project-app-id`       | {{ project-app-id }}       | String |
+| Project version number | Defined in `meta.yml` | `project-version`      | {{ project-version }}      | String |
 
 |     Description      |         Source        |       Output tag      |       Current result      |  Type  |
 |----------------------|-----------------------|-----------------------|---------------------------|--------|
-| Series home label    | Defined in `meta.yml` | `series-home-label` | {{ series-home-label }} | String |
-| Series nav label     | Defined in `meta.yml` | `series-home-label` | {{ series-home-label }} | String |
+| Project home label    | Defined in `meta.yml` | `project-home-label` | {{ project-home-label }} | String |
+| Project nav label     | Defined in `meta.yml` | `project-home-label` | {{ project-home-label }} | String |
 
 |     Description      |         Source        |       Output tag      |       Current result      |  Type  |
 |----------------------|-----------------------|-----------------------|---------------------------|--------|
-| Series footer | Defined in `meta.yml` | `series-footer` | {{ series-footer }} | String |
+| Project footer | Defined in `meta.yml` | `project-footer` | {{ project-footer }} | String |
 
 |                  Description                  |                                                 Source                                                |      Output tag     |      Current result     |  Type  |
 |-----------------------------------------------|-------------------------------------------------------------------------------------------------------|---------------------|-------------------------|--------|
@@ -152,12 +152,12 @@ See all the metadata gathered for a given page.
 | Slug of the page URL                                                     | Constructed from built-in Jekyll variables, useful as a page ID | `pageurl-slug`           | {{ pageurl-slug }}           | String  |
 | Slug of the base URL only                                                | A built-in Jekyll variable, slugified                           | `baseurl-slug`           | {{ baseurl-slug }}           | String  |
 | Is this the homepage?                                                    | If `pageurl-slug` matches `baseurl-slug`, this is the home page | `is-homepage`            | {{ is-homepage }}            | Boolean |
-| URL of a project-root search page                                        | URL of any potential `search.html` in project root              | `series-search-url`      | {{ series-search-url }}      | String  |
-| URL of a book-directory search page (deprecated, only use series-search) | URL of any potential `search.html` in `book/text`               | `book-search-url`        | {{ book-search-url }}        | String  |
-| Slug of project-root search URL                                          | Slug of above value                                             | `series-search-url-slug` | {{ series-search-url-slug }} | String  |
+| URL of a project-root search page                                        | URL of any potential `search.html` in project root              | `project-search-url`      | {{ project-search-url }}      | String  |
+| URL of a book-directory search page (deprecated, only use project-search) | URL of any potential `search.html` in `book/text`               | `book-search-url`        | {{ book-search-url }}        | String  |
+| Slug of project-root search URL                                          | Slug of above value                                             | `project-search-url-slug` | {{ project-search-url-slug }} | String  |
 | Slug of book/text search URL                                             | Slug of above value                                             | `book-search-url-slug`   | {{ book-search-url-slug }}   | String  |
 | Is this a search page?                                                   | Detects `/search.html` in page path                             | `is-search`              | {{ is-search }}              | Boolean |
-| Is this a project-root search page?                                      | Compares slugs of project search URL and current page URL       | `is-series-search`       | {{ is-series-search }}       | Boolean |
+| Is this a project-root search page?                                      | Compares slugs of project search URL and current page URL       | `is-project-search`       | {{ is-project-search }}       | Boolean |
 | Is this a book/text search page?                                         | Compares slugs of book/text search URL and current page URL     | `is-book-search`         | {{ is-book-search }}         | Boolean |
 
 |         Description         |                   Source                  |      Output tag     |      Current result     |   Type  |

--- a/_includes/search
+++ b/_includes/search
@@ -1,7 +1,7 @@
 {% comment %}
 The search form.
 Include this file in HTML with {% include search %}.
-Searches all books in the series.
+Searches all books in the project.
 {% endcomment %}
 
 {% include metadata %}

--- a/_sass/partials/_web-masthead.scss
+++ b/_sass/partials/_web-masthead.scss
@@ -25,9 +25,9 @@ $web-masthead: true !default;
             li {
                 display: inline-block;
                 margin: 0 0.25em 0 0;
-                // The divider between series and book title
+                // The divider between project and book title
                 // Should not show if there is only one work,
-                // and therefore no series title in masthead.
+                // and therefore no project title in masthead.
                 &:after {
                     content: "\2044"; // 2044 is a fraction slash
                     color: $masthead-text-color;
@@ -44,7 +44,7 @@ $web-masthead: true !default;
                     &:nth-of-type(2):before {
                         content: normal;
                     }
-                    &.masthead-series-name {
+                    &.masthead-project-name {
                         display: none;
                     }
                 }
@@ -52,16 +52,16 @@ $web-masthead: true !default;
         }
 
         // Possible future styles for these classes.
-        .masthead-series-name {}
+        .masthead-project-name {}
         .masthead-book-title {}
 
     } // .masthead
 
     // ...unless it's the home page, and we're on a small screen,
-    // in which case do show the series name.
+    // in which case do show the project name.
     @media only screen
     and (max-width: $max-width-default) {
-        body.home .masthead li.masthead-series-name {
+        body.home .masthead li.masthead-project-name {
             display: inline-block !important;
         }
     }

--- a/index.md
+++ b/index.md
@@ -18,13 +18,13 @@ With the Electric Book workflow, you store your books in plain text with great v
 For support, mail [support@electricbook.works](mailto:support@electricbook.works). The Electric Book is maintained by [Fire and Lion](http://fireandlion.com), who also provide paid priority support plans for publishers.
 {:#support}
 
-<!-- Remove these comment tags to activate a series home page for your book project
+<!-- Remove these comment tags to activate a project home page for your book project
 
 {% include metadata %}
 
-# {{ series-name }}
+# {{ project-name }}
 
-{{ series-description }}
+{{ project-description }}
 
 {% for book in site.data.meta.works %}
 *[{{ book.title }}]({{ book.directory }}/text/{{ book.products.web.start-page }}.html)*

--- a/samples/text/03-01.md
+++ b/samples/text/03-01.md
@@ -15,15 +15,15 @@ int random()
 }
 ~~~
 
-What about two consecutive clode blocks? Here's some YAML book metadata from this series, followed by some [funny code from StackOverflow](http://stackoverflow.com/a/766363/1781075).
+What about two consecutive clode blocks? Here's some YAML book metadata from this project, followed by some [funny code from StackOverflow](http://stackoverflow.com/a/766363/1781075).
 
 ~~~ yaml
-series:
-  # The name of the organisation or entity that owns this series
+project:
+  # The name of the organisation or entity that owns this project
   organisation: "Electric Book Works"
   # A live web address for the organisation
   url: "https://electricbookworks.com/"
-  # The name of the series of books in this folder.
+  # The name of the project of books in this folder.
   name: "The Electric Book workflow"
 ~~~
 


### PR DESCRIPTION
In developing the Electric Book Manager, we decided to refer to an Electric Book repo or folder as a 'project' not a 'series'. While I had 'series' in mind when I first created the Electric Book for the Bettercare series, it has since become clear that a single Electric Book repo might store any number of unrelated books, where it's simply convenient to have them share a repo, and things like partials and build tools.

So this change drops the term `series` throughout the template in favour of `project`.