### PR TITLE
Epub refinements

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -52,7 +52,7 @@ epub:
 # To hide the 'on the page' nav in epub, set this to 'true'.
 # Then you can put {% include toc %} anywhere in your epub
 # to generate a hidden nav element.
-  hide-nav: true
+  hide-nav: false
 }
 
 # ----------------------------------------------------------

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -41,11 +41,19 @@ web:
 # ----------------------------------------------------------
 # Epub settings
 # ----------------------------------------------------------
+epub:
 # If you're embedding fonts, uncomment and list the font-file names here
 # and put the font files in _epub/fonts, not book/fonts
-# epub-fonts:
-  # - Crimson-Roman.otf
-  # - Crimson-Italic.otf
+#   fonts:
+#     - Crimson-Roman.otf
+#     - Crimson-Italic.otf
+# Every EPUB3 must have a nav element, like a TOC,
+# but you are allowed to hide it from view.
+# To hide the 'on the page' nav in epub, set this to 'true'.
+# Then you can put {% include toc %} anywhere in your epub
+# to generate a hidden nav element.
+  hide-nav: true
+}
 
 # ----------------------------------------------------------
 # App settings

--- a/_includes/epub-package
+++ b/_includes/epub-package
@@ -144,8 +144,8 @@
 
         {% endfor %}
 
-        {% comment %}Add epub-fonts listed in settings.{% endcomment %}
-        {% for font in site.data.settings.epub-fonts %}
+        {% comment %}Add epub fonts listed in settings.{% endcomment %}
+        {% for font in site.data.settings.epub.fonts %}
 
             {% capture file-name %}{{ font | split: "." | first }}{% endcapture %}
             {% capture file-extension %}{{ font | split: "." | last }}{% endcapture %}

--- a/_includes/toc
+++ b/_includes/toc
@@ -96,7 +96,7 @@ Now we'll use all that to output the toc list.
 {% comment %}If we're making an epub, and we're starting
 at the top of the toc, put this in a nav element.{% endcomment %}
 {% if site.output == "epub" and toc-branch == epub-toc or toc-branch == print-pdf-toc or toc-branch == web-nav-tree %}
-<nav epub:type="toc" id="toc">
+<nav epub:type="toc" id="toc"{% if site.data.settings.epub.hide-nav == true %} hidden=""{% endif %}>
 {% endif %}
 
 <ol class="toc-list {% if toc-branch contains current-file %}active{% endif %}">

--- a/_sass/partials/_epub-base-typography.scss
+++ b/_sass/partials/_epub-base-typography.scss
@@ -108,7 +108,10 @@ $epub-base-typography: true !default;
         border: $rule-thickness solid rgba(255,255,255,0);
         margin: $line-height-default 0; // Adds space, esp. important for Kindle
         text-align: center; // Necessary for aligning :after content
-        // Note: Amazon Kindle will ignore this :after content setting
+        // Note: Amazon Kindle will ignore this :after content setting.
+        // An hr in Amazon can be hidden by setting hr { margin-left: -200%; }
+        // in a Kindle media query. See below for example code.
+        // We don't do that here because it is a case-by-case hack.
         &:after {
             content: $text-divider;
         }
@@ -117,6 +120,16 @@ $epub-base-typography: true !default;
         }
     }
 
+    // Queries that target Kindle devices
+    // @media amzn-kf8 {
+    //     hr {
+    //         margin-left: -200%;
+    //     }
+    // }
+    // @media amzn-mobi7 {
+    //     hr {
+    //         margin-left: -200%;
+    //     }
 
     // Superscripts and subscripts
 


### PR DESCRIPTION
Adds the ability to create a hidden `nav` element.

Every EPUB3 epub must have a `nav` element, which we generate with `{% include toc %}` and by adding a `toc` value to the file that contains it in the epub `files` list (e.g. `- "0-4-contents": "toc"`). But some books, such as novels, shouldn't have visible TOCs. 

Now we can set a nav to be hidden (i.e. `<nav ... hidden="">`) by setting `hide-nav: true` in `settings.yml`.

I've also added more guidance on `hr` text divider workarounds for Kindle.