### PR TITLE
External media

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -68,3 +68,16 @@ app:
 # in an expansion file, edit these settings.
 google-play-expansion-file-enabled: false
 google-play-public-api-key: ""
+
+# ----------------------------------------------------------
+# External media settings
+# ----------------------------------------------------------
+# If a large number of images makes your project too big,
+# you can store your images in a separate location.
+# See the docs for more information.
+remote-media:
+  development: ""
+  live: ""
+local-media:
+  development: ""
+  live: ""

--- a/_docs/images/external-media.md
+++ b/_docs/images/external-media.md
@@ -12,7 +12,7 @@ There is a template repo for external media at [github.com/electricbookworks/ele
 
 ## Setting external-media paths
 
-You set the full URL for the `remote-media` location in `_data/settings.yml`. For example:
+You set the full URL for the `remote-media` location in `_data/settings.yml`. The `remote-media` paths must be full URLS. For example:
 
 ```
 remote-media:
@@ -46,28 +46,43 @@ When using remote-media, translations must have their own image files in their t
 
 ## Local media
 
-Remote media works well for web output (while you're online at least), but can make PDF output very slow, because Prince has to fetch every image over the Internet. For faster PDF output you can tell the system to use images on your local machine instead by setting a `local-media` path, in addition to `remote-media`. For example:
+Remote media works well for web output, but it means you have to be online, and can make PDF output very slow, because Prince has to fetch every image over the Internet. For faster PDF output you can tell the system to use images on your local machine instead by setting a `local-media` path, in addition to `remote-media`.
+
+When a `local-media` path is set, PDF outputs will use that path to images, so that Prince does not have to fetch every image over the Internet.
+
+The local-media path can be set in two ways:
+
+1. As a path on your computer's filesystem, relative to the `_site` folder.
+2. As a URL served locally, by a webserver running on your machine.
+
+### Setting a filesystem path
+
+A relative filesystem path might look like this:
 
 ```
 local-media:
-  live: ""
-  development: ""
-```
-
-(Currently, the `live` local-media path is not used; but this might change in future. For example, the Electric Book Manager may use the `live` setting. So we recommend setting both for now.)
-
-When a `local-media` path is set, PDF outputs will use that path to images, so that Prince does not have to fetch every image over the Internet. Web output cannot use a `local-media` path, because the webserver cannot see outside of its root directory on your file system.
-
-The local-media path is a relative path on your computer; relative to the `_site` folder.
-
-So we recommend that you store your local copy of the external-media directory alongside the main project repo directory, to make the path to the local images simple.
-
-To use external media from a directory alongside the main project repo, then, you would write the path to go up two levels (`../../`) and into the external media directory. E.g.:
-
-```
-local-media:
+  live: "../../superpotatoes-media"
   development: "../../superpotatoes-media"
 ```
 
-Note: The `development` build is the default build type. A `live` build only really applies to web builds. The `build: live` config is set in `_config.live.yml`, which is generally only used for building live website packages.
+(Currently, the `live` local-media path is not used; but this might change in future. For example, the Electric Book Manager may use the `live` setting in future. So we recommend setting both for now.)
+
+Note: The `development` build is the default build type. A `live` build only really applies to web builds. We set `build: live` in `_config.live.yml`, which is generally only used for building live website packages.
 {:.box}
+
+We recommend that you store your local copy of the external-media directory alongside the main project repo directory, to make the filesystem path to the local images simple.
+
+To use external media from a directory alongside the main project repo, then, you would write the path to go up two levels (`../../`) and into the external media directory, as shown above.
+
+### Setting a local URL
+
+Web output cannot use a relative filesystem path, because a webserver cannot see outside of its own root directory on your filesystem.
+
+So you can use a webserver running on your own machine for offline development, e.g.
+
+```
+local-media:
+  development: "http://localhost:5000"
+```
+
+If you use the `electric-book-media` template for your external media repo, the OS-specific `run-` scripts there will launch a local server running at that address. You can run it at the same time as your local Jekyll instance of your book project.

--- a/_docs/images/external-media.md
+++ b/_docs/images/external-media.md
@@ -8,14 +8,16 @@ order: 4
 
 If a large number of images makes your project too big, you can store your images in a separate repo and serve them on a separate server for PDF and web output.
 
+There is a template repo for external media at [github.com/electricbookworks/electric-book-media](https://github.com/electricbookworks/electric-book-media).
+
 ## Setting external-media paths
 
 You set the full URL for the `remote-media` location in `_data/settings.yml`. For example:
 
 ```
 remote-media:
-  live: "http://media.example.com"
-  development: "http://dev.example.com/media"
+  live: "http://media.superpotatoes.com"
+  development: "http://dev.superpotatoes.com/media"
 ```
 
 To disable external media, just comment out the relevant settings or leave the values blank:
@@ -30,21 +32,19 @@ remote-media:
 
 At the remote-media domain, the paths to media should match the paths to that media in this project.
 
-For example, if a project called `example` contains two books, `foobar` and `helloworld`, the remote-media URL might be `http://media.example.com`. And on that media server, web images would be stored in `http://media.example.com/foobar/images/web` and `http://media.example.com/helloworld/images/web`.
+For example, if a project called `superpotatoes` contains two books, `mondial` and `fabula`, the remote-media URL might be `http://media.superpotatoes.com`. And on that media server, web images would be stored in `http://media.superpotatoes.com/mondial/images/web` and `http://media.superpotatoes.com/fabula/images/web`.
 
 ## Epub and app output
 
-Note that remote-media does not work for app or epub output. For books with enough images to warrant remote-media, it's recommended that you use a separate repo for your app, and you won't have a sensibly sized epub anyway.
+External media does not work for app or epub output. For apps with enough images to warrant external media, it's recommended that you use a separate Cordova-based repo for your app, into the `www` folder of which which you simply copy-paste your app-ready HTML.
 
 ## Translations
 
-When using remote-media, translations must have their own image files in their translation subdirectories (e.g. `http://example.com/foobar/fr/images/web`); that is, unlike local images they cannot inherit their parent language's images.
+When using remote-media, translations must have their own image files in their translation subdirectories (e.g. `http://superpotatoes.com/mondial/fr/images/web`). That is, unlike local images they cannot inherit their parent language's images in the absence of their own `images` folder.
 
 ## Local media
 
-Remote media works well for web output when you're online, but for faster PDF output you can tell the system to use images on your local machine instead.
-
-You can set a `local-media` path, too, in addition to `remote-media`, like this (using example paths):
+Remote media works well for web output (while you're online at least), but can make PDF output very slow, because Prince has to fetch every image over the Internet. For faster PDF output you can tell the system to use images on your local machine instead by setting a `local-media` path, in addition to `remote-media`. For example:
 
 ```
 local-media:
@@ -52,19 +52,19 @@ local-media:
   development: ""
 ```
 
-(Currently, the `live` local media has no meaning, and only the `development` default is used; but this might change in future, for example the Electric Book Manager may use the `live` setting. So set both.)
+(Currently, the `live` local-media path is not used; but this might change in future. For example, the Electric Book Manager may use the `live` setting. So we recommend setting both for now.)
 
-When a `local-media` path is set, PDF outputs will use that local media, so that Prince does not have to fetch every image online. Web output generally cannot use a `local-media` path, because the webserver cannot see outside of its root directory on your file system.
+When a `local-media` path is set, PDF outputs will use that path to images, so that Prince does not have to fetch every image over the Internet. Web output cannot use a `local-media` path, because the webserver cannot see outside of its root directory on your file system.
 
-The local-media path is set as a relative path on your computer, relative to the `_site` folder.
+The local-media path is a relative path on your computer; relative to the `_site` folder.
 
-So we recommend that you store your local copy of the external-media directory alongside the main project repo directory, to make the path to it simple.
+So we recommend that you store your local copy of the external-media directory alongside the main project repo directory, to make the path to the local images simple.
 
-To use external media from a directory alongside the main project repo, then, you would write it to go up two levels (`../../`) and into the external media directory. E.g.:
+To use external media from a directory alongside the main project repo, then, you would write the path to go up two levels (`../../`) and into the external media directory. E.g.:
 
 ```
 local-media:
-  development: "../../example-media"
+  development: "../../superpotatoes-media"
 ```
 
 Note: The `development` build is the default build type. A `live` build only really applies to web builds. The `build: live` config is set in `_config.live.yml`, which is generally only used for building live website packages.

--- a/_docs/images/external-media.md
+++ b/_docs/images/external-media.md
@@ -1,0 +1,71 @@
+---
+title: External media
+categories: images
+order: 4
+---
+
+# External media
+
+If a large number of images makes your project too big, you can store your images in a separate repo and serve them on a separate server for PDF and web output.
+
+## Setting external-media paths
+
+You set the full URL for the `remote-media` location in `_data/settings.yml`. For example:
+
+```
+remote-media:
+  live: "http://media.example.com"
+  development: "http://dev.example.com/media"
+```
+
+To disable external media, just comment out the relevant settings or leave the values blank:
+
+```
+remote-media:
+  live: ""
+  development: ""
+```
+
+## Structuring external-media files
+
+At the remote-media domain, the paths to media should match the paths to that media in this project.
+
+For example, if a project called `example` contains two books, `foobar` and `helloworld`, the remote-media URL might be `http://media.example.com`. And on that media server, web images would be stored in `http://media.example.com/foobar/images/web` and `http://media.example.com/helloworld/images/web`.
+
+## Epub and app output
+
+Note that remote-media does not work for app or epub output. For books with enough images to warrant remote-media, it's recommended that you use a separate repo for your app, and you won't have a sensibly sized epub anyway.
+
+## Translations
+
+When using remote-media, translations must have their own image files in their translation subdirectories (e.g. `http://example.com/foobar/fr/images/web`); that is, unlike local images they cannot inherit their parent language's images.
+
+## Local media
+
+Remote media works well for web output when you're online, but for faster PDF output you can tell the system to use images on your local machine instead.
+
+You can set a `local-media` path, too, in addition to `remote-media`, like this (using example paths):
+
+```
+local-media:
+  live: ""
+  development: ""
+```
+
+(Currently, the `live` local media has no meaning, and only the `development` default is used; but this might change in future, for example the Electric Book Manager may use the `live` setting. So set both.)
+
+When a `local-media` path is set, PDF outputs will use that local media, so that Prince does not have to fetch every image online. Web output generally cannot use a `local-media` path, because the webserver cannot see outside of its root directory on your file system.
+
+The local-media path is set as a relative path on your computer, relative to the `_site` folder.
+
+So we recommend that you store your local copy of the external-media directory alongside the main project repo directory, to make the path to it simple.
+
+To use external media from a directory alongside the main project repo, then, you would write it to go up two levels (`../../`) and into the external media directory. E.g.:
+
+```
+local-media:
+  development: "../../example-media"
+```
+
+Note: The `development` build is the default build type. A `live` build only really applies to web builds. The `build: live` config is set in `_config.live.yml`, which is generally only used for building live website packages.
+{:.box}

--- a/_docs/images/external-media.md
+++ b/_docs/images/external-media.md
@@ -34,6 +34,8 @@ At the remote-media domain, the paths to media should match the paths to that me
 
 For example, if a project called `superpotatoes` contains two books, `mondial` and `fabula`, the remote-media URL might be `http://media.superpotatoes.com`. And on that media server, web images would be stored in `http://media.superpotatoes.com/mondial/images/web` and `http://media.superpotatoes.com/fabula/images/web`.
 
+Images inserted by CSS (e.g. `background-image` files) cannot be in external media, because their paths are fixed in CSS. So do not move these to the external media location.
+
 ## Epub and app output
 
 External media does not work for app or epub output. For apps with enough images to warrant external media, it's recommended that you use a separate Cordova-based repo for your app, into the `www` folder of which which you simply copy-paste your app-ready HTML.

--- a/_includes/metadata
+++ b/_includes/metadata
@@ -5,6 +5,11 @@ as output tags, e.g. {{ title }} for the current
 book's title.
 {% endcomment %}
 
+{% assign build = "development" %}
+{% if site.build and site.build != "" %}
+    {% assign build = site.build %}
+{% endif %}
+
 {% capture output-format %}{{ site.output }}{% endcapture %}
 
 {% comment %}
@@ -30,8 +35,14 @@ which will be overridden below if we're on book pages.{% endcomment %}
 {% comment %}
 It's useful to know how many books are in this project
 {% endcomment %}
-
 {% assign number-of-works = site.data.meta.works | size %}
+
+{% comment %}Get an array of the book directories.
+Useful for checking whether we're in a real book directory.{% endcomment %}
+{% assign book-directory-array = "" | split: "|" %}
+{% for work in site.data.meta.works %}
+    {% assign book-directory-array = book-directory-array | push: work.directory %}
+{% endfor %}
 
 {% comment %}
 Get the directory for this book only
@@ -39,6 +50,16 @@ We'll rewrite this later if we're in a translation
 {% endcomment %}
 
 {% capture book-directory %}{{ page.path | replace: "/", " " | truncatewords: 1, "" }}{% endcapture %}
+
+{% comment %}Are we really in a listed book directory, or a directory
+in the root that isn't really a listed book?{% endcomment %}
+{% for directory in book-directory-array %}
+    {% if book-directory == directory %}
+        {% assign is-book-directory = true %}
+    {% else %}
+        {% assign is-book-directory = false %}
+    {% endif %}
+{% endfor %}
 
 {% comment %}Get the current directory name.{% endcomment %}
 
@@ -70,15 +91,6 @@ Get the current file's name
 {% endif %}
 
 {% comment %}
-Check whether we're in a subdirectory of `text`
-{% endcomment %}
-{% capture book-subdirectory %}{{ page.path | replace: "/", " " | truncatewords: 2, "" | split: " " | last }}{% endcapture %}
-{% assign is-book-subdirectory = false %}
-{% if page.path contains book-directory and page.path contains book-subdirectory and page.path contains "/text/" and page.path contains current-file %}
-    {% assign is-book-subdirectory = true %}
-{% endif %}
-
-{% comment %}
 Get this file's folder depth
 (The minus 1 avoids counting the file itself)
 {% endcomment %}
@@ -90,6 +102,19 @@ If the folder depth is more than 2, this is a subdirectory of `text`
 {% assign is-book-subsubdirectory = false %}
 {% if folder-depth > 2 %}
     {% assign is-book-subsubdirectory = true %}
+{% endif %}
+
+{% comment %}
+Check whether we're in a subdirectory of `text`
+{% endcomment %}
+{% capture book-subdirectory %}{{ page.path | replace: "/", " " | truncatewords: 2, "" | split: " " | last }}{% endcapture %}
+{% comment %}Discard that if it's a filename, like search.md.{% endcomment %}
+{% if book-subdirectory contains "." %}
+    {% capture book-subdirectory %}{% endcapture %}
+{% endif %}
+{% assign is-book-subdirectory = false %}
+{% if book-directory-array contains book-directory and page.path contains book-directory and page.path contains book-subdirectory and page.path contains "/text/" and page.path contains current-file %}
+    {% assign is-book-subdirectory = true %}
 {% endif %}
 
 {% comment %}
@@ -573,6 +598,37 @@ the {{ images }} path should include the language subdirectory.{% endcomment %}
 
     {% if translated-images-exist == true %}
         {% capture images %}{{ path-to-book-directory }}{{ book-subdirectory }}/{{ site.image-set }}{% endcapture %}
+    {% endif %}
+{% endif %}
+
+{% comment %}For PDF and web outputs, check if we are using external-media,
+and if we are, get the relevant path as `external-media`, defaulting to
+remote-media for web and local-media for PDF.{% endcomment %}
+{% if site.output == "print-pdf" or site.output == "screen-pdf" %}
+    {% if site.data.settings.local-media.[build] and site.data.settings.local-media.[build] != "" %}
+        {% capture external-media %}{% unless site.data.settings.local-media.[build] contains "http" %}{{ path-to-root-directory }}{% endunless %}{{ site.data.settings.local-media.[build] }}{% endcapture %}
+    {% elsif site.data.settings.remote-media.[build] and site.data.settings.remote-media.[build] != "" %}
+        {% capture external-media %}{{ site.data.settings.remote-media.[build] }}{% endcapture %}
+    {% endif %}
+{% endif %}
+{% if site.output == "web" %}
+    {% if site.data.settings.remote-media.[build] and site.data.settings.remote-media.[build] != "" %}
+        {% capture external-media %}{{ site.data.settings.remote-media.[build] }}{% endcapture %}
+    {% elsif site.data.settings.local-media.[build] and site.data.settings.local-media.[build] != "" %}
+        {% capture external-media %}{% unless site.data.settings.local-media.[build] contains "http" %}{{ path-to-root-directory }}{% endunless %}{{ site.data.settings.local-media.[build] }}{% endcapture %}
+    {% endif %}
+{% endif %}
+
+{% comment %}If we're using external media, set `images` accordingly.{% endcomment %}
+{% if external-media and external-media != "" %}
+    {% capture images %}{{ external-media }}/{{ book-directory }}/{{ site.image-set }}{% endcapture %}
+    {% if is-translation %}
+        {% capture images %}{{ external-media }}/{{ book-directory }}/{{ book-subdirectory }}/{{ site.image-set }}{% endcapture %}
+    {% endif %}
+    {% comment %}If we are not in a book directory, use the images
+    from the first book in the project.{% endcomment %}
+    {% if is-root-directory == true %}
+        {% capture images %}{{ external-media }}/{{ site.data.meta.works.[0].directory }}/{{ site.image-set }}{% endcapture %}
     {% endif %}
 {% endif %}
 

--- a/_includes/page-info
+++ b/_includes/page-info
@@ -4,9 +4,10 @@ See all the metadata gathered for a given page.
 
 {% include metadata %}
 
-|        Description        |           Source           |    Output tag   |    Current result   |  Type  |
-|---------------------------|----------------------------|-----------------|---------------------|--------|
-| The current output format | `site.output` in `_config` | `output-format` | {{ output-format }} | String |
+|                   Description                   |           Source           |    Output tag   |    Current result   |  Type  |
+|-------------------------------------------------|----------------------------|-----------------|---------------------|--------|
+| The current output format                       | `site.output` in `_config` | `output-format` | {{ output-format }} | String |
+| The current build type (default: `development`) | `site.build` in `_config`  | `build`         | {{ build }}         | String |
 
 |      Description       |         Source        |       Output tag       |       Current result       |  Type  |
 |------------------------|-----------------------|------------------------|----------------------------|--------|
@@ -33,6 +34,7 @@ See all the metadata gathered for a given page.
 |                  Description                  |                                                 Source                                                |      Output tag     |      Current result     |  Type  |
 |-----------------------------------------------|-------------------------------------------------------------------------------------------------------|---------------------|-------------------------|--------|
 | Number of works in project                    | Calculated from `meta.yml`                                                                            | `number-of-works`   | {{ number-of-works }}   | Number |
+| Book directories in project                   | A list of the `directory`s in `meta.yml`                                                              | `book-directory-array` | {{ book-directory-array }} | Array  |
 | Book directory name                           | Detected from page path, then overriden by value in `meta.yml`. Nil on project home and search pages. | `book-directory`    | {{ book-directory }}    | String |
 | URL as an array of directory names and a file | Extracted from page URL                                                                               | `url-as-array`      | {{ url-as-array }}      | Array  |
 | Number of parts in the URL array              | Calculated from `url-as-array`                                                                        | `url-as-array-size` | {{ url-as-array-size }} | Number |
@@ -154,19 +156,20 @@ See all the metadata gathered for a given page.
 | Variant epub stylesheet, if any       | Defined in `settings.yml`; if not set, inherits parent epub-stylesheet                                             | `epub-stylesheet`       | {{ epub-stylesheet }}                                                                                                                                                                                                                  | String  |
 | Variant app stylesheet, if any        | Defined in `settings.yml`; if not set, inherits parent app-stylesheet                                              | `app-stylesheet`        | {{ app-stylesheet }}                                                                                                                                                                                                                   | String  |
 
-|                                Description                                |                              Source                             |         Output tag        |         Current result        |   Type  |
-|---------------------------------------------------------------------------|-----------------------------------------------------------------|---------------------------|-------------------------------|---------|
-| Slug of the page URL                                                      | Constructed from built-in Jekyll variables, useful as a page ID | `pageurl-slug`            | {{ pageurl-slug }}            | String  |
-| Slug of the base URL only                                                 | A built-in Jekyll variable, slugified                           | `baseurl-slug`            | {{ baseurl-slug }}            | String  |
-| Is this the homepage?                                                     | If `pageurl-slug` matches `baseurl-slug`, this is the home page | `is-homepage`             | {{ is-homepage }}             | Boolean |
-| Are we in the root directory?                                             | If `path-to-root-directory == ""`                               | `is-root-directory`       | {{ is-root-directory }}       | Boolean |
-| URL of a project-root search page                                         | URL of any potential `search.html` in project root              | `project-search-url`      | {{ project-search-url }}      | String  |
-| URL of a book-directory search page (deprecated, only use project-search) | URL of any potential `search.html` in `book/text`               | `book-search-url`         | {{ book-search-url }}         | String  |
-| Slug of project-root search URL                                           | Slug of above value                                             | `project-search-url-slug` | {{ project-search-url-slug }} | String  |
-| Slug of book/text search URL                                              | Slug of above value                                             | `book-search-url-slug`    | {{ book-search-url-slug }}    | String  |
-| Is this a search page?                                                    | Detects `/search.html` in page path                             | `is-search`               | {{ is-search }}               | Boolean |
-| Is this a project-root search page?                                       | Compares slugs of project search URL and current page URL       | `is-project-search`       | {{ is-project-search }}       | Boolean |
-| Is this a book/text search page?                                          | Compares slugs of book/text search URL and current page URL     | `is-book-search`          | {{ is-book-search }}          | Boolean |
+|                                Description                                |                              Source                              |         Output tag        |         Current result        |   Type  |
+|---------------------------------------------------------------------------|------------------------------------------------------------------|---------------------------|-------------------------------|---------|
+| Slug of the page URL                                                      | Constructed from built-in Jekyll variables, useful as a page ID  | `pageurl-slug`            | {{ pageurl-slug }}            | String  |
+| Slug of the base URL only                                                 | A built-in Jekyll variable, slugified                            | `baseurl-slug`            | {{ baseurl-slug }}            | String  |
+| Is this the homepage?                                                     | If `pageurl-slug` matches `baseurl-slug`, this is the home page  | `is-homepage`             | {{ is-homepage }}             | Boolean |
+| Is this the root directory?                                               | Checks whether the path to the file is the same as the `baseurl` | `is-root-directory`       | {{ is-root-directory }}       | Boolean |
+| Is this a book directory?                                                 | Compares directory with directories listed in `meta.yml`         | `is-book-directory`       | {{ is-book-directory }}       | Boolean |
+| URL of a project-root search page                                         | URL of any potential `search.html` in project root               | `project-search-url`      | {{ project-search-url }}      | String  |
+| URL of a book-directory search page (deprecated, only use project-search) | URL of any potential `search.html` in `book/text`                | `book-search-url`         | {{ book-search-url }}         | String  |
+| Slug of project-root search URL                                           | Slug of above value                                              | `project-search-url-slug` | {{ project-search-url-slug }} | String  |
+| Slug of book/text search URL                                              | Slug of above value                                              | `book-search-url-slug`    | {{ book-search-url-slug }}    | String  |
+| Is this a search page?                                                    | Detects `/search.html` in page path                              | `is-search`               | {{ is-search }}               | Boolean |
+| Is this a project-root search page?                                       | Compares slugs of project search URL and current page URL        | `is-project-search`       | {{ is-project-search }}       | Boolean |
+| Is this a book/text search page?                                          | Compares slugs of book/text search URL and current page URL      | `is-book-search`          | {{ is-book-search }}          | Boolean |
 
 |         Description         |                   Source                  |      Output tag     |      Current result     |   Type  |
 |-----------------------------|-------------------------------------------|---------------------|-------------------------|---------|
@@ -189,6 +192,9 @@ See all the metadata gathered for a given page.
 | A list of translated fonts                                             | Detected from static files in the above potential location                              | `translation-fonts`                    | {% if is-translation %}{% if translation-fonts-number > 0 %}Files detected, but not shown here{% else %}No files detected{% endif %}{% else %}Not a translation{% endif %}  | Array   |
 | The number of translated fonts                                         | Calculated from the `translation-fonts` list                                            | `translation-fonts-number`             | {{ translation-fonts-number }}                                                                                                                                              | Number  |
 | Do translated fonts exist for this book and output format?             | Detected if `translation-fonts-number` > 0                                              | `translation-fonts-exist`              | {{ translation-fonts-exist }}                                                                                                                                               | Boolean |
+
+| Description                  | Source                  | Output tag       | Current result       | Type   |
+| Are we using external-media? | Set in `_data.settings` | `external-media` | {{ external-media }} | String |
 
 |         Description         |                   Source                  |      Output tag     |      Current result     |   Type  |
 |-----------------------------|-------------------------------------------|---------------------|-------------------------|---------|


### PR DESCRIPTION
This lets us keep images in a separate repo (or location generally), which is useful for large, image-heavy projects.