### PR TITLE
Content accordion

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -50,6 +50,13 @@ web:
   # Note that breadcrumbs slows your Jekyll build significantly.
   masthead:
     content: breadcrumbs
+  # ----------------------------------------------------------
+  # Content accordion
+  # ----------------------------------------------------------
+  # Do you want to collapse content sections in chapters on a
+  # particular heading level? Default h2, set in accordion.js.
+  # Set this to true to enable, or false to disable.
+  accordion: false
 
 # ----------------------------------------------------------
 # Epub settings
@@ -94,6 +101,13 @@ app:
   # Note that breadcrumbs slows your Jekyll build significantly.
   masthead:
     content: breadcrumbs
+  # ----------------------------------------------------------
+  # Content accordion
+  # ----------------------------------------------------------
+  # Do you want to collapse content sections in chapters on a
+  # particular heading level? Default h2, set in accordion.js.
+  # Set this to true to enable, or false to disable.
+  accordion: false
   # ----------------------------------------------------------
   # Expansion file
   # ----------------------------------------------------------

--- a/_docs/layout/colour-profiles.md
+++ b/_docs/layout/colour-profiles.md
@@ -2,7 +2,7 @@
 title: Colour profiles
 categories:
   - layout
-order: 4
+order: 5
 ---
 
 # Colour profiles

--- a/_docs/layout/content-accordion.md
+++ b/_docs/layout/content-accordion.md
@@ -1,0 +1,55 @@
+---
+title: Web and app content accordion
+categories: layout
+order: 4
+---
+
+# Web and app content accordion
+{:.no_toc}
+
+* Page contents
+{:toc}
+
+A book chapter can be much too long for reasonable reading on screen. Also, a chapter might contain many images, and downloading them all every time you read just part of the chapter could use up a lot of a user's data. For these reasons, you can turn on a content accordion for web and app pages.
+
+The content accordion breaks up your page into sections, and collapses them, showing only each section's heading. To open or close a section, a user just clicks on the heading (or the toggle icon beside it).
+
+In addition, images in [figures](../editing/figures.html) will only load when a section is opened. This way, if a user doesn't open a given section, their device won't download it, saving them data.
+
+The content accordion only works in chapter files (i.e. markdown files that do not have a `style` set in their YAML frontmatter, or have it set to something other than `chapter`, such as frontmatter).
+
+## Activating the content accordion
+
+To turn on the content accordion, change the value of `accordion` in `_data.settings.yml` to `true`:
+
+```
+  accordion: true
+```
+
+This is set separately for `web` and `app` outputs. So you'll find in `settings.yml` that you can set `accordion` in two places.
+
+## Setting the accordion heading level
+
+By default, the content accordion collapses on `h2`s. You can change this in the `// Options` section of `assets/js/accordion.js`. For instance, to set the accordion to collapse on third-level headings, change:
+
+```
+var accordionHeads = '#content h2'
+```
+
+to
+
+```
+var accordionHeads = '#content h3'
+```
+
+You should also set which accordion section should open by default, if a user comes to a chapter without selecting an accordion. The default setting opens the first `h2` by default:
+
+```
+var defaultAccordionHead = '#content h2:first-of-type'
+```
+
+You can change `h2` to `h3` here, for instance, or just leave it blank to not set a default, in which case all accordions will be closed when a user comes to a chapter without selecting an accordion:
+
+```
+var defaultAccordionHead = ''
+```

--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -147,6 +147,7 @@ $web-search: true !default;
 $web-nav-bar: true !default;
 $web-footer: true !default;
 $web-language-select: true !default;
+$web-accordion: true !default;
 
 // Book parts
 $web-cover: true !default;
@@ -210,6 +211,7 @@ $web-reset-sequences: true !default; // This should stay last in the @import lis
 @import "partials/web-search";
 @import "partials/web-footer";
 @import "partials/web-language-select";
+@import "partials/web-accordion";
 
 // Book parts
 @import "partials/web-cover";

--- a/_sass/partials/_web-accordion.scss
+++ b/_sass/partials/_web-accordion.scss
@@ -1,0 +1,44 @@
+$web-accordion: true !default;
+@if $web-accordion {
+
+    // Accordions
+    [role="tab"] {
+        position: relative;
+        padding-right: $line-height-default;
+        &:hover {
+            cursor: pointer;
+        }
+        a {
+            color: $color-accent;
+            &:first-of-type {
+                margin-right: 0.4em;
+            }
+        }
+        &:after {
+            position: absolute;
+            top: 0;
+            right: 0;
+        }
+    }
+
+    [data-accordion="closed"] {
+        @media (min-width: $break-point-width) {
+            font-size: $font-size-default;
+        }
+        &:after {
+            content: $nav-bar-children-prompt;
+        }
+    }
+
+    [data-accordion="open"] {
+        margin-top: $line-height-default;
+        &:after {
+            content: $nav-bar-children-prompt-hide;
+        }
+    }
+
+    [aria-expanded="false"] {
+        display: none;
+    }
+
+}

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -147,6 +147,7 @@ $web-search: true !default;
 $web-nav-bar: true !default;
 $web-footer: true !default;
 $web-language-select: true !default;
+$web-accordion: true !default;
 
 // Book parts
 $web-cover: true !default;
@@ -210,6 +211,7 @@ $web-reset-sequences: true !default; // This should stay last in the @import lis
 @import "partials/web-search";
 @import "partials/web-footer";
 @import "partials/web-language-select";
+@import "partials/web-accordion";
 
 // Book parts
 @import "partials/web-cover";

--- a/assets/js/accordion.js
+++ b/assets/js/accordion.js
@@ -1,0 +1,471 @@
+"use strict";
+
+console.log('Debugging accordions.js');
+
+// --------------------------------------------------------------
+// Options
+// 
+// 1. Use CSS selectors to list the headings that will
+//    define each accordion section, e.g. '#content h2'
+var accordionHeads = '#content h3'
+// 2. Which heading's section should we show by default?
+var defaultAccordionHead = '#content h3:first-of-type'
+// --------------------------------------------------------------
+
+function ebAccordionInit() {
+    return navigator.userAgent.indexOf('Opera Mini') === -1 &&
+        'querySelectorAll' in document &&
+        'addEventListener' in window &&
+        !!Array.prototype.forEach;
+}
+
+function ebAccordionSetUpSections(collapserButtons) {
+
+    if (!document.querySelector(accordionHeads)) return;
+    document.querySelector(defaultAccordionHead).id = 'defaultAccordionSection';
+
+    // add role="tablist" to the parent of the role="tab"s
+    var content = document.querySelector('#content');
+    content.setAttribute('role', 'tablist');
+
+    // loop through collapserButtons
+    collapserButtons.forEach(function(collapserButton) {
+
+        // make a section to move the collapsing content into
+        var section = document.createElement('section');
+        section.setAttribute('role', 'tabpanel');
+        section.setAttribute('aria-labelledby', collapserButton.id);
+        section.setAttribute('data-accordion-container', collapserButton.id);
+
+        // add the section to the doc
+        content.insertBefore(section, collapserButton);
+
+
+        // make a header, add it to the section
+        var header = document.createElement('header');
+
+        //  move the toggle to the header
+        header.appendChild(collapserButton);
+
+        // make a link for this id
+        var accordionLink = document.createElement('a');
+        accordionLink.href = '#' + collapserButton.id;
+        accordionLink.innerHTML = collapserButton.innerHTML;
+
+        // Add the link inside the toggle
+        collapserButton.innerHTML = accordionLink.outerHTML;
+        collapserButton.setAttribute('role', 'tab');
+
+        // add the header to the section
+        section.appendChild(header);
+
+
+        // make a div for the rest of the contents
+        var container = document.createElement('div');
+        container.setAttribute('data-container', true);
+
+        // add it to the section
+        section.appendChild(container);
+    });
+}
+
+function ebAccordionFillSections() {
+    // grab the individual #contents elements of the page
+    var contentItems = document.querySelectorAll('#content > *');
+
+    var currentSection = false;
+    // loop through it
+    contentItems.forEach(function(contentItem) {
+
+        // if this is a section, update currentSection, then move on
+        if (contentItem.getAttribute('role') === 'tabpanel') {
+            currentSection = contentItem;
+            return;
+        }
+
+        // have we reached the first section yet? if not, move on
+        if (!currentSection) return;
+
+        // otherwise, move it inside the currentSection's data-container
+        currentSection.querySelector('[data-container]')
+                      .appendChild(contentItem);
+    });
+}
+
+function ebMoveThemeKeys() {
+    // get the theme keys and the theme key links
+    var themeKeys = document.querySelectorAll('.theme-key');
+    var themeKeysLinks = document.querySelectorAll('.theme-key a');
+
+    themeKeysLinks.forEach(function(themeKeysLink) {
+        // up to themeKeys div, up to data-container, up to section,
+        // on to next section, down to heading, down to h2
+        themeKeysLink.parentNode.parentNode.parentNode
+                     .nextElementSibling.firstChild.firstChild
+                     .appendChild(themeKeysLink);
+    })
+
+    // remove now empty theme keys divs
+    themeKeys.forEach(function(themeKey) {
+        themeKey.parentNode.removeChild(themeKey);
+    })
+}
+
+function ebAccordionHideAll() {
+    var tabPanels = document.querySelectorAll('[role="tabpanel"]');
+    tabPanels.forEach(function(current) {
+        current.querySelector('[role="tab"]')
+               .setAttribute('data-accordion', 'closed');
+        current.querySelector('[data-container]')
+               .setAttribute('aria-expanded', 'false');
+    });
+}
+
+function ebAccordionHideAllExceptThisOne(targetID) {
+
+    console.log('Starting ebAccordionHideAllExceptThisOne...');
+
+    var tabPanels = document.querySelectorAll('[role="tabpanel"]');
+    tabPanels.forEach(function(tabPanel) {
+        // if it's the one we just clicked, skip it
+        if(tabPanel.getAttribute('aria-labelledby') === targetID) return;
+
+        // otherwise, hide it
+        tabPanel.querySelector('[role="tab"]')
+               .setAttribute('data-accordion', 'closed');
+        tabPanel.querySelector('[data-container]')
+               .setAttribute('aria-expanded', 'false');
+    });
+}
+
+function ebAccordionCheckParent(node) {
+
+    if(node != null) {
+        console.log('Checking for parent element of "' + node.innerText.substring(0, 20) + '..."');
+    }
+
+    // if there is no parent, or something went wrong, exit
+    if(!node) return false;
+    if(!node.parentNode) return false;
+    if(node.tagName == "BODY") {
+
+        console.log('Parent node is the body element. We\'re done looking.');
+
+        return false;
+    }
+
+    var nodeParent = node.parentNode;
+
+    console.log('nodeParent is "' + nodeParent.innerText.substring(0,20) + '..."');
+
+    var parentAttribute = nodeParent.getAttribute('data-accordion-container');
+
+    // if there's a parent, check if it's got data-accordion-container
+    // and return that value, which is copied from the id of the section heading
+    if(parentAttribute) {
+        return nodeParent.getAttribute('data-accordion-container');
+    } else {
+        console.log('Parent node of "' + node.innerText.substring(0,20) + '..." is not an accordion section');
+    }
+
+    return ebAccordionCheckParent(nodeParent);
+}
+
+// find and return containing section
+// (the aria-labelledby attribute matches the ID)
+function ebAccordionFindSection(targetToCheck) {
+
+    if(targetToCheck != null) {
+        console.log('Finding section that contains: ' + targetToCheck.outerHTML.substring(0,80));
+    }
+
+    // work recursively up the DOM looking for the section
+    return ebAccordionCheckParent(targetToCheck);
+}
+
+function ebWhichTarget(targetID) {
+
+    console.log('Starting ebWhichTarget...');
+
+    var targetToCheck;
+
+    // if we're given an ID, use it
+    if(targetID) {
+        console.log('Using targetID ' + targetID);
+
+        // Decode the targetID URI in case it's not ASCII
+        console.log('targetID encoded: ' + targetID);
+        var targetID = decodeURIComponent(targetID);
+        console.log('targetID decoded: ' + targetID);
+
+        targetToCheck = document.getElementById(targetID);
+    } else {
+        // else use the hash
+        var trimmedHash = window.location.hash.replace('#', '');
+
+        // Decode the trimmedHash in case it's not ASCII
+        console.log('Using trimmedHash; encoded: ' + trimmedHash);
+        var trimmedHash = decodeURIComponent(trimmedHash);
+        console.log('using trimmedHash; decoded: ' + trimmedHash);
+
+        targetToCheck = document.getElementById(trimmedHash);
+    }
+
+
+    // if the ID doesn't exist, exit
+    if(!targetToCheck) {
+        return false;
+    }
+
+    return targetToCheck;
+}
+
+function ebAccordionShow(targetID) {
+
+    console.log('Starting ebAccordionShow...');
+    console.log('ebAccordionShow\'s targetID is: ' + targetID);
+
+    var targetToCheck = ebWhichTarget(targetID);
+    if (!targetToCheck) return;
+
+    var sectionID = ebAccordionFindSection(targetToCheck);
+    // if there's a section to show
+    if (!sectionID) return;
+
+    // set the accordion, then work down to toggle and content div
+    var sectionTarget = '[aria-labelledby="' + sectionID +'"]';
+    var sectionToShow = document.querySelector(sectionTarget);
+
+    // update the tab
+    var tab = sectionToShow.querySelector('[role="tab"]');
+    tab.setAttribute('data-accordion', 'open')
+
+    // update the tab contents
+    var tabContents = sectionToShow.querySelector('[data-container]');
+    tabContents.setAttribute('aria-expanded', 'true');
+
+    // lazyload the images inside
+    var lazyimages = sectionToShow.querySelectorAll('[data-srcset]');
+    console.log('lazyimages: ' + lazyimages.innerHTML);
+    if (lazyimages.innerHTML != undefined) {
+        ebLazyLoadImages(lazyimages);
+    }
+
+    // if we have a slideline in this section, check if it's a portrait one
+    var slidelinesInThisSection = sectionToShow.querySelectorAll('.slides');
+
+    slidelinesInThisSection.forEach(function(slidelineInThisSection) {
+        var firstFigureImg = slidelineInThisSection.querySelector('.figure img');
+
+        if (firstFigureImg) {
+            firstFigureImg.addEventListener('load', function() {
+                var portraitSlideline = (firstFigureImg.height > firstFigureImg.width);
+                if(portraitSlideline) {
+                    slidelineInThisSection.querySelector('nav').classList.add('nav-slides-portrait');
+                }
+            })
+        };
+    })
+
+    if(typeof(videoShow) === 'function') {
+        videoShow(sectionToShow);
+    }
+}
+
+function ebAccordionListenForAnchorClicks() {
+
+    console.log('Starting ebAccordionListenForAnchorClicks...');
+
+    // listen for clicks on *all* the anchors (;_;)
+    var allTheAnchors = document.querySelectorAll('#content a');
+    allTheAnchors.forEach(function(oneOfTheAnchors) {
+
+        // if it's an external link, exit
+        if(oneOfTheAnchors.target === '_blank') return;
+
+        oneOfTheAnchors.addEventListener("click", function(ev) {
+
+            ev.stopPropagation();
+
+            // ignore target blank / rel noopener links
+            if(this.getAttribute('rel') === 'noopener') return;
+
+            // get the target ID by removing any file path and the #
+            if(this.hasAttribute('href')) {
+                var targetID = this.getAttribute('href').replace(/.*#/, '');
+                console.log('The targetID is: ' + targetID);
+            } else {
+                return;
+            }
+            // if it's an open accordion, close it
+            if(this.parentNode.getAttribute('data-accordion') === 'open') {
+                ebAccordionHideAll();
+                return;
+            }
+
+            // did we click on a thing that wasn't an accordion?
+            // which section / accordion is it inside?
+            if(!this.parentNode.getAttribute('data-accordion')) {
+
+                console.log('We clicked on something that is not an accordion. Now to find targetID ' + targetID + ' in the DOM...');
+
+                // find the target of the link in the DOM
+                var targetOfLink = document.getElementById(targetID);
+                // recursively update targetID until we have a data-accordion
+                targetID = ebAccordionFindSection(targetOfLink);
+            }
+
+            // now open the right closed accordion
+            ebAccordionShow(targetID);
+            ebAccordionHideAllExceptThisOne(targetID);
+        })
+    })
+}
+
+function ebAccordionListenForHeadingClicks() {
+    // also listen for heading clicks
+    var allTheToggleHeaders = document.querySelectorAll('[data-accordion]');
+    allTheToggleHeaders.forEach(function(oneOfTheToggleHeaders) {
+        oneOfTheToggleHeaders.addEventListener("click", function() {
+            // simulate anchor click
+            this.querySelector('a').click();
+        })
+    })
+}
+
+function ebAccordionListenForNavClicks() {
+    // also listen for nav clicks
+    var navLinks = document.querySelectorAll('#nav [href]');
+    navLinks.forEach(function(navLink) {
+        navLink.addEventListener("click", function() {
+            // get the section and click to open it if it's closed
+            var theSection = document.getElementById(this.hash.replace(/.*#/, ''));
+            // simulate anchor click, if it's closed
+            if(theSection) {
+                if(theSection.getAttribute('data-accordion') === 'closed') {
+                    theSection.querySelector('a').click();
+                }
+            }
+        })
+    })
+}
+
+function ebAccordionListenForHashChange() {
+
+    console.log('Starting ebAccordionListenForHashChange...');
+
+    window.addEventListener("hashchange", function() {
+        // get the target ID from the hash
+        var targetID = window.location.hash;
+        console.log('targetID encoded: ' + targetID);
+        var targetID = decodeURIComponent(targetID);
+        console.log('targetID decoded: ' + targetID);
+        // get the target of the link
+        var targetOfLink = document.getElementById(targetID.replace(/.*#/, ''));
+        console.log('targetOfLink: ' + targetOfLink.innerHTML);
+
+        // check if it's in the viewport already
+        var targetRect = targetOfLink.getBoundingClientRect();
+        var targetInViewport = targetRect.top >= - targetRect.height
+                            && targetRect.left >= - targetRect.width
+                            && targetRect.bottom <= targetRect.height + window.innerHeight
+                            && targetRect.right <= targetRect.width + window.innerWidth;
+
+        // check if it's an accordion
+        var targetAccordionStatus = targetOfLink.getAttribute('data-accordion');
+
+        // if it's in the viewport and it's not an accordion, then exit
+        if(targetInViewport && !targetAccordionStatus) return;
+
+        // if it's an accordion and it's closed, open it / jump to it
+        if(targetAccordionStatus === 'closed') {
+            targetOfLink.querySelector('a').click();
+            return;
+        }
+
+        // otherwise, open the appropriate accordion
+        var targetAccordionID = ebAccordionFindSection(targetOfLink);
+
+        ebAccordionShow(targetAccordionID);
+        ebAccordionHideAllExceptThisOne(targetAccordionID);
+    });
+}
+
+function ebAccordify() {
+    // early exit for older browsers
+    if (!ebAccordionInit()) return;
+
+    // exit if there aren't any headings
+    var collapserTargets = accordionHeads;
+    var collapserButtons = document.querySelectorAll(collapserTargets);
+    if (!collapserButtons) return;
+
+    // exit if this isn't a chapter
+    var thisIsNotAChapter = (document.querySelector('body').getAttribute('class').indexOf('chapter') === -1);
+    var thisHasNoH2s = (document.querySelector(accordionHeads) === null);
+    var thisIsEndmatter = (document.querySelector('body').getAttribute('class').indexOf('endmatter') !== -1);
+    if(thisIsNotAChapter || thisHasNoH2s || thisIsEndmatter) return;
+
+    ebAccordionSetUpSections(collapserButtons);
+    ebAccordionFillSections();
+    ebMoveThemeKeys();
+
+    if(searchTerm) {
+        // loop through sections
+        var accordionSections = document.querySelectorAll('section[data-accordion-container]');
+        accordionSections.forEach(function(accordionSection) {
+
+            // check for any markjs marks
+            var searchTermsInSection = accordionSection.querySelectorAll('[data-markjs]');
+            var numberOfSearchTermsInSection = searchTermsInSection.length;
+
+            // mark the sections that have the search term inside
+            if(!!numberOfSearchTermsInSection) {
+                var sectionHeaderLink = accordionSection.querySelector('header a');
+                sectionHeaderLink.innerHTML = '<mark>' + sectionHeaderLink.innerHTML + '</mark>';
+
+                // add a mini-summary paragraph
+                var searchResultsMiniSummary = document.createElement('p');
+                searchResultsMiniSummary.innerHTML = numberOfSearchTermsInSection + ' search results for ' + '"<mark>' + searchTerm + '</mark>"';
+                accordionSection.querySelector('header').appendChild(searchResultsMiniSummary);
+            }
+        });
+
+        // add a summary before the first section
+        var searchTerms = document.querySelectorAll('[data-markjs]');
+        var numberOfSearchTerms = searchTerms.length;
+        if(!!numberOfSearchTerms) {
+            // make the summary paragraph
+            var searchResultsSummary = document.createElement('p');
+            searchResultsSummary.classList.add('search-results-summary')
+            searchResultsSummary.innerHTML = numberOfSearchTerms + ' search results for ' + '"<mark>' + searchTerm + '</mark>".';
+
+            // add it after the main heading
+            var mainHeading = document.querySelector('h1');
+            var contentDiv =  document.querySelector('#content');
+
+            contentDiv.insertBefore(searchResultsSummary, mainHeading.nextSibling);
+
+            // add a link to the first result
+            searchTerms[0].id = 'first-search-result';
+            searchResultsSummary.innerHTML += ' <a href="#first-search-result">Jump to first result &darr;</a>.'
+        }
+    }
+
+    // if there's no hash, show the first section
+    // else (there is a hash, so) show that section
+    if(!window.location.hash) {
+        ebAccordionHideAllExceptThisOne('defaultAccordionSection');
+        ebAccordionShow('defaultAccordionSection');
+        return;
+    }
+
+    ebAccordionHideAll();
+    ebAccordionShow();
+}
+
+ebAccordify();
+ebAccordionListenForAnchorClicks();
+ebAccordionListenForHeadingClicks();
+ebAccordionListenForNavClicks();
+ebAccordionListenForHashChange();

--- a/assets/js/accordion.js
+++ b/assets/js/accordion.js
@@ -7,9 +7,9 @@ console.log('Debugging accordions.js');
 // 
 // 1. Use CSS selectors to list the headings that will
 //    define each accordion section, e.g. '#content h2'
-var accordionHeads = '#content h3'
+var accordionHeads = '#content h2'
 // 2. Which heading's section should we show by default?
-var defaultAccordionHead = '#content h3:first-of-type'
+var defaultAccordionHead = '#content h2:first-of-type'
 // --------------------------------------------------------------
 
 function ebAccordionInit() {
@@ -22,7 +22,13 @@ function ebAccordionInit() {
 function ebAccordionSetUpSections(collapserButtons) {
 
     if (!document.querySelector(accordionHeads)) return;
-    document.querySelector(defaultAccordionHead).id = 'defaultAccordionSection';
+
+    // Give the default accordion section an id, if it's set
+    if (defaultAccordionHead != '') {
+        if (document.querySelector(defaultAccordionHead)) {
+            document.querySelector(defaultAccordionHead).id = 'defaultAccordionSection';
+        }
+    }
 
     // add role="tablist" to the parent of the role="tab"s
     var content = document.querySelector('#content');

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -7,3 +7,11 @@ layout: null
 {% include_relative mark.min.js %}
 {% include_relative mark-search-terms.js %}
 {% include_relative videos.js %}
+
+{% comment %} Enable the content accordion in _data settings.yml,
+and define its options in assets/accordion.js {% endcomment %}
+{% if site.output == "web" and site.data.settings.web.accordion == true %}
+	{% include_relative accordion.js %}
+{% elsif site.output == "app" and site.data.settings.app.accordion == true %}
+	{% include_relative accordion.js %}
+{% endif %}

--- a/book/styles/app.scss
+++ b/book/styles/app.scss
@@ -151,6 +151,7 @@ $web-search: true;
 $web-nav-bar: true;
 $web-footer: true;
 $web-language-select: true;
+$web-accordion: true;
 
 // Book parts
 $web-cover: true;

--- a/book/styles/web.scss
+++ b/book/styles/web.scss
@@ -151,6 +151,7 @@ $web-search: true;
 $web-nav-bar: true;
 $web-footer: true;
 $web-language-select: true;
+$web-accordion: true;
 
 // Book parts
 $web-cover: true;


### PR DESCRIPTION
This adds the ability to have sections in chapters collapse into expandable sections. This is especially useful in books with long chapters. As I've noted in the docs in this PR:

A book chapter can be much too long for reasonable reading on screen. Also, a chapter might contain many images, and downloading them all every time you read just part of the chapter could use up a lot of a user's data. For these reasons, you can turn on a content accordion for web and app pages.

The content accordion breaks up your page into sections, and collapses them, showing only each section's heading. To open or close a section, a user just clicks on the heading (or the toggle icon beside it).

In addition, images in figures will only load when a section is opened. This way, if a user doesn't open a given section, their device won't download it, saving them data.

The content accordion only works in chapter files (i.e. markdown files that do not have a `style` set in their YAML frontmatter, or have it set to something other than `chapter`, such as frontmatter).

#### Activating the content accordion

To turn on the content accordion, change the value of `accordion` in `_data.settings.yml` to `true`:

```
  accordion: true
```

This is set separately for `web` and `app` outputs. So you'll find in `settings.yml` that you can set `accordion` in two places.

#### Setting the accordion heading level

By default, the content accordion collapses on `h2`s. You can change this in the `// Options` section of `assets/js/accordion.js`. For instance, to set the accordion to collapse on third-level headings, change:

```
var accordionHeads = '#content h2'
```

to

```
var accordionHeads = '#content h3'
```

You should also set which accordion section should open by default, if a user comes to a chapter without selecting an accordion. The default setting opens the first `h2` by default:

```
var defaultAccordionHead = '#content h2:first-of-type'
```

You can change `h2` to `h3` here, for instance, or just leave it blank to not set a default, in which case all accordions will be closed when a user comes to a chapter without selecting an accordion:

```
var defaultAccordionHead = ''
```

Thanks to @SteveBarnett who created the original Javascript in `accordion.js`, which I've lightly tweaked.