### PR TITLE
Pagination

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -31,7 +31,12 @@ variants:
 # Web settings
 # ----------------------------------------------------------
 # Turn pagination (next/previous) on or off
-web-pagination: true
+web:
+  pagination: true
+  # Choose 'direction' for 'Next/Previous' pagination,
+  # or 'titles' to show page titles at pagination,
+  # or 'arrows' to use only arrows.
+  pagination-type: "arrows"
 
 # ----------------------------------------------------------
 # Epub settings
@@ -46,7 +51,12 @@ web-pagination: true
 # App settings
 # ----------------------------------------------------------
 # Turn pagination (next/previous) on or off
-app-pagination: true
+app:
+  pagination: true
+  # Choose 'direction' for 'Next/Previous' pagination,
+  # or 'titles' to show page titles at pagination,
+  # or 'arrows' to use only arrows.
+  pagination-type: "arrows"
 # If your book is huge and you need to store images
 # in an expansion file, edit these settings.
 google-play-expansion-file-enabled: false

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -4,7 +4,6 @@
 # ----------------------------------------------------------
 electric-book-manager: enable
 electric-book-manager-key: ""
-# ----------------------------------------------------------
 
 # Variant settings
 # Set a variant of the work to output.
@@ -27,22 +26,27 @@ variants:
     epub-stylesheet: ""
     app-stylesheet: ""
   - variant: yourvariant
+
 # ----------------------------------------------------------
+# Web settings
+# ----------------------------------------------------------
+# Turn pagination (next/previous) on or off
+web-pagination: true
 
 # ----------------------------------------------------------
 # Epub settings
 # ----------------------------------------------------------
 # If you're embedding fonts, uncomment and list the font-file names here
 # and put the font files in _epub/fonts, not book/fonts
-
 # epub-fonts:
   # - Crimson-Roman.otf
   # - Crimson-Italic.otf
-# ----------------------------------------------------------
 
 # ----------------------------------------------------------
 # App settings
 # ----------------------------------------------------------
+# Turn pagination (next/previous) on or off
+app-pagination: true
 # If your book is huge and you need to store images
 # in an expansion file, edit these settings.
 google-play-expansion-file-enabled: false

--- a/_includes/file-list
+++ b/_includes/file-list
@@ -1,75 +1,19 @@
+{% capture file-list-output %}
+
+{% comment %} Include metadata and output the file list.
+ Capture that output, then print it to the page,
+ stripping out white space. {% endcomment %}
+
 {% include metadata %}
 
-{% if site.output == 'print-pdf' %}
+{{ file-list }}
 
-{% for file in print-pdf-file-list %}
-{% for file-title in file %}
-{% if file-title[0] %}
-{{ file-title[0] }}.html
-{% else %}
-{{ file-title }}.html
-{% endif %}
-{% endfor %}
-{% endfor %}
+{% endcapture %}
 
-{% endif %}
+{{ file-list-output | strip | replace: "
 
+", "
+" | replace: "
 
-{% if site.output == 'screen-pdf' %}
-
-{% for file in screen-pdf-file-list %}
-{% for file-title in file %}
-{% if file-title[0] %}
-{{ file-title[0] }}.html
-{% else %}
-{{ file-title }}.html
-{% endif %}
-{% endfor %}
-{% endfor %}
-
-{% endif %}
-
-
-{% if site.output == 'epub' %}
-
-{% for file in epub-file-list %}
-{% for file-title in file %}
-{% if file-title[0] %}
-{{ file-title[0] }}.html
-{% else %}
-{{ file-title }}.html
-{% endif %}
-{% endfor %}
-{% endfor %}
-
-{% endif %}
-
-
-{% if site.output == 'app' %}
-
-{% for file in app-file-list %}
-{% for file-title in file %}
-{% if file-title[0] %}
-{{ file-title[0] }}.html
-{% else %}
-{{ file-title }}.html
-{% endif %}
-{% endfor %}
-{% endfor %}
-
-{% endif %}
-
-
-{% if site.output == 'web' %}
-
-{% for file in web-file-list %}
-{% for file-title in file %}
-{% if file-title[0] %}
-{{ file-title[0] }}.html
-{% else %}
-{{ file-title }}.html
-{% endif %}
-{% endfor %}
-{% endfor %}
-
-{% endif %}
+", "
+" }}

--- a/_includes/metadata
+++ b/_includes/metadata
@@ -40,9 +40,17 @@ We'll rewrite this later if we're in a translation
 
 {% capture book-directory %}{{ page.path | replace: "/", " " | truncatewords: 1, "" }}{% endcapture %}
 
-{% comment %}Get the current directory name.
-First, remove any file extensions, then create at array of what's left{% endcomment %}
-{% assign url-as-array = page.url | split: "." %}
+{% comment %}Get the current directory name.{% endcomment %}
+
+{% comment %} If the page is an index.html page, we need to add 'index',
+because Jekyll's page.url for index.html is / {% endcomment %}
+{% if page.url contains ".html" %}
+    {% capture page-url %}{{ page.url }}{% endcapture %}
+{% else %}
+    {% capture page-url %}{{ page.url }}index.html{% endcapture %}
+{% endif %}
+{% comment %}Remove any file extensions, then create an array of what's left{% endcomment %}
+{% assign url-as-array = page-url | split: "." %}
 {% assign url-as-array = url-as-array | first | remove_first: "/" | split: "/" %}
 {% assign url-as-array-size = url-as-array | size %}
 
@@ -436,6 +444,22 @@ override any metadata set for that variant.{% endcomment %}
     {% endfor %}
 
 {% endif %}
+
+{% comment %} Generate a file-list for the current output. {% endcomment %}
+{% capture file-list-name %}{{ site.output }}-file-list{% endcapture %}
+
+{% comment %} Don't indent. We don't want indents in file lists. {% endcomment %}
+{% capture file-list %}
+{% for file in [file-list-name] %}
+{% for file-title in file %}
+{% if file-title[0] %}
+{{ file-title[0] }}.html
+{% else %}
+{{ file-title }}.html
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endcapture %}
 
 {% comment %}
 Check if we're on the project homepage:

--- a/_includes/pagination
+++ b/_includes/pagination
@@ -87,7 +87,7 @@ not pages like landing and search pages. {% endcomment %}
         {% unless include.direction == "next" %}    
             {% if previous-page and previous-page-url != "" and previous-page-url != this-page-url %}
                 <div class="pagination-previous">
-                    <a href="{{ previous-page-url }}">{% if previous-page-title and previous-page-title != "" and site.data.settings[output-format].pagination-type == "titles" %}{{ previous-page-title }}{% elsif site.data.settings[output-format].pagination-type == "direction" %}{{ locale.nav.previous }}{% else %}&#x2190;{% endif %}</a>
+                    <a href="{{ path-to-root-directory }}{{ previous-page-url }}">{% if previous-page-title and previous-page-title != "" and site.data.settings[output-format].pagination-type == "titles" %}{{ previous-page-title }}{% elsif site.data.settings[output-format].pagination-type == "direction" %}{{ locale.nav.previous }}{% else %}&#x2190;{% endif %}</a>
                 </div>
             {% endif %}
         {% endunless %}
@@ -95,7 +95,7 @@ not pages like landing and search pages. {% endcomment %}
         {% unless include.direction == "previous" %}
             {% if next-page and next-page-url != "" and next-page-url != this-page-url %}
                 <div class="pagination-next">
-                    <a href="{{ next-page-url }}">{% if next-page-title and next-page-title != "" and site.data.settings[output-format].pagination-type == "titles" %}{{ next-page-title }}{% elsif site.data.settings[output-format].pagination-type == "direction" %}{{ locale.nav.previous }}{% else %}&#x2192;{% endif %}</a>
+                    <a href="{{ path-to-root-directory }}{{ next-page-url }}">{% if next-page-title and next-page-title != "" and site.data.settings[output-format].pagination-type == "titles" %}{{ next-page-title }}{% elsif site.data.settings[output-format].pagination-type == "direction" %}{{ locale.nav.previous }}{% else %}&#x2192;{% endif %}</a>
                 </div>
             {% endif %}
         {% endunless %}

--- a/_includes/pagination
+++ b/_includes/pagination
@@ -1,155 +1,104 @@
-Pagination...
+{% comment %} Includes pagination to the next and previous pages,
+according to the order of the output-format's file-list,
+which is defined in meta.yml at 'files'. 
+To have the include only show one direction, in the include tag
+use direction="next" or direction="previous". {% endcomment %}
 
 {% include metadata %}
 
-{% comment %} Get the starting nav tree to paginate by... {% endcomment %}
-{% if site.output == "app" %}
-    {% assign tree-to-paginate = app-nav-tree %}
-{% else %}
-    {% assign tree-to-paginate = web-nav-tree %}
+{% comment %} Check if this file is in the file list.
+We will only paginate files in the file list. {% endcomment %}
+{% capture current-file-with-extension %}{{current-file}}.html{% endcapture %}
+{% if file-list contains current-file-with-extension %}
+    {% assign current-file-in-file-list = true %}
 {% endif %}
 
-{% comment %} ... but use a specific tree if specified by the include tag,
-e.g. if this include has called itself for a page's children. {% endcomment %}
-{% if include.tree-to-paginate %}
-    {% assign tree-to-paginate = include.tree-to-paginate %}
-{% endif %}
+{% comment %} Only paginate book chapters,
+not pages like landing and search pages. {% endcomment %}
+{% if is-book-subdirectory and current-file-in-file-list %}
 
-{% comment %} Capture the current filename here
-(don't use the current-file we get from metadata, because
-that changes when we pass this include to itself for children.
-Keep the page we're on in a page-to-paginate variable,
-to pass to this include for children. {% endcomment %}
-{% if include.page-to-paginate %}
-    {% capture page-to-paginate %}{{ include.page-to-paginate }}{% endcapture %}
-{% else %}
-    {% if page.url contains ".html" %}
-        {% capture page-to-paginate %}{{ page.url | split: "/" | last | replace: ".html", "" }}{% endcapture %}
-    {% else %}
-        {% comment %} File is an index.html file, which Jekyll
-        stores as a folder path only. {% endcomment %}
-        {% capture page-to-paginate %}index{% endcapture %}
-    {% endif %}
-{% endif %}
+    {% comment %} Create an array from the file-list we get from metadata,
+    and capture the current file's name.{% endcomment %}
+    {% assign pages-to-paginate = file-list | split: " " %}
+    {% capture page-to-look-for %}{{ current-file }}.html{% endcapture %}
 
-{% comment %} Loop through the nav. When you find the file we're on,
-assign a match, and assign index numbers to its position
-in the nav tree using Liquid's index and index0.
-If no match, and the page in nav has children,
-pass the children to this include. {% endcomment %}
-{% assign pagination-match = false %}
-{% for page in tree-to-paginate %}
-    {% if page.file == page-to-paginate %}
-        {% assign pagination-match = true %}
-        {% assign page-index0 = forloop.index0 %}
-        {% assign page-index1 = forloop.index %}
-        {% break %}
-    {% elsif pagination-match != true and page.children %}
-{% comment %} Don't indent the include tag: avoids
-including it as a markdown code block {% endcomment %}
-{% include pagination tree-to-paginate=page.children page-to-paginate=page-to-paginate %}
-    {% endif %}
-{% endfor %}
-
-{% comment %} If we have a match, loop through the nav again.
-This time, we're looking for pages with indexes
-before and after the index we stored above. {% endcomment %}
-{% if pagination-match == true %}
-    {% for page in tree-to-paginate %}
-        {% if page-index0 == forloop.index0 %}
-            {% assign this-page = page %}
-        {% endif %}
-        {% if page-index0 == forloop.index %}
-            {% assign prev-page = page %}
-        {% endif %}
-        {% if page-index1 == forloop.index0 %}
-            {% assign next-page = page %}
-        {% endif %}
-    {% endfor %}
-{% endif %}
-
-{% comment %} Now create a div for each pagination item,
-if there is a file to link to. {% endcomment %}
-
-{% if prev-page.file and prev-page.file != "" %}
-<div class="pagination-previous">
-    <a href="{{prev-page.file}}.html{% if prev-page.id and prev-page.id != "" %}#{{ prev-page.id }}{% endif %}">prev: {{ prev-page.label }}</a>
-</div>
-{% endif %}
-
-{% if this-page.file and this-page.file != "" %}
-<div class="pagination-this">
-    <a href="{{this-page.file}}.html{% if this-page.id and this-page.id != "" %}#{{ this-page.id }}{% endif %}">this: {{ this-page.label }}</a>
-</div>
-{% endif %}
-
-{% if next-page.file and next-page.file != "" %}
-<div class="pagination-next">
-    <a href="{{next-page.file}}.html{% if next-page.id and next-page.id != "" %}#{{ next-page.id }}{% endif %}">next: {{ next-page.label }}</a>
-</div>
-{% endif %}
-
-
-{% comment %}
-
-The code above isn't working properly. I think the looping is faulty,
-though I haven't figured it out yet. Meanwhile, here is a sketch of
-another approach we might take: flatten arrays to create one big array 
-of all pages in nav in order.
-
-
-// get the page-to-paginate
-...
-
-// use the main nav-tree unless a tree is passed by the include
-...
-
-// if a flattenednavinprogress exists, use it, otherwise create a new one
-if include.flattenednavinprogress
-    assign flattenednavinprogress = include.flattenednavinprogress
-else
-    {% assign flattenednavinprogress = "" | split: ',' %}
-fi
-
-// add all nested pages, in order, to the same, flat array,
-// passing this include to itself recursively until we're done
-// with all the children
-for page in tree
-    flattenednavinprogress | push: page
-    if children
-        include pagination tree=page.children flattenednavinprogress=flattenednavinprogress
-    if forloop.last
-        include pagination tree=page.children flattenednavinprogress=flattenednavinprogress
-        assign flattenednavfinal = flattenednavinprogress
-
-// ^^ can we be sure that that forloop.last will fire at the right time,
-// and not before the last item's children have been added to the array?
-// or should we just assign flattenednavfinal after endfor? But if we do,
-// won't it assign after every loop through the children?
-// perhaps we should check the array for page-to-paginate, and if it exists
-// pass this one more time (to get the next item in the array) before assigning
-// flattenednavfinal?
-
-
-// once we're done, get indexes
-if flattenednavfinal
-    for page in flattenednavfinal
-        if page.file == page-to-paginate
+    {% comment %} Loop through the file-list looking for the current file.
+    When we find it, get the previous and next files, too,
+    by using Liquid's option to index from 0 or 1. {% endcomment %}
+    {% for page in pages-to-paginate %}
+        {% if page == page-to-look-for %}
+            {% assign pagination-match = true  %}
             {% assign page-index0 = forloop.index0 %}
             {% assign page-index1 = forloop.index %}
-            {% break %} -- not sure I need this
+            {% break %}
+        {% endif %}
+    {% endfor %}
 
-// now compare indexes to get next/previous
-if flattenednavfinal
-    for page in flattenednavfinal
-        {% if page-index0 == forloop.index0 %}
-            {% assign this-page = page %}
-        {% endif %}
-        {% if page-index0 == forloop.index %}
-            {% assign prev-page = page %}
-        {% endif %}
-        {% if page-index1 == forloop.index0 %}
-            {% assign next-page = page %}
-        {% endif %}
+    {% comment %} If we have a match, store the previous and next files. {% endcomment %}
+    {% if pagination-match == true %}
+        {% for page in pages-to-paginate %}
+            {% if page-index0 == forloop.index0 %}
+                {% assign this-page = page %}
+            {% endif %}
+            {% if page-index0 == forloop.index %}
+                {% assign previous-page = page %}
+            {% endif %}
+            {% if page-index1 == forloop.index0 %}
+                {% assign next-page = page %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
 
-{% endcomment %}
+    {% comment %} We're going to look up the next and previous pages' titles. 
+    Remove index.html from URLs so that they compare with
+    Jekyll's folder-based-paths for the page.url of index.html files. {% endcomment %}
+    {% if previous-page contains "/index.html" %}
+        {% capture previous-page-url %}/{{ book-directory }}/{% if is-translation %}{{ language }}/{% endif %}text/{% endcapture %}
+    {% else %}
+        {% capture previous-page-url %}/{{ book-directory }}/{% if is-translation %}{{ language }}/{% endif %}text/{{ previous-page }}{% endcapture %}
+    {% endif %}
+    {% if this-page contains "/index.html" %}
+        {% capture this-page-url %}/{{ book-directory }}/{% if is-translation %}{{ language }}/{% endif %}text/{% endcapture %}
+    {% else %}
+        {% capture this-page-url %}/{{ book-directory }}/{% if is-translation %}{{ language }}/{% endif %}text/{{ this-page }}{% endcapture %}
+    {% endif %}
+    {% if next-page contains "/index.html" %}
+        {% capture next-page-url %}/{{ book-directory }}/{% if is-translation %}{{ language }}/{% endif %}text/{% endcapture %}
+    {% else %}
+        {% capture next-page-url %}/{{ book-directory }}/{% if is-translation %}{{ language }}/{% endif %}text/{{ next-page }}{% endcapture %}
+    {% endif %}
+
+    {% comment %} Now look through all pages to find the titles. {% endcomment %}
+    {% for page in site.pages %}
+        {% if page.url == previous-page-url %}
+            {% capture previous-page-title %}{{ page.title }}{% endcapture %}
+        {% endif %}
+        {% if page.url == next-page-url %}
+            {% capture next-page-title %}{{ page.title }}{% endcapture %}
+        {% endif %}
+    {% endfor %}
+
+    {% comment %} Now create a div for each pagination item,
+    if there is a file to link to. Don't include a link if
+    it points to the page we're on. This can happen when the page
+    is the first file in the file-list.{% endcomment %}
+
+    <div class="pagination">
+        {% unless include.direction == "next" %}    
+            {% if previous-page and previous-page-url != "" and previous-page-url != this-page-url %}
+                <div class="pagination-previous">
+                    <a href="{{ previous-page-url }}">{% if previous-page-title and previous-page-title != "" and site.data.settings[output-format].pagination-type == "titles" %}{{ previous-page-title }}{% elsif site.data.settings[output-format].pagination-type == "direction" %}{{ locale.nav.previous }}{% else %}&#x2190;{% endif %}</a>
+                </div>
+            {% endif %}
+        {% endunless %}
+
+        {% unless include.direction == "previous" %}
+            {% if next-page and next-page-url != "" and next-page-url != this-page-url %}
+                <div class="pagination-next">
+                    <a href="{{ next-page-url }}">{% if next-page-title and next-page-title != "" and site.data.settings[output-format].pagination-type == "titles" %}{{ next-page-title }}{% elsif site.data.settings[output-format].pagination-type == "direction" %}{{ locale.nav.previous }}{% else %}&#x2192;{% endif %}</a>
+                </div>
+            {% endif %}
+        {% endunless %}
+    </div>
+
+{% endif %}

--- a/_includes/pagination
+++ b/_includes/pagination
@@ -1,0 +1,155 @@
+Pagination...
+
+{% include metadata %}
+
+{% comment %} Get the starting nav tree to paginate by... {% endcomment %}
+{% if site.output == "app" %}
+    {% assign tree-to-paginate = app-nav-tree %}
+{% else %}
+    {% assign tree-to-paginate = web-nav-tree %}
+{% endif %}
+
+{% comment %} ... but use a specific tree if specified by the include tag,
+e.g. if this include has called itself for a page's children. {% endcomment %}
+{% if include.tree-to-paginate %}
+    {% assign tree-to-paginate = include.tree-to-paginate %}
+{% endif %}
+
+{% comment %} Capture the current filename here
+(don't use the current-file we get from metadata, because
+that changes when we pass this include to itself for children.
+Keep the page we're on in a page-to-paginate variable,
+to pass to this include for children. {% endcomment %}
+{% if include.page-to-paginate %}
+    {% capture page-to-paginate %}{{ include.page-to-paginate }}{% endcapture %}
+{% else %}
+    {% if page.url contains ".html" %}
+        {% capture page-to-paginate %}{{ page.url | split: "/" | last | replace: ".html", "" }}{% endcapture %}
+    {% else %}
+        {% comment %} File is an index.html file, which Jekyll
+        stores as a folder path only. {% endcomment %}
+        {% capture page-to-paginate %}index{% endcapture %}
+    {% endif %}
+{% endif %}
+
+{% comment %} Loop through the nav. When you find the file we're on,
+assign a match, and assign index numbers to its position
+in the nav tree using Liquid's index and index0.
+If no match, and the page in nav has children,
+pass the children to this include. {% endcomment %}
+{% assign pagination-match = false %}
+{% for page in tree-to-paginate %}
+    {% if page.file == page-to-paginate %}
+        {% assign pagination-match = true %}
+        {% assign page-index0 = forloop.index0 %}
+        {% assign page-index1 = forloop.index %}
+        {% break %}
+    {% elsif pagination-match != true and page.children %}
+{% comment %} Don't indent the include tag: avoids
+including it as a markdown code block {% endcomment %}
+{% include pagination tree-to-paginate=page.children page-to-paginate=page-to-paginate %}
+    {% endif %}
+{% endfor %}
+
+{% comment %} If we have a match, loop through the nav again.
+This time, we're looking for pages with indexes
+before and after the index we stored above. {% endcomment %}
+{% if pagination-match == true %}
+    {% for page in tree-to-paginate %}
+        {% if page-index0 == forloop.index0 %}
+            {% assign this-page = page %}
+        {% endif %}
+        {% if page-index0 == forloop.index %}
+            {% assign prev-page = page %}
+        {% endif %}
+        {% if page-index1 == forloop.index0 %}
+            {% assign next-page = page %}
+        {% endif %}
+    {% endfor %}
+{% endif %}
+
+{% comment %} Now create a div for each pagination item,
+if there is a file to link to. {% endcomment %}
+
+{% if prev-page.file and prev-page.file != "" %}
+<div class="pagination-previous">
+    <a href="{{prev-page.file}}.html{% if prev-page.id and prev-page.id != "" %}#{{ prev-page.id }}{% endif %}">prev: {{ prev-page.label }}</a>
+</div>
+{% endif %}
+
+{% if this-page.file and this-page.file != "" %}
+<div class="pagination-this">
+    <a href="{{this-page.file}}.html{% if this-page.id and this-page.id != "" %}#{{ this-page.id }}{% endif %}">this: {{ this-page.label }}</a>
+</div>
+{% endif %}
+
+{% if next-page.file and next-page.file != "" %}
+<div class="pagination-next">
+    <a href="{{next-page.file}}.html{% if next-page.id and next-page.id != "" %}#{{ next-page.id }}{% endif %}">next: {{ next-page.label }}</a>
+</div>
+{% endif %}
+
+
+{% comment %}
+
+The code above isn't working properly. I think the looping is faulty,
+though I haven't figured it out yet. Meanwhile, here is a sketch of
+another approach we might take: flatten arrays to create one big array 
+of all pages in nav in order.
+
+
+// get the page-to-paginate
+...
+
+// use the main nav-tree unless a tree is passed by the include
+...
+
+// if a flattenednavinprogress exists, use it, otherwise create a new one
+if include.flattenednavinprogress
+    assign flattenednavinprogress = include.flattenednavinprogress
+else
+    {% assign flattenednavinprogress = "" | split: ',' %}
+fi
+
+// add all nested pages, in order, to the same, flat array,
+// passing this include to itself recursively until we're done
+// with all the children
+for page in tree
+    flattenednavinprogress | push: page
+    if children
+        include pagination tree=page.children flattenednavinprogress=flattenednavinprogress
+    if forloop.last
+        include pagination tree=page.children flattenednavinprogress=flattenednavinprogress
+        assign flattenednavfinal = flattenednavinprogress
+
+// ^^ can we be sure that that forloop.last will fire at the right time,
+// and not before the last item's children have been added to the array?
+// or should we just assign flattenednavfinal after endfor? But if we do,
+// won't it assign after every loop through the children?
+// perhaps we should check the array for page-to-paginate, and if it exists
+// pass this one more time (to get the next item in the array) before assigning
+// flattenednavfinal?
+
+
+// once we're done, get indexes
+if flattenednavfinal
+    for page in flattenednavfinal
+        if page.file == page-to-paginate
+            {% assign page-index0 = forloop.index0 %}
+            {% assign page-index1 = forloop.index %}
+            {% break %} -- not sure I need this
+
+// now compare indexes to get next/previous
+if flattenednavfinal
+    for page in flattenednavfinal
+        {% if page-index0 == forloop.index0 %}
+            {% assign this-page = page %}
+        {% endif %}
+        {% if page-index0 == forloop.index %}
+            {% assign prev-page = page %}
+        {% endif %}
+        {% if page-index1 == forloop.index0 %}
+            {% assign next-page = page %}
+        {% endif %}
+
+{% endcomment %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,6 +18,15 @@ layout: compress
 {% include start-content.html %}
 {{ content }}
 {% include close-content.html %}
+
+{% if site.output == "web" and site.data.settings.web-pagination == true %}
+{% include pagination %}
+{% endif %}
+
+{% if site.output == "app" and site.data.settings.app-pagination == true %}
+{% include pagination %}
+{% endif %}
+
 {% include nav.html %}
 {% include footer.html %}
 {% include close-body.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,11 +19,10 @@ layout: compress
 {{ content }}
 {% include close-content.html %}
 
-{% if site.output == "web" and site.data.settings.web-pagination == true %}
+{% if site.output == "web" and site.data.settings.web.pagination == true %}
 {% include pagination %}
 {% endif %}
-
-{% if site.output == "app" and site.data.settings.app-pagination == true %}
+{% if site.output == "app" and site.data.settings.app.pagination == true %}
 {% include pagination %}
 {% endif %}
 

--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -176,6 +176,7 @@ $web-tables: true !default;
 $web-letters: true !default;
 $web-verse: true !default;
 $web-video: true !default;
+$web-pagination: true !default;
 
 // Type-control classes
 $web-smallcaps: true !default;
@@ -238,6 +239,7 @@ $web-reset-sequences: true !default; // This should stay last in the @import lis
 @import "partials/web-letters";
 @import "partials/web-verse";
 @import "partials/web-video";
+@import "partials/web-pagination";
 
 // Type-control classes
 @import "partials/web-smallcaps";

--- a/_sass/partials/_web-pagination.scss
+++ b/_sass/partials/_web-pagination.scss
@@ -6,7 +6,7 @@ $web-pagination: true !default;
     .pagination {
         font-family: $font-text-secondary;
         padding: $line-height-default;
-        width: $max-width-default / 2;
+        max-width: $max-width-default / 2;
         margin: auto;
         .pagination-previous {
             float: left;

--- a/_sass/partials/_web-pagination.scss
+++ b/_sass/partials/_web-pagination.scss
@@ -1,0 +1,25 @@
+$web-pagination: true !default;
+@if $web-pagination {
+
+    // Pagination (next and previous pages)
+
+    .pagination {
+        font-family: $font-text-secondary;
+        padding: $line-height-default;
+        width: $max-width-default / 2;
+        margin: auto;
+        .pagination-previous {
+            float: left;
+            a {
+                padding: 0 1em;                
+            }
+        }
+        .pagination-next {
+            float: right;
+            a {
+                padding: 0 1em;                
+            }
+        }
+    }
+
+}

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -176,6 +176,7 @@ $web-tables: true !default;
 $web-letters: true !default;
 $web-verse: true !default;
 $web-video: true !default;
+$web-pagination: true !default;
 
 // Type-control classes
 $web-smallcaps: true !default;
@@ -238,6 +239,7 @@ $web-reset-sequences: true !default; // This should stay last in the @import lis
 @import "partials/web-letters";
 @import "partials/web-verse";
 @import "partials/web-video";
+@import "partials/web-pagination";
 
 // Type-control classes
 @import "partials/web-smallcaps";

--- a/book/styles/app.scss
+++ b/book/styles/app.scss
@@ -180,6 +180,7 @@ $web-tables: true;
 $web-letters: true;
 $web-verse: true;
 $web-video: true;
+$web-pagination: true;
 
 // Type-control classes
 $web-smallcaps: true;

--- a/book/styles/web.scss
+++ b/book/styles/web.scss
@@ -180,6 +180,7 @@ $web-tables: true;
 $web-letters: true;
 $web-verse: true;
 $web-video: true;
+$web-pagination: true;
 
 // Type-control classes
 $web-smallcaps: true;

--- a/samples/styles/app.scss
+++ b/samples/styles/app.scss
@@ -180,6 +180,7 @@ $web-tables: true;
 $web-letters: true;
 $web-verse: true;
 $web-video: true;
+$web-pagination: true;
 
 // Type-control classes
 $web-smallcaps: true;

--- a/samples/styles/web.scss
+++ b/samples/styles/web.scss
@@ -180,6 +180,7 @@ $web-tables: true;
 $web-letters: true;
 $web-verse: true;
 $web-video: true;
+$web-pagination: true;
 
 // Type-control classes
 $web-smallcaps: true;

--- a/samples/text/00-01-halftitle-page.md
+++ b/samples/text/00-01-halftitle-page.md
@@ -1,5 +1,5 @@
 ---
-title: Title page
+title: Half-title page
 style: halftitle-page
 ---
 


### PR DESCRIPTION
For a long time we've needed a way to add 'next/previous' links to files. This adds that.

First, it adds an include called `pagination`, which adds previous and next links. By adding a 'direction' parameter to the include tag, this can show only previous or next, e.g. `{% include pagination direction="next" %}` will only output 'next' links.

The order of pagination is determined by the `files` list for each format in `meta.yml`.

Pagination only applies to web and app outputs. By default, pagination is added at the end of book files (in the `default` layout). It can be turned off in `settings.yml`. The pagination format can also be changed there to use 'Next' and 'Previous', to use page titles, or to use arrows. Arrows are the default.

I've also moved file-list generation to `metadata`, and simplified the `file-list` include.