### PR TITLE
Fix page-header functionality

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,7 +18,7 @@
     {% include head-elements %}
 
 </head>
-<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}">
+<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}"{% if page.header %} data-header="{{ page.header }}"{% else %} data-header="{{ page.title }}"{% endif %}>
 <div id="wrapper">
 
 
@@ -40,7 +40,7 @@
     {% include head-elements %}
 
 </head>
-<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}">
+<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %} data-title="{{ page.title }}"{% if page.header %} data-header="{{ page.header }}{% endif %}">
 <div id="wrapper">
 
 

--- a/_sass/partials/_print-page-headers-footers-content.scss
+++ b/_sass/partials/_print-page-headers-footers-content.scss
@@ -4,12 +4,13 @@ $print-page-headers-footers-content: true !default;
   // This partial sets page header and footer content.
   // It sets separate content for .frontmatter and .chapter pages.
 
-  // Assign a string to the body title attribute.
-  // In markdown, this is set with header: in a file's YAML frontmatter.
+  // Assign a string to the body data-title attribute.
+  // In markdown, this is set with header: in a file's YAML frontmatter,
+  // and falls back to the page title.
 
   body {
     string-set:
-      page-header attr(title);
+      page-header attr(data-header);
   }
 
   // Assign strings to use in headers and footers for each level of heading (h1-h6),
@@ -18,7 +19,7 @@ $print-page-headers-footers-content: true !default;
   // h1 also sets the string for h2, in case there is no h2 on the page yet.
   //
   // Note string-set lets us define multiple values, which can be used as fallbacks.
-  // Unlike CSS overrides, the first string is not overriden by later strings.
+  // Like font-family settings, later strings are fallbacks for earlier strings.
   h1 { 
     string-set: 
       h1-text content(),


### PR DESCRIPTION
A while back we removed the `title` attribute from the `body` element, forgetting why I'd added it in the first place: to use for running heads. Those broke verso running heads that used `string(page-header)`, which is our default.

This fixes that functionality, but in a clearer way, by using a `data-header` attribute on the `body` element.