### PR TITLE
App output improvements for better iOS build process and user experience

### DIFF
--- a/_app/build.json
+++ b/_app/build.json
@@ -10,6 +10,8 @@
 #   development-team-id: "YOURTEAMID"
 #   package-type: "development"
 # See https://cordova.apache.org/docs/en/latest/guide/platforms/ios/ for details.
+# In secrets.yml, change ios package-type above to match the provisioning profile
+# that you are currently building with. Usual options are development, ad-hoc, app-store
 # Never share or commit _data/secrets.yml to your repository!
 # See https://developer.android.com/studio/publish/app-signing.html
 layout: min
@@ -38,7 +40,7 @@ layout: min
         "release": {
             "codeSignIdentity": "iPhone Developer",
             "developmentTeam": "{{ site.data.secrets.ios.development-team-id }}",
-            "packageType": "app-store",
+            "packageType": "{{ site.data.secrets.ios.package-type }}",
             "buildFlag": [
                 "EMBEDDED_CONTENT_CONTAINS_SWIFT = YES",
                 "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES=NO",

--- a/_app/config.xml
+++ b/_app/config.xml
@@ -28,6 +28,7 @@ layout: min
     <platform name="ios">
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
+        <preference name="EnableViewportScale" value="true"/>
     </platform>
     <engine name="android" spec="~6.2.3" />
     <plugin name="cordova-plugin-whitelist" spec="1" />

--- a/_includes/figure
+++ b/_includes/figure
@@ -29,9 +29,9 @@ because https://github.com/jekyll/jekyll/issues/2248.
 {% if include.image or include.images %}
 <div class="figure-images contains-{{ number-of-images }}">
     {%for image in figure-images %}
-        {% if include.link %}<a href="{{ include.link }}">{% elsif site.output == "web" or site.output == "app" %}<a href="{{ images }}/{{ image }}">{% endif %}
+        {% if include.link %}<a href="{{ include.link }}">{% elsif site.output == "web" %}<a href="{{ images }}/{{ image }}">{% endif %}
             <img src="{{ images }}/{{ image }}" alt="{% if include.title %}{{ include.title }}: {% endif %}{% if include.description %}{{ include.description }}{% else %}{{ include.caption }}{% endif %}{% if include.image-height != nil %} height-{{ include.image-height }}{% endif %}" />
-        {% if include.link or site.output == "web" or site.output == "app" %}</a>{% endif %}
+        {% if include.link or site.output == "web" %}</a>{% endif %}
     {% endfor %}
 </div>
 {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -104,7 +104,7 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">
-    <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width">
+    <meta name="viewport" content="user-scalable=yes, initial-scale=1, width=device-width">
 
     {% comment %}
     Customize this policy to fit your own app's needs. For more guidance, see:


### PR DESCRIPTION
On iOS apps, we can't have images open in a new tab, because the device has no back button and the user is trapped on the image. So we've removed that default and made the app zoomable instead, so that users can cimply zoom in place. (In web output, users will click to open the image in a new tab, the analog of zooming.)

We've also added better control for building various kinds of signed/release apps for testing and distribution.