### PR TITLE
Baseline grid

### DIFF
--- a/_sass/partials/_print-baseline-grid.scss
+++ b/_sass/partials/_print-baseline-grid.scss
@@ -1,0 +1,17 @@
+$show-baseline-grid: false !default;
+@if $show-baseline-grid {
+
+	$color-baselines: lightblue !default;
+
+	@page {
+		// (Stripes! Thanks https://css-tricks.com/stripes-css/)
+		background-color: white;
+		background: linear-gradient(
+			$color-baselines 50%,
+			white 50%
+		);
+		// background-position: 0 $bleed;
+		background-size: 100% $line-height-default * 2;
+	}
+
+}

--- a/_sass/partials/_print-page-headers-footers-style.scss
+++ b/_sass/partials/_print-page-headers-footers-style.scss
@@ -9,6 +9,7 @@
 
 @mixin header-position() {
   vertical-align: top;
+  line-height: 1;
   margin-top: $header-space-from-top;
   text-align: $header-text-align;
 }
@@ -23,6 +24,7 @@
 
 @mixin footer-position() {
   vertical-align: bottom;
+  line-height: 1;
   margin-bottom: $footer-space-from-bottom;
   text-align: $footer-text-align;
 }

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -190,7 +190,7 @@ $header-case: uppercase !default; // none|capitalize|uppercase|lowercase|initial
 $footer-case: uppercase !default; // none|capitalize|uppercase|lowercase|initial|inherit;
 $header-letter-spacing: 0.1em !default;
 $footer-letter-spacing: 0.1em !default;
-$header-space-from-top: $margin-top / 2 !default;
+$header-space-from-top: $margin-top / 2 + ($line-height-default / 4) !default; // should align with baseline grid
 $footer-space-from-bottom: $margin-bottom / 2 !default;
 $header-text-align: center !default;
 $footer-text-align: center !default;
@@ -199,6 +199,10 @@ $footer-text-align: center !default;
 // Specify a colour for highlighting; use 'inherit' for none.
 $highlight-tightened: inherit !default;
 $highlight-loosened: inherit !default;
+
+// Show or hide a baseline grid, based on line-height-default.
+// Set to true to show or false to hide.
+$show-baseline-grid: false !default;
 
 // ---------------------------------
 // Set to false to turn partials off
@@ -285,6 +289,7 @@ $print-page-setup-lightning-source: false !default; // Removes crop marks and se
 @import "partials/print-hide-non-printing"; // Hides anything .non-printing
 @import "partials/print-fitting"; // Classes for floating, tracking, shrinking, etc.
 @import "partials/print-hyphenation"; // Sets hyphenation dictionary
+@import "partials/print-baseline-grid"; // Shows a baseline grid
 
 // ---------------------
 // Theme modules

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -190,7 +190,7 @@ $header-case: uppercase !default; // none|capitalize|uppercase|lowercase|initial
 $footer-case: uppercase !default; // none|capitalize|uppercase|lowercase|initial|inherit;
 $header-letter-spacing: 0.1em !default;
 $footer-letter-spacing: 0.1em !default;
-$header-space-from-top: $margin-top / 2 !default;
+$header-space-from-top: $margin-top / 2 + ($line-height-default / 4) !default; // should align with baseline grid
 $footer-space-from-bottom: $margin-bottom / 2 !default;
 $header-text-align: center !default;
 $footer-text-align: center !default;
@@ -199,6 +199,10 @@ $footer-text-align: center !default;
 // Specify a colour for highlighting; use 'inherit' for none.
 $highlight-tightened: inherit !default;
 $highlight-loosened: inherit !default;
+
+// Show or hide a baseline grid, based on line-height-default.
+// Set to true to show or false to hide.
+$show-baseline-grid: false !default;
 
 // ---------------------------------
 // Set to false to turn partials off
@@ -284,6 +288,7 @@ $print-page-headers-footers-style: true !default; // Sets styling for headers an
 @import "partials/print-hide-non-printing"; // Hides anything .non-printing
 @import "partials/print-fitting"; // Classes for floating, tracking, shrinking, etc.
 @import "partials/print-hyphenation"; // Sets hyphenation dictionary
+@import "partials/print-baseline-grid"; // Shows a baseline grid
 
 // ---------------------
 // Theme modules

--- a/book/styles/print-pdf.scss
+++ b/book/styles/print-pdf.scss
@@ -30,8 +30,8 @@ $edition-suffix: null;
 // First, we set several variables related to overall page setup.
 $page-width: 152mm;
 $page-height: 229mm;
-$margin-top: 20mm;
-$margin-bottom: 20mm;
+$margin-top: 60pt; // by setting this in points, you align with your baseline grid
+$margin-bottom: 60pt;
 $margin-outside: 20mm;
 $margin-inside: 20mm;
 $bleed: 3mm;
@@ -195,7 +195,7 @@ $header-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $footer-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $header-letter-spacing: 0.1em;
 $footer-letter-spacing: 0.1em;
-$header-space-from-top: $margin-top / 2;
+$header-space-from-top: $margin-top / 2 + ($line-height-default / 4);
 $footer-space-from-bottom: $margin-bottom / 2;
 $header-text-align: center;
 $footer-text-align: center;
@@ -204,6 +204,10 @@ $footer-text-align: center;
 // Specify a colour for highlighting; use 'inherit' for none.
 $highlight-tightened: inherit;
 $highlight-loosened: inherit;
+
+// Show or hide a baseline grid, based on line-height-default.
+// Set to true to show or false to hide.
+$show-baseline-grid: false;
 
 // ---------------------------------
 // Set to false to turn partials off

--- a/book/styles/screen-pdf.scss
+++ b/book/styles/screen-pdf.scss
@@ -30,8 +30,8 @@ $edition-suffix: null;
 // First, we set several variables related to overall page setup.
 $page-width: 152mm;
 $page-height: 229mm;
-$margin-top: 20mm;
-$margin-bottom: 20mm;
+$margin-top: 60pt; // by setting this in points, you align with your baseline grid
+$margin-bottom: 60pt;
 $margin-outside: 20mm;
 $margin-inside: 20mm;
 $bleed: 0;
@@ -195,7 +195,7 @@ $header-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $footer-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $header-letter-spacing: 0.1em;
 $footer-letter-spacing: 0.1em;
-$header-space-from-top: $margin-top / 2;
+$header-space-from-top: $margin-top / 2 + ($line-height-default / 4);
 $footer-space-from-bottom: $margin-bottom / 2;
 $header-text-align: center;
 $footer-text-align: center;
@@ -204,6 +204,10 @@ $footer-text-align: center;
 // Specify a colour for highlighting; use 'inherit' for none.
 $highlight-tightened: inherit;
 $highlight-loosened: inherit;
+
+// Show or hide a baseline grid, based on line-height-default.
+// Set to true to show or false to hide.
+$show-baseline-grid: false;
 
 // ---------------------------------
 // Set to false to turn partials off

--- a/samples/styles/print-pdf.scss
+++ b/samples/styles/print-pdf.scss
@@ -30,8 +30,8 @@ $edition-suffix: null;
 // First, we set several variables related to overall page setup.
 $page-width: 152mm;
 $page-height: 229mm;
-$margin-top: 20mm;
-$margin-bottom: 20mm;
+$margin-top: 60pt; // by setting this in points, you align with your baseline grid
+$margin-bottom: 60pt;
 $margin-outside: 20mm;
 $margin-inside: 20mm;
 $bleed: 3mm;
@@ -195,7 +195,7 @@ $header-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $footer-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $header-letter-spacing: 0.1em;
 $footer-letter-spacing: 0.1em;
-$header-space-from-top: $margin-top / 2;
+$header-space-from-top: $margin-top / 2 + ($line-height-default / 4);
 $footer-space-from-bottom: $margin-bottom / 2;
 $header-text-align: center;
 $footer-text-align: center;
@@ -204,6 +204,10 @@ $footer-text-align: center;
 // Specify a colour for highlighting; use 'inherit' for none.
 $highlight-tightened: inherit;
 $highlight-loosened: inherit;
+
+// Show or hide a baseline grid, based on line-height-default.
+// Set to true to show or false to hide.
+$show-baseline-grid: false;
 
 // ---------------------------------
 // Set to false to turn partials off

--- a/samples/styles/screen-pdf.scss
+++ b/samples/styles/screen-pdf.scss
@@ -30,8 +30,8 @@ $edition-suffix: null;
 // First, we set several variables related to overall page setup.
 $page-width: 152mm;
 $page-height: 229mm;
-$margin-top: 20mm;
-$margin-bottom: 20mm;
+$margin-top: 60pt; // by setting this in points, you align with your baseline grid
+$margin-bottom: 60pt;
 $margin-outside: 20mm;
 $margin-inside: 20mm;
 $bleed: 0;
@@ -195,7 +195,7 @@ $header-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $footer-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $header-letter-spacing: 0.1em;
 $footer-letter-spacing: 0.1em;
-$header-space-from-top: $margin-top / 2;
+$header-space-from-top: $margin-top / 2 + ($line-height-default / 4);
 $footer-space-from-bottom: $margin-bottom / 2;
 $header-text-align: center;
 $footer-text-align: center;
@@ -204,6 +204,10 @@ $footer-text-align: center;
 // Specify a colour for highlighting; use 'inherit' for none.
 $highlight-tightened: inherit;
 $highlight-loosened: inherit;
+
+// Show or hide a baseline grid, based on line-height-default.
+// Set to true to show or false to hide.
+$show-baseline-grid: false;
 
 // ---------------------------------
 // Set to false to turn partials off


### PR DESCRIPTION
This adds the ability to show a baseline grid, as stripes the width of the default line height in print. To show the baseline grid in print, you set:

`$show-baseline-grid: true`

in the book's `print-pdf.scss` or `screen-pdf.scss`.

It also sets the default top and bottom margins in PDF in points, which solves a long mystery about why text pages and chapter openers were not aligning.