### PR TITLE
Clean img alt tags

### DIFF
--- a/_includes/figure
+++ b/_includes/figure
@@ -30,7 +30,7 @@ because https://github.com/jekyll/jekyll/issues/2248.
 <div class="figure-images contains-{{ number-of-images }}">
     {%for image in figure-images %}
         {% if include.link %}<a href="{{ include.link }}">{% elsif site.output == "web" %}<a href="{{ images }}/{{ image }}">{% endif %}
-            <img src="{{ images }}/{{ image }}" alt="{% if include.title %}{{ include.title }}: {% endif %}{% if include.description %}{{ include.description }}{% else %}{{ include.caption }}{% endif %}{% if include.image-height != nil %} height-{{ include.image-height }}{% endif %}" />
+            <img src="{{ images }}/{{ image }}" alt="{% capture figure-image-alt-text %}{% if include.title %}{{ include.title }}: {% endif %}{% if include.description %}{{ include.description }}{% else %}{{ include.caption }}{% endif %}{% endcapture %}{{ figure-image-alt-text | replace: "&nbsp;", " " | replace: "&shy;", "" | markdownify | strip_html }}" {% if include.image-height != nil %}class="height-{{ include.image-height }}"{% endif %}/>
         {% if include.link or site.output == "web" %}</a>{% endif %}
     {% endfor %}
 </div>

--- a/_includes/image
+++ b/_includes/image
@@ -13,6 +13,15 @@ defaulting to src. {% endcomment %}
 	{% assign file-extension = include.src | split: "." | last %}
 {% endif %}
 
+{% comment %} Capture and clean any alt text. {% endcomment %}
+{% if include.alt %}
+    {% capture image-alt %}{{ include.alt 
+    | replace: "&nbsp;", " "
+    | replace: "&shy;", ""
+    | markdownify
+    | strip_html }}{% endcapture %}
+{% endif %}
+
 {% comment %} Adjust the value of `sizes` if your site design does not need
 full-width images everywhere. Here is a guide:
 https://builtvisible.com/responsive-images-for-busy-people-a-quick-primer/ {% endcomment %}
@@ -30,6 +39,6 @@ https://builtvisible.com/responsive-images-for-busy-people-a-quick-primer/ {% en
 
     {% if include.class %} class="{{ include.class }}"{% endif %}
     {% if include.id %} id="{{ include.id }}"{% endif %}
-    {% if include.alt %} alt="{{ include.alt }}"{% endif %} />
+    {% if image-alt %} alt="{{ image-alt }}"{% endif %} />
 
 {% endcapture %}{{ image-tag | strip_newlines | strip }}

--- a/samples/text/02-01-plain-images.md
+++ b/samples/text/02-01-plain-images.md
@@ -8,11 +8,11 @@ title: "Plain images"
 
 Also see the docs on [including images in content]({{ site.canonical-url }}/docs/editing/images.html) and [adding them to your project]({{ site.canonical-url }}/docs/images/adding-image-files.html).
 
-For exmaples of plain images, here's the first chapter of [*The Count of Monte Christo* by Alexandre Dumas](http://www.gutenberg.org/files/1184/1184-h/1184-h.htm){:#count-2}.
+For examples of plain images, here's the first chapter of [*The Count of Monte Christo* by Alexandre Dumas](http://www.gutenberg.org/files/1184/1184-h/1184-h.htm){:#count-2}.
 
 First, here is an SVG showing the relationships in this novel.
 
-{% include image file="count-of-monte-cristo-relations.svg" alt="https://commons.wikimedia.org" %}
+{% include image file="count-of-monte-cristo-relations.svg" alt="Image of network of relationships in The Count of Monte Christo from https://commons.wikimedia.org" %}
 [Relationships in *The Count of Monte Christo*](https://commons.wikimedia.org/wiki/File:CountOfMonteCristoRelations.svg#/media/File:CountOfMonteCristoRelations.svg). This is actually a paragraph that starts with an inline image, and has an `image-with-caption` class, which turns any text in this paragraph into a caption. The remaining images in this chapter are plain images, with no text or class attached.
 {:.image-with-caption}
 

--- a/samples/text/02-02-figures.md
+++ b/samples/text/02-02-figures.md
@@ -45,8 +45,8 @@ A program that employs the pre-cloak stage of superheroes has been active in Rwa
     image="fradkin-2.jpg"
     image-height="15"
     reference="Figure 2"
-    caption="On the pediatric ward of the A.C. Camargo Cancer Center, superhero IV covers transform children’s chemo drip into _Superformula_. Design & Branding © J. Walter Thompson, Brazil, 2016 (Accessed 15 May 2016)."
-    description="On the pediatric ward of the A.C. Camargo Cancer Center, superhero IV covers transform children’s chemo drip into _Superformula_. Design & Branding © J. Walter Thompson, Brazil, 2016 (Accessed 15 May 2016)."
+    caption="On the pediatric ward of the A.C. Camargo Cancer Center, superhero IV covers transform children’s chemo drip into _Superformula_. Design & Branding © J. Walter Thompson, Brazil, 2016 (Accessed 15&nbsp;May 2016)."
+    description="A poster that describes _Superformula to fight cancer_ covers, which have superhero logos on the covers of chemo drips. There is a batman logo on the cover in the foreground. Photos and text explain how the cover is attached."
 %}
 
 So where to go? I pondered on the future of the project; an effort conceived in several stages. The Rwandans were standing in the background. Therapists were asking what to do…. The cart was put in motion; it was rolling down the hill; but still, the next step was elusive. Then, bang! the answer hit me: A compilation! A directory for the therapists; in particular, those who work with high-risk children. I envisioned a sleek database; a gold-foil embossed book. I celebrated, having settled on direction. My compass was following the course.


### PR DESCRIPTION
Strip out HTML and common entities from image alt tags (esp for epub validity, since EPUB3 can't use named entities).