### PR TITLE
Epub fixes

### DIFF
--- a/_includes/toc
+++ b/_includes/toc
@@ -126,7 +126,7 @@ at the top of the toc, put this in a nav element.{% endcomment %}
     {% if include-in-toc == true %}
 
         <li class="toc-entry-title{% if page.url contains item.file %} active{% endif %}{% if item.class != nil %} {{ item.class }}{% endif %}">
-            {% if item.file != nil %}<a href="{{ item.file }}.html{% if item.id != nil %}#{{ item.id }}{% endif %}"
+            {% if item.file != nil %}<a href="{{ item.file }}.html{% if item.id and item.id != "" %}#{{ item.id }}{% endif %}"
                {% if page.url contains item.file %}class="active"{% endif %}>{% endif %}
                 <span class="toc-entry-text">{{ item.label | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}</span>
             {% if item.file != nil %}</a>{% endif %}

--- a/_sass/partials/_epub-base-typography.scss
+++ b/_sass/partials/_epub-base-typography.scss
@@ -18,6 +18,7 @@ $epub-base-typography: true !default;
         line-height: $line-height-default;
         page-break-after: avoid;
         margin: $line-height-default 0 0 0;
+        text-align: left; // some epub readers justify headings unless we set this
     }
     h1 {
         font-family: $font-display-main;
@@ -54,15 +55,15 @@ $epub-base-typography: true !default;
 
     // Lists
 
-    ol {
-        list-style: decimal;
+    ol, ul {
         list-style-position: outside;
-        margin: 0 0 $line-height-default 1em;
+        margin: 0 0 $line-height-default $line-height-default;
+    }
+    ol {
+        list-style-type: decimal;
     }
     ul {
         list-style-type: disc;
-        list-style-position: outside;
-        margin: 0 0 $line-height-default 1em;
     }
     ul ul, ol ol, blockquote ul ul, blockquote ol ol {
         margin-bottom: 0;

--- a/_sass/partials/_epub-index.scss
+++ b/_sass/partials/_epub-index.scss
@@ -26,9 +26,14 @@ $epub-index: true !default;
                 text-decoration: none;
             }
         }
-        .duplicate {
-            display: none;
-        }
+    }
+    // We don't nest .duplicate under this ol/ul, because if we do
+    // then Kindlegen says we're hiding too much and errors out,
+    // even if we're not actually using the class. It seems Kindlegen
+    // freaks out just because we might use the class on 10000+
+    // characters, which is its display: none limit.
+    .duplicate {
+        display: none;
     }
 
 }

--- a/_sass/partials/_epub-previous-publications-page.scss
+++ b/_sass/partials/_epub-previous-publications-page.scss
@@ -5,15 +5,16 @@ $epub-previous-publications-page: true !default;
 
     .previous-publications-page {
         margin: $start-depth auto 0 auto;
-        text-align: center;
+        * {
+            text-align: center; // because many epub readers try to justify text by default
+        }
         p {
             text-indent: 0;
             margin-bottom: $line-height-default / 2;
-            text-align: center;
             hyphens: none;
         }
-        h1, h2 {
-            font-size: $font-size-default * 1.25;
+        h2, h3, h4, h5, h6 {
+            font-size: $font-size-default;
         }
     }
 

--- a/_sass/partials/_epub-tables.scss
+++ b/_sass/partials/_epub-tables.scss
@@ -16,11 +16,12 @@ $epub-tables: true !default;
 	th, td {
 		border: 1px solid $color-light;
 		padding: $line-height-default / 2;
-		& p,
-		& ol,
-		& ul {
+		p, ol, ul {
 			margin: 0;
 			padding: 0;
+		}
+		ol, ul {
+			list-style-position: inside;
 		}
 	}
 	.table-row-stub {

--- a/_sass/partials/_web-base-typography.scss
+++ b/_sass/partials/_web-base-typography.scss
@@ -56,15 +56,15 @@ $web-base-typography: true !default;
 
     // Lists
 
-    ol {
-        list-style: decimal;
+    ol, ul {
         list-style-position: outside;
-        margin: 0 0 $line-height-default 1em;
+        margin: 0 0 $line-height-default $line-height-default;
+    }
+    ol {
+        list-style-type: decimal;
     }
     ul {
         list-style-type: disc;
-        list-style-position: outside;
-        margin: 0 0 $line-height-default 1em;
     }
     ul ul, ol ol, blockquote ul ul, blockquote ol ol {
         margin-bottom: 0;

--- a/_sass/partials/_web-previous-publications-page.scss
+++ b/_sass/partials/_web-previous-publications-page.scss
@@ -13,8 +13,8 @@ $web-previous-publications-page: true !default;
                 text-align: center;
                 hyphens: none;
             }
-            h1, h2 {
-                font-size: $font-size-default * 1.25;
+            h2, h3, h4, h5, h6 {
+                font-size: $font-size-default;
             }
         }
     }

--- a/_sass/partials/_web-tables.scss
+++ b/_sass/partials/_web-tables.scss
@@ -16,11 +16,12 @@ $web-tables: true !default;
 	th, td {
 		border: 1px solid $color-light;
 		padding: $line-height-default / 2;
-		& p,
-		& ol,
-		& ul {
+		p, ol, ul {
 			margin: 0;
 			padding: 0;
+		}
+		ol, ul {
+			list-style-position: inside;
 		}
 	}
 	.table-row-stub {

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -416,7 +416,8 @@ set /p process=Enter a number and hit return.
 
         :: ...and run Jekyll to build new HTML
         :epubJekyllBuild
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,%config%"
+            if "%epubIncludeMathJax%"=="y" call bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.mathjax-enabled.yml,%config%"
+            if not "%epubIncludeMathJax%"=="y" call bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,%config%"
             echo HTML generated.
             :epubJekyllDone
 
@@ -570,7 +571,9 @@ set /p process=Enter a number and hit return.
         :epubGetMathjax
             echo Copying MathJax to epub...
             :: Copy mathjax folder from /assets/js to _site/epub
-            xcopy /q /e "../assets/js/mathjax" "" > nul
+            :: Suppress the console output with /NFL /NDL /NJH /NJS /NC /NS
+            :: Adding /NP will also suppress progress bar.
+            robocopy "%location%_site/assets/js/mathjax" "%location%_site/epub/mathjax" /E /NFL /NDL /NJH /NJS /NC /NS
             :: If this is a translation, move mathjax into the language folder
             if "%epubIncludeMathJax%"=="y" if not "%subdirectory%"=="" move "mathjax" "%subdirectory%\mathjax"
             if "%epubIncludeMathJax%"=="y" if not "%subdirectory%"=="" echo MathJax moved to translation folder.

--- a/samples/text/01-05.md
+++ b/samples/text/01-05.md
@@ -19,3 +19,78 @@ Table 5. Subjective rankings of the Wilcoxon tests while food-serving with pince
 | 6 | 4 (4.9) | 4 (4.6) | 4 (4.8)
 
 That is data from [an actual scientific study](https://www.researchgate.net/publication/13582831_Effects_of_shape_and_operation_of_chopsticks_on_food-serving_performance) into the effectiveness of different kinds of chopsticks and ways to hold them.
+
+Here's a bigger table containing some lists. This table shows the skeletal muscles in your forehead and eyelid.
+
+<table>
+    <tr>
+        <th>Muscle</th>
+        <th>Origin</th>
+        <th>Insertion</th>
+        <th>Nerve</th>
+        <th>Action</th>
+    </tr>
+    <tr>
+        <td>occipitofrontalis</td>
+        <td>
+            <ul>
+                <li>2 occipital bellies</li>
+                <li>2 frontal bellies</li>
+            </ul>
+        </td>
+        <td>galea aponeurotica</td>
+        <td>facial nerve</td>
+        <td>raises the eyebrows</td>
+    </tr>
+    <tr>
+        <td>occipitalis</td>
+        <td>
+            <ul>
+                <li>superior nuchal line of the occipital bone</li>
+                <li>mastoid part of the temporal bone</li>
+            </ul>
+        </td>
+        <td>galea aponeurotica</td>
+        <td>posterior auricular nerve (facial nerve)</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>frontalis</td>
+        <td>galea aponeurotica</td>
+        <td>skin of frontal region</td>
+        <td>facial nerve</td>
+        <td>wrinkles eyebrow</td>
+    </tr>
+    <tr>
+        <td>orbicularis oculi</td>
+        <td>
+            <ol>
+                <li>frontal bone</li>
+                <li>medial palpebral ligament</li>
+                <li>lacrimal bone</li>
+            </ol>
+        </td>
+        <td>lateral palpebral raphe</td>
+        <td>zygomatic branch of facial</td>
+        <td>closes eyelids</td>
+    </tr>
+    <tr>
+        <td>corrugator supercilii</td>
+        <td>superciliary arches</td>
+        <td>
+            <ul>
+                <li>forehead skin</li>
+                <li>near eyebrow</li>
+            </ul>
+        </td>
+        <td>facial nerve</td>
+        <td>wrinkles forehead</td>
+    </tr>
+    <tr>
+        <td>depressor supercilii</td>
+        <td>medial orbital rim</td>
+        <td>medial aspect of bony orbit</td>
+        <td>facial nerve</td>
+        <td>Depresses the eyebrow</td>
+    </tr>
+</table>


### PR DESCRIPTION
This adds a bunch of fixes and improvements for epub output and styling:

- No empty fragments IDs in TOCs
- More specific heading alignment (silly epub readers love justifying even headings by default)
- Dodge Kindlegen's paranoia about `display: none` on 10000+ chars
- Fix a regression where MathJax JS was not being copied in Win output (broken when I added app output recently)
- Add a sample of a list in a table, and fix marker position of lists in tables