### PR TITLE
Project logo in metadata

### DIFF
--- a/_includes/metadata
+++ b/_includes/metadata
@@ -27,6 +27,7 @@ These values can be overridden in _data/locales.yml for translations.
 {% capture project-email %}{{ site.data.meta.project.email }}{% endcapture %}
 {% capture project-name %}{{ site.data.meta.project.name }}{% endcapture %}
 {% capture project-description %}{{ site.data.meta.project.description }}{% endcapture %}
+{% capture project-logo %}{{ site.data.meta.project.logo }}{% endcapture %}
 {% capture project-image %}{{ site.data.meta.project.image }}{% endcapture %}
 {% capture project-credit %}{{ site.data.meta.project.credit }}{% endcapture %}
 {% capture project-language %}{{ site.data.meta.project.language }}{% endcapture %}

--- a/_includes/page-info
+++ b/_includes/page-info
@@ -16,6 +16,7 @@ See all the metadata gathered for a given page.
 | Project email          | Defined in `meta.yml` | `project-email`        | {{ project-email }}        | String |
 | Project name           | Defined in `meta.yml` | `project-name`         | {{ project-name }}         | String |
 | Project description    | Defined in `meta.yml` | `project-description`  | {{ project-description }}  | String |
+| Project logo           | Defined in `meta.yml` | `project-logo`         | {{ project-logo }}         | String |
 | Project image          | Defined in `meta.yml` | `project-image`        | {{ project-image }}        | String |
 | Project credit         | Defined in `meta.yml` | `project-credit`       | {{ project-credit }}       | String |
 | Project language       | Defined in `meta.yml` | `project-language`     | {{ project-language }}     | String |


### PR DESCRIPTION
Distinguish between project image (e.g. for OG meta) and project logo (e.g. for title page).