### PR TITLE
Don't add HTML entities to doctype in epub by default

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -45,9 +45,7 @@
 
 
 {% elsif site.output == 'epub' %}
-<!DOCTYPE html [
-    {% include html-entities.html %}
-]>
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="{{ language }}">
 <head>
     <title>

--- a/_includes/html-entities.html
+++ b/_includes/html-entities.html
@@ -1,7 +1,16 @@
 {% comment %}This file inserts a range of HTML entities into a DOCTYPE declaration,
-necessary to make HTML that contains HTMl entities valid in EPUB3.
+sometimes necessary to make HTML that contains HTMl entities valid in EPUB3.
 The list is taken from https://www.w3.org/TR/html4/sgml/entities.html
-Does it bulk up our epub files? Yes :( Does it make our lives easier? Yes :){% endcomment %}
+It is usually not necessary to use this: kramdown should by default convert all
+entities into unicode characters (if you're using Ruby 1.9 or later).
+So only use this include if you're getting undeclared-entity errors in EpubCheck.
+To use it, edit _includes/head.html to change the epub-output's
+<!DOCTYPE html>
+to
+<!DOCTYPE html [
+    {% include html-entities.html %}
+]>
+{% endcomment %}
 <!ENTITY nbsp   "&#160;">
 <!ENTITY iexcl  "&#161;">
 <!ENTITY cent   "&#162;">


### PR DESCRIPTION
Kramdown seems to be reliably conveting entities to unicode, which obviates the need to add these entity declarations. So I'm no longer including them by default in epub output.

In epub readers that ignore doctypes (like Calibre), the entity declaration syntax causes problems (specifically, a stray `]>` at the top of the `body`.