### PR TITLE
Add image-with-caption class

### DIFF
--- a/_docs/classes.md
+++ b/_docs/classes.md
@@ -34,6 +34,7 @@ Use these classes in your markdown to create specific formatting effects.
 | Frontmatter references | `.frontmatter-reference` | Inline | Tag links in the Table of Contents whose page numbers must match yout frontmatter reference style set in CSS. | No
 | Glossary | `.glossary` | Block | Use this after the last entry in a series of definition lists to define the entire list of definitions as a glossary. | No
 | Hide from print | `.non-printing` | Block or inline | Hides the element from print output. Useful for things like clickable buttons, which are only intended for screens, not paper. | No
+| Image with caption | `.image-with-caption` | Block | Used for paragraphs that start with an inline image, and turns the text in the paragraph into a caption. Makes simple images with captions quick and easy. | No
 | Keep together | `.keep-together` | Block | Prevents an element from breaking across pages. (E.g. you want to keep a short list on the same page.) | No
 | Keep with next | `.keep-with-next` | Block | Prevents a page break between this element and the next one. | No
 | Letter | `.letter` | Block | Formats a blockquote as a letter, by spacing the paragraphs in it. | No

--- a/_sass/partials/_epub-figures.scss
+++ b/_sass/partials/_epub-figures.scss
@@ -86,4 +86,18 @@ $epub-figures: true !default;
 			}
 		}
 	}
+
+	// Paragraphs that start with an image
+	.image-with-caption {
+	    font-size: $font-size-default * $font-size-smaller;
+	    margin: $line-height-default 0;
+	    text-align: center;
+	    img {
+	        display: block;
+	        margin: $line-height-default auto;
+	        height: 80%; // allows space for caption
+	        max-height: 80vh;
+	    }
+	}
+
 }

--- a/_sass/partials/_print-figures.scss
+++ b/_sass/partials/_print-figures.scss
@@ -123,4 +123,16 @@ $print-figures: true !default;
 		text-indent: 0;
 	}
 
+	// Paragraphs that start with an image
+	.image-with-caption {
+	    font-size: $font-size-default * $font-size-smaller;
+	    margin: $line-height-default 0;
+	    text-align: center;
+	    page-break-inside: avoid;
+	    img {
+	        display: block;
+	        margin: $line-height-default auto;
+	    }
+	}
+
 }

--- a/_sass/partials/_web-figures.scss
+++ b/_sass/partials/_web-figures.scss
@@ -101,4 +101,18 @@ $web-figures: true !default;
 			}
 		}
 	}
+
+	// Paragraphs that start with an image
+	.image-with-caption {
+	    font-size: $font-size-default * $font-size-smaller;
+	    margin: $line-height-default 0;
+	    text-align: center;
+	    img {
+	        display: block;
+	        margin: $line-height-default auto;
+	        height: 80%; // allows space for caption
+	        max-height: 80vh;
+	    }
+	}
+
 }


### PR DESCRIPTION
In simple books, a `figure` include can be overkill when all you need is an image and a caption. So in other projects we've often used this simple technique, which is to do:

```
![](image.jpg)
This is the caption.
{:.image-with-caption}
```

Then we set `display: block` on the image, and format `.image-with-caption` as caption text.

This has become so useful that I'm baking it into the template here. I've already [added a sample to *Samples*](https://github.com/electricbookworks/electric-book/pull/197/commits/6eb220d0be514578baa8188387f016f1b183243e#diff-588f780137756893108f863e2d023b21).