### PR TITLE
Add variable for default rule thickness

### DIFF
--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -49,6 +49,9 @@ $spaced-paras: true !default;
 // Buttons
 $button-border-radius: 0.1em !default; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 1px !default;
+
 // Colours
 $color-text-main: #222222 !default;
 $color-text-secondary: #222222 !default;

--- a/_sass/epub.scss
+++ b/_sass/epub.scss
@@ -46,6 +46,9 @@ $spaced-paras: false !default;
 // Buttons
 $button-border-radius: 0.1em !default; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 1px !default;
+
 // Colours
 $color-text-main: initial !default;
 $color-text-secondary: initial !default;

--- a/_sass/partials/_epub-base-typography.scss
+++ b/_sass/partials/_epub-base-typography.scss
@@ -104,7 +104,7 @@ $epub-base-typography: true !default;
         // `content:`, `border: 0` or `border: none`. We don't use background-image 
         // because of problems linking to the image after export from here.
         // Kindle output ignores rgba. So this is the least-bad solution.
-        border: 1px solid rgba(255,255,255,0);
+        border: $rule-thickness solid rgba(255,255,255,0);
         margin: $line-height-default 0; // Adds space, esp. important for Kindle
         text-align: center; // Necessary for aligning :after content
         // Note: Amazon Kindle will ignore this :after content setting
@@ -153,7 +153,7 @@ $epub-base-typography: true !default;
         font-family: $font-text-secondary;
         font-size: inherit;
         color: inherit;
-        border: 1px solid $color-mid;
+        border: $rule-thickness solid $color-mid;
         display: block;
         margin: $line-height-default 0;
         width: 100%;

--- a/_sass/partials/_epub-boxes.scss
+++ b/_sass/partials/_epub-boxes.scss
@@ -8,7 +8,7 @@ $epub-boxes: true !default;
 		color: inherit;
 		font-weight: inherit;
 		font-size: inherit;
-		border: 1px solid $color-light;
+		border: $rule-thickness solid $color-light;
 		margin: $line-height-default 0;
 		padding: ($line-height-default / 2);
 		& p:last-of-type {

--- a/_sass/partials/_epub-cover.scss
+++ b/_sass/partials/_epub-cover.scss
@@ -17,7 +17,7 @@ $epub-cover: true !default;
 	img.cover {
 		max-height: 100%;
 		max-width: 100%;
-		border: 1px solid $color-light;
+		border: $rule-thickness solid $color-light;
 	}
 
 }

--- a/_sass/partials/_epub-notes.scss
+++ b/_sass/partials/_epub-notes.scss
@@ -7,7 +7,7 @@ $epub-notes: true !default;
 	// Footnotes section
 	.footnotes {
 	  margin: ($line-height-default * 2) 0 0 0;
-	  border-top: 1px solid $color-light;
+	  border-top: $rule-thickness solid $color-light;
 	}
 	.footnotes p {
 		text-indent: 0;
@@ -20,7 +20,7 @@ $epub-notes: true !default;
 		float: right;
 		min-width: 5em;
 		padding: $line-height-default / 2;
-		border-top: 1px solid $color-light;
+		border-top: $rule-thickness solid $color-light;
 		text-indent: 0;
 		font-size: $font-size-default * $font-size-smaller;
 		line-height: $line-height-default * $font-size-smaller;

--- a/_sass/partials/_epub-tables.scss
+++ b/_sass/partials/_epub-tables.scss
@@ -14,7 +14,7 @@ $epub-tables: true !default;
 		font-weight: bold;
 	}
 	th, td {
-		border: 1px solid $color-light;
+		border: $rule-thickness solid $color-light;
 		padding: $line-height-default / 2;
 		& p,
 		& ol,

--- a/_sass/partials/_print-boxes.scss
+++ b/_sass/partials/_print-boxes.scss
@@ -9,7 +9,7 @@ $print-boxes: true !default;
 		color: inherit;
 		font-weight: inherit;
 		font-size: inherit;
-		border: 0.5pt solid $color-accent;
+		border: $rule-thickness solid $color-accent;
 		margin: $line-height-default 0;
 		padding: $line-height-default $line-height-default 0 $line-height-default;
 		// No text-indent on paragraphs after boxes

--- a/_sass/partials/_print-notes.scss
+++ b/_sass/partials/_print-notes.scss
@@ -39,7 +39,7 @@ $print-notes: true !default;
 		min-width: 5em;
 		margin: ($line-height-default * 0.75) 0 ($line-height-default * 0.5) ($line-height-default);
 		padding: ($line-height-default * 0.25) 0 0 0;
-		border-top: 0.5pt solid $color-light;
+		border-top: $rule-thickness solid $color-light;
 		box-sizing: border-box;
 		// Don't text-indent paragraphs that follow sidenotes that follow a heading.
 		// We allow for up to three sidenotes between the heading and paragraph.

--- a/_sass/partials/_print-tables.scss
+++ b/_sass/partials/_print-tables.scss
@@ -8,24 +8,24 @@ $print-tables: true !default;
 		margin: $line-height-default 0;
 		font-size: $font-size-default * $font-size-smaller;
 		width: 100%;
+		max-width: $page-width - $margin-inside - $margin-outside;
 	}
 	thead, th, .table-subhead {
 		font-weight: bold;
 		page-break-after: avoid;
 	}
 	th, td {
-		border-top: 0.5pt solid $color-light;
-		border-bottom: 0.5pt solid $color-light;
+		border-top: $rule-thickness solid $color-light;
+		border-bottom: $rule-thickness solid $color-light;
 		border-left: 0;
 		border-right: 0;
 		padding: ($line-height-default * 0.1) ($line-height-default * 0.2);
 		vertical-align: top;
 		page-break-inside: avoid;
-		& p,
-		& ol,
-		& ul {
+		p, ul, ol, dl {
 			margin: 0;
 			padding: 0;
+			text-align: left;
 		}
 	}
 	.table-row-stub {

--- a/_sass/partials/_web-base-typography.scss
+++ b/_sass/partials/_web-base-typography.scss
@@ -150,7 +150,7 @@ $web-base-typography: true !default;
         font-family: $font-text-secondary;
         font-size: inherit;
         color: inherit;
-        border: 1px solid $color-mid;
+        border: $rule-thickness solid $color-mid;
         display: block;
         margin: $line-height-default 0;
         width: 100%;

--- a/_sass/partials/_web-boxes.scss
+++ b/_sass/partials/_web-boxes.scss
@@ -8,7 +8,7 @@ $web-boxes: true !default;
 		color: inherit;
 		font-weight: inherit;
 		font-size: inherit;
-		border: 1px solid $color-light;
+		border: $rule-thickness solid $color-light;
 		margin: $line-height-default 0;
 		padding: ($line-height-default / 2);
 		& p:last-of-type {

--- a/_sass/partials/_web-cover.scss
+++ b/_sass/partials/_web-cover.scss
@@ -22,7 +22,7 @@ $web-cover: true !default;
 	img.cover {
 		max-height: 100%;
 		max-width: 100%;
-		border: 1px solid $color-light;
+		border: $rule-thickness solid $color-light;
 	}
 
 }

--- a/_sass/partials/_web-footer.scss
+++ b/_sass/partials/_web-footer.scss
@@ -9,7 +9,7 @@ $web-footer: true !default;
 		bottom: 0;
 		background-color: $footer-background-color;
 		font-family: $font-text-secondary;
-		border-top: 1px solid $footer-border-color;
+		border-top: $rule-thickness solid $footer-border-color;
 		margin: ($line-height-default * 2) 0 0 0;
 		padding: $line-height-default / 2;
 		width: 100%; // Prevents floating when preceding elements float or flex

--- a/_sass/partials/_web-masthead.scss
+++ b/_sass/partials/_web-masthead.scss
@@ -6,7 +6,7 @@ $web-masthead: true !default;
     .masthead {
         font-family: $font-text-secondary;
         background-color: $masthead-background-color;
-        border-bottom: 1px solid $masthead-border-color;
+        border-bottom: $rule-thickness solid $masthead-border-color;
         width: 100%;
         text-align: center;
         color: $masthead-text-color;

--- a/_sass/partials/_web-nav-bar.scss
+++ b/_sass/partials/_web-nav-bar.scss
@@ -57,7 +57,7 @@ $web-nav-bar: true !default;
         height: 100%;
         overflow-x: hidden; // Hides horizontal scrollbar
         background-color: $nav-bar-background-color;
-        border-top: 1px solid $nav-bar-border-color;
+        border-top: $rule-thickness solid $nav-bar-border-color;
         padding-right: 17px; // Hides scroll bar
 
         .js-nav-open & {
@@ -67,7 +67,7 @@ $web-nav-bar: true !default;
         .js-nav & {
             width: $nav-bar-width;
             border-top: none;
-            border-right: 1px solid $nav-bar-border-color;
+            border-right: $rule-thickness solid $nav-bar-border-color;
             position: absolute;
             top: 0;
             left: 0;

--- a/_sass/partials/_web-notes.scss
+++ b/_sass/partials/_web-notes.scss
@@ -9,7 +9,7 @@ $web-notes: true !default;
 	.footnotes {
 	  margin: ($line-height-default * 2) 0 0 0;
 	  padding: $line-height-default 0;
-	  border-top: 1px solid $color-light;
+	  border-top: $rule-thickness solid $color-light;
 	  color: $color-mid;
 	}
 	.footnotes p {
@@ -25,7 +25,7 @@ $web-notes: true !default;
 		min-width: 5em;
 		margin: 0 -12em ($line-height-default / 2) 2em;
 		padding: $line-height-default / 2;
-		border-top: 1px solid $color-light;
+		border-top: $rule-thickness solid $color-light;
 		text-indent: 0;
 		font-size: $font-size-default * $font-size-smaller;
 		line-height: $line-height-default * $font-size-smaller;

--- a/_sass/partials/_web-search.scss
+++ b/_sass/partials/_web-search.scss
@@ -28,7 +28,7 @@ $web-search: true !default;
             margin: $line-height-default 0;
             input {
                 // padding: 0.75em 0.75em;
-                // border: 1px solid $color-light;
+                // border: $rule-thickness solid $color-light;
                 // font-family: $font-text-secondary;
                 // font-size: inherit;
                 // color: inherit;

--- a/_sass/partials/_web-tables.scss
+++ b/_sass/partials/_web-tables.scss
@@ -14,7 +14,7 @@ $web-tables: true !default;
 		font-weight: bold;
 	}
 	th, td {
-		border: 1px solid $color-light;
+		border: $rule-thickness solid $color-light;
 		padding: $line-height-default / 2;
 		& p,
 		& ol,

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -85,6 +85,9 @@ $spaced-paras: false !default;
 // Buttons
 $button-border-radius: 0.1em !default; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 0.5pt !default;
+
 // Hyphenation
 // Variables here apply to p, ul, ol, dl
 $hyphenation: auto !default; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -85,6 +85,9 @@ $spaced-paras: false !default;
 // Buttons
 $button-border-radius: 0.1em !default; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 0.5pt !default;
+
 // Hyphenation
 // Variables here apply to p, ul, ol, dl
 $hyphenation: auto !default; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -49,6 +49,9 @@ $spaced-paras: true !default;
 // Buttons
 $button-border-radius: 0.1em !default; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 1px !default;
+
 // Colours
 $color-text-main: #222222 !default;
 $color-text-secondary: #222222 !default;

--- a/book/styles/app.scss
+++ b/book/styles/app.scss
@@ -53,6 +53,9 @@ $spaced-paras: true;
 // Buttons
 $button-border-radius: 0.1em; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 1px;
+
 // Colours
 $color-text-main: #222222;
 $color-text-secondary: #222222;

--- a/book/styles/epub.scss
+++ b/book/styles/epub.scss
@@ -50,6 +50,9 @@ $spaced-paras: false;
 // Buttons
 $button-border-radius: 0.1em; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 1px;
+
 // Colours
 $color-text-main: initial;
 $color-text-secondary: initial;

--- a/book/styles/print-pdf.scss
+++ b/book/styles/print-pdf.scss
@@ -89,6 +89,9 @@ $spaced-paras: false;
 // Buttons
 $button-border-radius: 0.1em; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 0.5pt;
+
 // Hyphenation
 // Variables here apply to p, ul, ol, dl
 $hyphenation: auto; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)

--- a/book/styles/screen-pdf.scss
+++ b/book/styles/screen-pdf.scss
@@ -89,6 +89,9 @@ $spaced-paras: false;
 // Buttons
 $button-border-radius: 0.1em; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 0.5pt;
+
 // Hyphenation
 // Variables here apply to p, ul, ol, dl
 $hyphenation: auto; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)

--- a/book/styles/web.scss
+++ b/book/styles/web.scss
@@ -53,6 +53,9 @@ $spaced-paras: true;
 // Buttons
 $button-border-radius: 0.1em; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 1px;
+
 // Colours
 $color-text-main: #222222;
 $color-text-secondary: #222222;

--- a/samples/styles/app.scss
+++ b/samples/styles/app.scss
@@ -53,6 +53,9 @@ $spaced-paras: true;
 // Buttons
 $button-border-radius: 0.1em; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 1px;
+
 // Colours
 $color-text-main: #222222;
 $color-text-secondary: #222222;

--- a/samples/styles/epub.scss
+++ b/samples/styles/epub.scss
@@ -50,6 +50,9 @@ $spaced-paras: false;
 // Buttons
 $button-border-radius: 0.1em; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 1px;
+
 // Colours
 $color-text-main: initial;
 $color-text-secondary: initial;

--- a/samples/styles/print-pdf.scss
+++ b/samples/styles/print-pdf.scss
@@ -89,6 +89,9 @@ $spaced-paras: false;
 // Buttons
 $button-border-radius: 0.1em; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 0.5pt;
+
 // Hyphenation
 // Variables here apply to p, ul, ol, dl
 $hyphenation: auto; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)

--- a/samples/styles/screen-pdf.scss
+++ b/samples/styles/screen-pdf.scss
@@ -89,6 +89,9 @@ $spaced-paras: false;
 // Buttons
 $button-border-radius: 0.1em; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 0.5pt;
+
 // Hyphenation
 // Variables here apply to p, ul, ol, dl
 $hyphenation: auto; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)

--- a/samples/styles/web.scss
+++ b/samples/styles/web.scss
@@ -53,6 +53,9 @@ $spaced-paras: true;
 // Buttons
 $button-border-radius: 0.1em; // Roundness of button corners.
 
+// Rules, lines
+$rule-thickness: 1px;
+
 // Colours
 $color-text-main: #222222;
 $color-text-secondary: #222222;


### PR DESCRIPTION
We've been hard-coding the thickness of rules (e.g. around boxes) into our partials. This can result is inconsistent styling. So this change makes `$rule-thickness` a Sass variable.