### PR TITLE
Remove data- attributes and leave defaults in place

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,10 +47,20 @@ var filetypes = 'jpg,jpeg,gif,png';
 
 
 // Minify and clean SVGs and copy to destinations
+// For EpubCheck-safe SVGs, we remove data- attributes
+// and don't strip defaults like <style "type=text/css">
 gulp.task('images:svg', function () {
     console.log('Processing SVG images from ' + paths.img.source);
     gulp.src(paths.img.source + '*.svg')
-    .pipe(svgmin())
+    .pipe(svgmin({
+       plugins: [{
+            removeAttrs: { attrs: 'data.*' }
+        }, {
+            removeUnknownsAndDefaults: {
+                defaultAttrs: false
+            }
+        }],
+    }))
     .pipe(gulp.dest(paths.img.printpdf))
     .pipe(gulp.dest(paths.img.screenpdf))
     .pipe(gulp.dest(paths.img.web))


### PR DESCRIPTION
Refining our SVG optimisation in `gulpfile.js` is an ongoing process as we see more SVGs in books we work on. This change:

1. Removes `data-` attributes, which by their nature are custom and EpubCheck errors on them.
2. Retains default attributes, which SVGO strips by default. In particular, for EPubCheck we need to retain `type="text/css"` in `<style>` tags for EpubCheck validation.
