### PR TITLE
Back button

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,7 +1,7 @@
 {% include metadata %}
 
 {% if site.output == "print-pdf" %}
-<!doctype html>
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="{{ language }}" xml:lang="{{ language }}"{% if site.data.locales[language].direction %} dir="{{ site.data.locales[language].direction }}"{% endif %}>
 <head>
     <title>
@@ -27,7 +27,7 @@
 
 
 {% elsif site.output == "screen-pdf" %}
-<!doctype html>
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="{{ language }}" xml:lang="{{ language }}"{% if site.data.locales[language].direction %} dir="{{ site.data.locales[language].direction }}"{% endif %}>
 <head>
     <title>
@@ -152,7 +152,7 @@
 
 
 {% else %}
-<!doctype html>
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="{{ language }}" xml:lang="{{ language }}"{% if site.data.locales[language].direction %} dir="{{ site.data.locales[language].direction }}"{% endif %}>
 <head>
     <title>

--- a/_includes/nav-button.html
+++ b/_includes/nav-button.html
@@ -1,1 +1,4 @@
-<a href="#nav">{{ locale.nav.menu }}</a>
+<div class="nav-buttons">
+	<a class="nav-back-button">{{ locale.nav.back }}</a>
+	<a class="nav-button" href="#nav">{{ locale.nav.menu }}</a>
+</div>

--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -109,6 +109,7 @@ $nav-bar-children-prompt-hide: "\2212" !default; // \2212 is an actual minus sig
 $nav-bar-scrollbar: true !default;
 $nav-bar-width: 15em !default;
 $nav-bar-fixed: true !default; // fixed is not fully supported on many mobile browsers
+$nav-bar-back-button-hide: false !default;
 $nav-bar-label-color: $color-light !default;
 $nav-bar-label-background-color: $masthead-background-color !default;
 $nav-bar-label-border-color: transparent !default;

--- a/_sass/partials/_web-nav-bar.scss
+++ b/_sass/partials/_web-nav-bar.scss
@@ -1,7 +1,29 @@
 $web-nav-bar: true !default;
+$nav-bar-back-button-hide: false !default;
 @if $web-nav-bar {
 
     // Navigation
+
+    .nav-buttons {
+        position: absolute;
+        top: 0;
+        left: 0;
+        margin: 0.5em;
+    }
+
+    .nav-back-button {
+        font-family: $font-text-secondary;
+        font-size: inherit;
+        color: $nav-bar-label-color;
+        background-color: $nav-bar-label-background-color;
+        border: $rule-thickness solid $nav-bar-label-border-color;
+        border-radius: $button-border-radius;
+        padding: 0.25em 0.5em;
+        cursor: pointer;
+        @if $nav-bar-back-button-hide {
+            display: none;
+        }
+    }
 
     [href="#nav"] {
         font-family: $font-text-secondary;
@@ -11,11 +33,9 @@ $web-nav-bar: true !default;
         border: $rule-thickness solid $nav-bar-label-border-color;
         border-radius: $button-border-radius;
         padding: 0.25em 0.5em;
-        margin: 0.25em;
-        position: absolute;
-        top: 0;
-        left: 0;
         .js-nav-open & {
+            // Covers screen area, to let users click
+            // anywhere on page to close nav bar
             right: 0;
             bottom: 0;
             background-color: rgba(0,0,0,0.5);
@@ -24,10 +44,15 @@ $web-nav-bar: true !default;
     // Reset position to fixed if $nav-bar-fixed: true
     $nav-bar-fixed: false !default;
     @if $nav-bar-fixed {
-        [href="#nav"] {
+        .nav-buttons {
             position: fixed;
             z-index: 1; // less than .js-nav #nav
         }
+        [href="#nav"] {
+             .js-nav-open & {
+                 z-index: inherit;
+             }
+         }
     }
 
     .visuallyhidden {

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -109,6 +109,7 @@ $nav-bar-children-prompt-hide: "\2212" !default; // \2212 is an actual minus sig
 $nav-bar-scrollbar: true !default;
 $nav-bar-width: 15em !default;
 $nav-bar-fixed: true !default; // fixed is not fully supported on many mobile browsers
+$nav-bar-back-button-hide: true !default;
 $nav-bar-label-color: $color-light !default;
 $nav-bar-label-background-color: $masthead-background-color !default;
 $nav-bar-label-border-color: transparent !default;

--- a/assets/js/locales.js
+++ b/assets/js/locales.js
@@ -89,16 +89,21 @@ function localiseText() {
     // We cannot localise the nav/TOC, since the root search page
     // always uses the parent-language. So we replace the nav
     // on the search page with a back button instead.
+    // In case we have a back button (`$nav-bar-back-button-hide; true` in scss)
+    // hide that one.
     var searchNavButtonToReplace = document.querySelector('.search-page [href="#nav"]');
     var searchNavDivToReplace = document.querySelector('.search-page #nav');
-    if (searchNavButtonToReplace) {
-        searchNavButtonToReplace.innerHTML = locales[pageLanguage].nav.back;
-        searchNavButtonToReplace.addEventListener('click', function(ev) {
-            ev.preventDefault();
-            console.log('Going back...');
-            window.history.back();
-        });
-
+    var navBackButton = document.querySelector('.nav-back-button');
+    if (searchNavButtonToReplace && navBackButton) {
+        if (document.referrer != "" || window.history.length > 0) {
+            navBackButton.remove();
+            searchNavButtonToReplace.innerHTML = locales[pageLanguage].nav.back;
+            searchNavButtonToReplace.addEventListener('click', function(ev) {
+                ev.preventDefault();
+                console.log('Going back...');
+                window.history.back();
+            });
+        };
     };
     if (searchNavDivToReplace) {
         searchNavDivToReplace.innerHTML = '';

--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -1,6 +1,6 @@
- "use strict";
+"use strict";
 
-(function () {
+function ebNav() {
 
   // let Opera Mini use the footer-anchor pattern
   if (navigator.userAgent.indexOf('Opera Mini') === - 1) {
@@ -35,7 +35,7 @@
         subMenus[i].querySelector('ol, ul').classList.add('visuallyhidden');
         subMenus[i].querySelector('a, .docs-list-title')
                    .insertAdjacentHTML('afterend', showChildrenButton);
-      }
+      };
 
       // show the menu when we click the link
       menuLink.addEventListener("click", function(ev) {
@@ -47,7 +47,7 @@
       var ebHideMenu = function() {
           menu.classList.add("visuallyhidden");
           document.documentElement.classList.remove('js-nav-open');
-      }
+      };
 
       // listen for clicks inside the menu
       menu.addEventListener("click", function(ev) {
@@ -58,7 +58,7 @@
             ev.preventDefault();
             ebHideMenu();
             return;
-        }
+        };
 
         // show the children when we click a .has-children
         if (clickedElement.hasAttribute("data-toggle-nav")) {
@@ -66,26 +66,51 @@
             clickedElement.classList.toggle('show-children');
             clickedElement.nextElementSibling.classList.toggle('visuallyhidden');
             return;
-        }
+        };
 
         // if it's an anchor with an href (an in-page link)
         if (clickedElement.tagName === "A" && clickedElement.getAttribute('href')) {
             ebHideMenu();
             return;
-        }
+        };
 
         // if it's an anchor without an href (a nav-only link)
         if (clickedElement.tagName === "A") {
             clickedElement.nextElementSibling.classList.toggle('show-children');
             clickedElement.nextElementSibling.nextElementSibling.classList.toggle('visuallyhidden');
             return;
-        }
+        };
 
 
       });
 
-    }
+      // This enables a back button, e.g. for where we don't have a
+      // browser or hardware back button, and we have Jekyll add one.
+      // This button is hidden in scss with `$nav-bar-back-button-hide: true;`.
+      // If the user has navigated (i.e. there is a document referrer),
+      // listen for clicks on our back button and go back when clicked.
+      // We check history.length > 2 because new tab plus landing page
+      // can constitute 2 entries in the history (varies by browser).
+      if (document.referrer != "" || window.history.length > 2) {
+        var navBackButton = document.querySelector('a.nav-back-button');
+        if (navBackButton) {
+            navBackButton.addEventListener('click', function(ev) {
+                ev.preventDefault();
+                console.log('Going back...');
+                window.history.back();
+            });
+        };
+      } else {
+          var navBackButton = document.querySelector('a.nav-back-button');
+          if (navBackButton) {
+            navBackButton.parentNode.removeChild(navBackButton);
+          };
+      };
 
-  }
+    };
 
-}());
+  };
+
+};
+
+ebNav();

--- a/book/styles/app.scss
+++ b/book/styles/app.scss
@@ -113,6 +113,7 @@ $nav-bar-children-prompt-hide: "\2212"; // \2212 is an actual minus sign
 $nav-bar-scrollbar: true;
 $nav-bar-width: 15em;
 $nav-bar-fixed: true;
+$nav-bar-back-button-hide: false;
 $nav-bar-label-color: $color-light;
 $nav-bar-label-background-color: $masthead-background-color;
 $nav-bar-label-border-color: transparent !default;

--- a/book/styles/web.scss
+++ b/book/styles/web.scss
@@ -113,6 +113,7 @@ $nav-bar-children-prompt-hide: "\2212"; // \2212 is an actual minus sign
 $nav-bar-scrollbar: true;
 $nav-bar-width: 15em;
 $nav-bar-fixed: true;
+$nav-bar-back-button-hide: true;
 $nav-bar-label-color: $color-light;
 $nav-bar-label-background-color: $masthead-background-color;
 $nav-bar-label-border-color: transparent !default;

--- a/samples/styles/app.scss
+++ b/samples/styles/app.scss
@@ -113,6 +113,7 @@ $nav-bar-children-prompt-hide: "\2212"; // \2212 is an actual minus sign
 $nav-bar-scrollbar: true;
 $nav-bar-width: 15em;
 $nav-bar-fixed: true;
+$nav-bar-back-button-hide: false;
 $nav-bar-label-color: $color-light;
 $nav-bar-label-background-color: $masthead-background-color;
 $nav-bar-label-border-color: transparent !default;

--- a/samples/styles/web.scss
+++ b/samples/styles/web.scss
@@ -113,6 +113,7 @@ $nav-bar-children-prompt-hide: "\2212"; // \2212 is an actual minus sign
 $nav-bar-scrollbar: true;
 $nav-bar-width: 15em;
 $nav-bar-fixed: true;
+$nav-bar-back-button-hide: true;
 $nav-bar-label-color: $color-light;
 $nav-bar-label-background-color: $masthead-background-color;
 $nav-bar-label-border-color: transparent !default;


### PR DESCRIPTION
When we create apps for iOS and Windows, most devices do not offer users a back button.

This PR adds a back button beside the 'Contents' button. The button is hidden by default for web output, and shown by default for app output. (This can be changed with `$nav-bar-back-button-hide` in scss.)
