### PR TITLE
Remove http-equiv meta from epub head

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -55,7 +55,7 @@
     {{ project-name }}{% if page.title %}: {{ page.title }}{% endif %}
     {% endif %}
     </title>
-    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta charset="utf-8"/>
     <link rel="stylesheet" type="text/css" href="{{ path-to-styles-directory }}/{{ epub-stylesheet }}" />
     
     {% comment %}Metadata defined in page frontmatter overrides


### PR DESCRIPTION
Version 3 of EpubCheck throws an error at this tag. Which is a problem at distributors (e.g. CoreSource) that can still validate using old EpubCheck versions.

As I can tell, we only really need the charset encoding, so I've replaced it with a simpler meta charset tag.