### PR TITLE
Fix some errors with app output on Windows

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -102,7 +102,7 @@
 
 
 {% elsif site.output == "app" %}
-<html{% if site.data.locales[language].direction %} dir="{{ site.data.locales[language].direction }}"{% endif %}>
+<html lang="{{ language }}"{% if site.data.locales[language].direction %} dir="{{ site.data.locales[language].direction }}"{% endif %}>
     <head>
 
     <title>

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -602,8 +602,14 @@ You may need to reload the web page once this server is running."
 			# Build the apps if required
 			if [ "$appbuildgenerateapp" = "a" ]
 				then
-				echo "Building Android app..."
 				cd _site/app
+	            echo "Removing old Android platform files..."
+	            cordova platform remove android
+	            echo "Fetching latest Android platform files..."
+	            call cordova platform add android
+	            echo "Preparing platforms and plugins..."
+	            call cordova prepare android
+				echo "Building Android app..."
 				if [ "$apprelease" = "y" ]
 					then
 						cordova build android --release
@@ -614,6 +620,10 @@ You may need to reload the web page once this server is running."
 				echo "Done. Opening folder containing Android app..."
 				# (On OSX, this will be open, not xdg-open.)
 				xdg-open _site/app/platforms/android/build/outputs/apk/
+
+				echo "Attempting to run app in emulator..."
+				cordova emulate android
+
 			# Building iOS not available on Linux, only newish Macs
 			elif [ "$appbuildgenerateapp" = "i" ]
 				then
@@ -639,6 +649,13 @@ You may need to reload the web page once this server is running."
 			elif [ "$appbuildgenerateapp" = "ai" ]
 				then
 				echo "Building Android app first, then iOS app."
+				cd _site/app
+	            echo "Removing old Android platform files..."
+	            cordova platform remove android
+	            echo "Fetching latest Android platform files..."
+	            call cordova platform add android
+	            echo "Preparing platforms and plugins..."
+	            call cordova prepare android
 				echo "Building Android app..."
 				if [ "$apprelease" = "y" ]
 					then
@@ -649,6 +666,10 @@ You may need to reload the web page once this server is running."
 				echo "Done. Opening folder containing Android app..."
 				# (On OSX, this will be open, not xdg-open.)
 				xdg-open _site/app/platforms/android/build/outputs/apk/
+
+				echo "Attempting to run app in emulator..."
+				cordova emulate android
+
 				echo "Building iOS app..."
 				if [ "$apprelease" = "y" ]
 					then

--- a/run-mac.command
+++ b/run-mac.command
@@ -604,8 +604,14 @@ You may need to reload the web page once this server is running."
 			# Build the apps if required
 			if [ "$appbuildgenerateapp" = "a" ]
 				then
-				echo "Building Android app..."
 				cd _site/app
+	            echo "Removing old Android platform files..."
+	            cordova platform remove android
+	            echo "Fetching latest Android platform files..."
+	            call cordova platform add android
+	            echo "Preparing platforms and plugins..."
+	            call cordova prepare android
+				echo "Building Android app..."
 				if [ "$apprelease" = "y" ]
 					then
 						cordova build android --release
@@ -616,6 +622,8 @@ You may need to reload the web page once this server is running."
 				echo "Done. Opening folder containing Android app..."
 				# (On Linux, this is xdg-open, not open.)
 				open _site/app/platforms/android/build/outputs/apk/
+				echo "Attempting to run app in emulator..."
+				cordova emulate android
 			# Building iOS not available on Linux, only newish Macs
 			elif [ "$appbuildgenerateapp" = "i" ]
 				then
@@ -641,6 +649,13 @@ You may need to reload the web page once this server is running."
 			elif [ "$appbuildgenerateapp" = "ai" ]
 				then
 				echo "Building Android app first, then iOS app."
+				cd _site/app
+	            echo "Removing old Android platform files..."
+	            cordova platform remove android
+	            echo "Fetching latest Android platform files..."
+	            call cordova platform add android
+	            echo "Preparing platforms and plugins..."
+	            call cordova prepare android
 				echo "Building Android app..."
 				if [ "$apprelease" = "y" ]
 					then
@@ -651,6 +666,10 @@ You may need to reload the web page once this server is running."
 				echo "Done. Opening folder containing Android app..."
 				# (On Linux, this is xdg-open, not open.)
 				open _site/app/platforms/android/build/outputs/apk/
+
+				echo "Attempting to run app in emulator..."
+				cordova emulate android
+
 				echo "Building iOS app..."
 				if [ "$apprelease" = "y" ]
 					then

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -761,6 +761,15 @@ set /p process=Enter a number and hit return.
             echo Building your Android app... If you get an error, make sure Cordova and Android Studio are installed.
             cd _site/app
 
+            :: Prepare for build
+            echo Removing old Android platform files...
+            call cordova platform remove android
+            echo Fetching latest Android platform files...
+            call cordova platform add android
+            echo Preparing platforms and plugins...
+            call cordova prepare android
+            echo Building app...
+
             if "%apprelease%"=="y" (
                 call cordova build android --release
             ) else (
@@ -769,6 +778,11 @@ set /p process=Enter a number and hit return.
 
             echo Opening folder containing app...
             %SystemRoot%\explorer.exe "%location%_site\app\platforms\android\build\outputs\apk"
+
+            :: Try to emulate
+            echo "Attempting to run app in emulator..."
+            call cordova emulate android
+
             :appbuildaftercordova
             cd "%location%"
 


### PR DESCRIPTION
This fixes some glitches in app output. I've added the same output-script fixes to the unix shell scripts, but haven't tested them yet.

Really the biggest headache with testing app output is how finicky the IDEs are (Android Studio, Visual Studio and XCode).