### PR TITLE
Fixes the ability to set the nav-source as files

### DIFF
--- a/_includes/nav-list
+++ b/_includes/nav-list
@@ -1,63 +1,105 @@
 {% comment %}
-How this works:
-1. First we store the current file name as "current-file", so we can work out when
-   it's the active nav item.
-2. The "nav-tree" variable has been defined in the include tag that included this file,
-   usually starting with the nav list in meta.yml stored by metadata as "web-nav-tree".
-3. To include children items in that tree, this file includes itself recursively, 
-   redefining "nav-tree" each time as the children of the nav-tree it received originally.
-4. Turtles all the way down, as deep as the nav tree in meta.yml goes.
-Credit to Christian Specht for the inspiration:
-https://christianspecht.de/2014/06/18/building-a-pseudo-dynamic-tree-menu-with-jekyll/
+The nav list might be created from the files list or the nav list
+defined in meta.yml. This is defined in _config.yml as nav-source.
 {% endcomment %}
 
-{% comment %}If this is neither a text directory (i.e. in a book) nor a docs page,
-such as the home page or project search page...{% endcomment %}
-{% if is-book-subdirectory != true and is-docs-page != true %}
+{% if site.nav-source == "nav" %}
+  
+  {% comment %}
+  How this works:
+  1. First we store the current file name as "current-file", so we can work out when
+     it's the active nav item.
+  2. The "nav-tree" variable has been defined in the include tag that included this file,
+     usually starting with the nav list in meta.yml stored by metadata as "web-nav-tree".
+  3. To include children items in that tree, this file includes itself recursively, 
+     redefining "nav-tree" each time as the children of the nav-tree it received originally.
+  4. Turtles all the way down, as deep as the nav tree in meta.yml goes.
+  Credit to Christian Specht for the inspiration:
+  https://christianspecht.de/2014/06/18/building-a-pseudo-dynamic-tree-menu-with-jekyll/
+  {% endcomment %}
 
-  {% comment %}Get a list of all the pages we've output to check against{% endcomment %}
-  {% capture page-list %}{{ site.pages | remove: ".html" }}{% endcapture %}
+  {% comment %}If this is neither a text directory (i.e. in a book) nor a docs page,
+  such as the home page or project search page...{% endcomment %}
+  {% if is-book-subdirectory != true and is-docs-page != true %}
 
-  {% comment %}Create a nav list{% endcomment %}
-  <ol>
+    {% comment %}Get a list of all the pages we've output to check against{% endcomment %}
+    {% capture page-list %}{{ site.pages | remove: ".html" }}{% endcapture %}
 
-    {% for item in include.nav-tree | sort: "order" %}
-        <li class="{% unless page-list contains item.file %}no-file{% endunless %}
-        {% if item.children == nil %} no-children{% else %} has-children{% endif %}{% if item.class != nil %} {{ item.class }}{% endif %}">
-            <a {% if item.file != nil %}href="{{ path-to-root-directory }}{{ include.directory }}{% if is-translation %}/{{ language }}{% endif %}/text/{{ item.file }}.html{% if item.id != nil %}#{{ item.id }}{% endif %}"{% endif %} >
-                {{ item.label | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}
-            </a>
-            {% if item.children != nil %}
-              {% include nav-list nav-tree=item.children directory=include.directory %}
-            {% endif %}
-        </li>
-    {% endfor %}
+    {% comment %}Create a nav list{% endcomment %}
+    <ol>
 
-  </ol>
+      {% for item in include.nav-tree | sort: "order" %}
+          <li class="{% unless page-list contains item.file %}no-file{% endunless %}
+          {% if item.children == nil %} no-children{% else %} has-children{% endif %}{% if item.class != nil %} {{ item.class }}{% endif %}">
+              <a {% if item.file != nil %}href="{{ path-to-root-directory }}{{ include.directory }}{% if is-translation %}/{{ language }}{% endif %}/text/{{ item.file }}.html{% if item.id != nil %}#{{ item.id }}{% endif %}"{% endif %} >
+                  {{ item.label | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}
+              </a>
+              {% if item.children != nil %}
+                {% include nav-list nav-tree=item.children directory=include.directory %}
+              {% endif %}
+          </li>
+      {% endfor %}
 
-{% comment %}Otherwise, we're in a text directory (i.e. in a book),
-and we're not on a docs page, create the full book nav.{% endcomment %}
-{% else %}
+    </ol>
 
-  {% capture nav-branch %}{{ include.nav-tree }}{% endcapture %}
-  {% capture page-list %}{{ site.pages | remove: ".html" }}{% endcapture %}
+  {% comment %}Otherwise, we're in a text directory (i.e. in a book),
+  and we're not on a docs page, create the full book nav.{% endcomment %}
+  {% else %}
 
-  <ol class="{% if nav-branch contains current-file %}active{% endif %}">
-    {% for item in include.nav-tree | sort: "order" %}
-        <li class="{% if page.url contains item.file %}active{% endif %}
-        {% unless page-list contains item.file %}no-file{% endunless %}
-        {% if item.link == "none" %}no-link{% endif %}
-        {% if item.children == nil %}no-children{% else %}has-children{% endif %}
-        {% if item.class != nil %}{{ item.class }}{% endif %}">
-            <a {% if item.file != nil and item.link != "none" %}href="{{ item.file }}.html{% if item.id != nil %}#{{ item.id }}{% endif %}"{% endif %}
-               class="{% if page.url contains item.file %}active{% endif %}">
-                {{ item.label | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}
-            </a>
-            {% if item.children != nil %}
-              {% include nav-list nav-tree=item.children %}
-            {% endif %}
-        </li>
-    {% endfor %}
-  </ol>
+    {% capture nav-branch %}{{ include.nav-tree }}{% endcapture %}
+    {% capture page-list %}{{ site.pages | remove: ".html" }}{% endcapture %}
+
+    <ol class="{% if nav-branch contains current-file %}active{% endif %}">
+      {% for item in include.nav-tree | sort: "order" %}
+          <li class="{% if page.url contains item.file %}active{% endif %}
+          {% unless page-list contains item.file %}no-file{% endunless %}
+          {% if item.link == "none" %}no-link{% endif %}
+          {% if item.children == nil %}no-children{% else %}has-children{% endif %}
+          {% if item.class != nil %}{{ item.class }}{% endif %}">
+              <a {% if item.file != nil and item.link != "none" %}href="{{ item.file }}.html{% if item.id != nil %}#{{ item.id }}{% endif %}"{% endif %}
+                 class="{% if page.url contains item.file %}active{% endif %}">
+                  {{ item.label | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}
+              </a>
+              {% if item.children != nil %}
+                {% include nav-list nav-tree=item.children %}
+              {% endif %}
+          </li>
+      {% endfor %}
+    </ol>
+
+  {% endif %}
+
+  {% comment %}
+  Otherwise, if the site.nav-source is anything or 'files',
+  build the nav-list from the files list in meta.yml.
+  {% endcomment %}
+
+  {% else %}
+
+    <ol>
+
+      {% comment %}If the include tag specifies a directory, we assume
+      we're already in a `for work in works` loop.{% endcomment %}
+      {% if include.directory %}
+        {% capture book-text-path %}{{ include.directory }}/text/{% endcapture %}
+        {% assign relevant-files = work.products[site.output].files %}
+      {% else %}
+        {% capture book-text-path %}{{ book-directory }}/{% if is-translation %}{{ book-subdirectory }}/{% endif %}text/{% endcapture %}
+        {% assign relevant-files = file-list %}
+      {% endif %}
+
+      {% assign relevant-pages = site.pages | where_exp: 'page', 'page.path contains book-text-path' | sort: "url" %}
+      {% capture this-page-path %}{{ page.path }}{% endcapture %}
+
+      {% for page in relevant-pages %}
+        {% capture relevant-page-filename %}{{ page.path | split: "." | first | split: "/" | last }}{% endcapture %}
+        {% if relevant-files contains relevant-page-filename %}
+          <li{% if relevant-page-filename == current-file and this-page-path contains book-text-path %} class="active"{% endif %}>
+            <a href="{{ page.url }}">{{ page.title }}</a>
+          </li>
+        {% endif %}
+      {% endfor %}
+
+    </ol>
 
 {% endif %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,140 +1,91 @@
-{% if site.nav-source == "nav" %}
+<div id="nav" class="non-printing">
 
-    <div id="nav" class="non-printing">
+        {% comment %}If we're neither in a book or a docs page,
+        show the project name.{% endcomment %}
+        {% if is-book-subdirectory != true and is-docs-page != true %}
+        <h2>{{ project-name }}</h2>
 
-            {% comment %}If we're neither in a book or a docs page,
-            show the project name.{% endcomment %}
-            {% if is-book-subdirectory != true and is-docs-page != true %}
-            <h2>{{ project-name }}</h2>
+        {% comment %}If docs are generating, and we're on a docs page
+        show a docs heading and version number{% endcomment %}
+        {% elsif output-docs == true and is-docs-page == true %}
+        <h2>Electric Book docs (v{{ site.version }})</h2>
 
-            {% comment %}If docs are generating, and we're on a docs page
-            show a docs heading and version number{% endcomment %}
-            {% elsif output-docs == true and is-docs-page == true %}
-            <h2>Electric Book docs (v{{ site.version }})</h2>
+        {% comment %}Otherwise show the book title{% endcomment %}
+        {% else %}
+        <h2>{{ title }}</h2>
+        {% endif %}
 
-            {% comment %}Otherwise show the book title{% endcomment %}
-            {% else %}
-            <h2>{{ title }}</h2>
+        {% comment %}Add the search box.{% endcomment %}
+        <div class="search">
+            {% include search %}
+        </div><!--.search-->
+
+        {% comment %}Create the nav list{% endcomment %}
+        <div class="nav-list">
+
+            {% comment %}If this is not the homepage,
+            include a link to the homepage.{% endcomment %}
+            {% if is-homepage != true %}
+                <ol class="nav-project-home">
+                    <li><a href="{{ path-to-root-directory }}index.html">{{ locale.nav.home }}</a></li>
+                </ol>
             {% endif %}
 
-            {% comment %}Add the search box.{% endcomment %}
-            <div class="search">
-                {% include search %}
-            </div><!--.search-->
+            {% comment %}If docs are on (i.e. output set to true in _config.yml),
+            show the docs nav.{% endcomment %}
+            {% if output-docs %}
+                <ul>
+                    <li{% unless is-docs-page %} class="has-children"{% endunless %}><a href="{{ path-to-root-directory }}docs">Docs</a>
+                    {% include docs-by-category %}
+                    </li>
+                </ul>
+            {% endif %}
 
-            {% comment %}Create the nav list{% endcomment %}
-            <div class="nav-list">
+            {% comment %}If this is any non-book, non-docs page,
+            such as the home page or project search...{% endcomment %}
+            {% if is-book-subdirectory != true and is-docs-page != true %}
 
-                {% comment %}If this is not the homepage,
-                include a link to the homepage.{% endcomment %}
-                {% if is-homepage != true %}
-                    <ol class="nav-project-home">
-                        <li><a href="{{ path-to-root-directory }}index.html">{{ locale.nav.home }}</a></li>
-                    </ol>
-                {% endif %}
+                {% comment %}If there is only one book, don't include its title{% endcomment %}
+                {% if number-of-works == 1 %}
 
-                {% comment %}If docs are on (i.e. output set to true in _config.yml),
-                show the docs nav.{% endcomment %}
-                {% if output-docs %}
-                    <ul>
-                        <li{% unless is-docs-page %} class="has-children"{% endunless %}><a href="{{ path-to-root-directory }}docs">Docs</a>
-                        {% include docs-by-category %}
-                        </li>
-                    </ul>
-                {% endif %}
-
-                {% comment %}If this is any non-book, non-docs page,
-                such as the home page or project search...{% endcomment %}
-                {% if is-book-subdirectory != true and is-docs-page != true %}
-
-                    {% comment %}If there is only one book, don't include its title{% endcomment %}
-                    {% if number-of-works == 1 %}
-
-                        {% for work in site.data.meta.works | sort: "order" %}
-                            {% assign home-nav-work-directory = work.directory %}
-                            {% assign home-nav-work-tree = work.products[site.output].nav %}
-                            {% include nav-list nav-tree=home-nav-work-tree directory=home-nav-work-directory %}
-                        {% endfor %}
-
-                    {% else %}
-
-                        <ol class="nav-book-list">
-                        {% for work in site.data.meta.works | sort: "order" %}
+                    {% for work in site.data.meta.works | sort: "order" %}
                         {% assign home-nav-work-directory = work.directory %}
                         {% assign home-nav-work-tree = work.products[site.output].nav %}
-                            <li class="has-children">
-                                <a href="{{ path-to-root-directory }}{{ work.directory }}/text/{{ work.products[site.output].start-page }}.html">
-                                    {{ work.title }}
-                                </a>
-                                {% include nav-list nav-tree=home-nav-work-tree directory=home-nav-work-directory %}
-                            </li>
-                        {% endfor %}
-                        </ol>
-
-                    {% endif %}
+                        {% include nav-list nav-tree=home-nav-work-tree directory=home-nav-work-directory %}
+                    {% endfor %}
 
                 {% else %}
 
-                    {% comment %}Fetch recursive navigation{% endcomment %}
-                    {% if site.output == "app" %}
-                        {% include nav-list nav-tree=app-nav-tree %}
-                    {% else %}
-                        {% include nav-list nav-tree=web-nav-tree %}
-                    {% endif %}
+                    <ol class="nav-book-list">
+                    {% for work in site.data.meta.works | sort: "order" %}
+                    {% assign home-nav-work-directory = work.directory %}
+                    {% assign home-nav-work-tree = work.products[site.output].nav %}
+                        <li class="has-children">
+                            <a href="{{ path-to-root-directory }}{{ work.directory }}/text/{{ work.products[site.output].start-page }}.html">
+                                {{ work.title }}
+                            </a>
+                            {% include nav-list nav-tree=home-nav-work-tree directory=home-nav-work-directory %}
+                        </li>
+                    {% endfor %}
+                    </ol>
 
                 {% endif %}
 
-            </div><!--.nav-list-->
-
-            <div class="widgets">
-                {% include widgets %}
-            </div><!--.widgets-->
-
-    </div><!--#nav-->
-
-{% else %}
-
-    <div id="nav" class="non-printing">
-
-            {% comment %}If we're neither in a book or a docs page{% endcomment %}
-            {% if is-book-subdirectory != true and is-docs-page != true %}
-            <h2>{{ project-name }}</h2>
-
-            {% comment %}If docs are generating, and we're on a docs page{% endcomment %}
-            {% elsif output-docs == "true" and is-docs-page == true %}
-            <h2>Electric Book docs (v{{ site.version }})</h2>
-
-            {% comment %}Otherwise use the book title{% endcomment %}
             {% else %}
-            <h2>{{ title }}</h2>
+
+                {% comment %}Fetch recursive navigation{% endcomment %}
+                {% if site.output == "app" %}
+                    {% include nav-list nav-tree=app-nav-tree %}
+                {% else %}
+                    {% include nav-list nav-tree=web-nav-tree %}
+                {% endif %}
+
             {% endif %}
 
-            {% comment %}Add the search box.{% endcomment %}
-            <div class="search">
-                {% include search %}
-            </div><!--.search-->
+        </div><!--.nav-list-->
 
-            <div class="nav-list">
-                <ul>
-                    {% comment %}
-                    - Get the file-list
-                    - Pull out file-titles in the file-list
-                    - If the file key has a value, that's a file-title
-                    - Put it in a list item, with a hyperlink pointing to the file
-                    - And if the current page.url contains the file name, this must be the active page
-                    - So add the class `nav-page-active` to the list item.
-                    {% endcomment %}
-                    {% for file in web-file-list %}
-                        {% for file-title in file %}
-                            {% if file-title[1] %}
-                                <li class="nav-page{% if page.url contains file-title[0] %} nav-page-active{% endif %}">
-                                    <a href="{{ path-to-root-directory }}{{ book-directory }}{% if is-translation %}/{{ language }}{% endif %}/text/{{ file-title[0] }}.html" class="nav-page-link">{{ file-title[1] }}</a>
-                                </li>
-                            {% endif %}
-                        {% endfor %}
-                    {% endfor %}
-                </ul>
-            </div><!--.nav-list-->
-        </div><!--#nav-->
+        <div class="widgets">
+            {% include widgets %}
+        </div><!--.widgets-->
 
-{% endif %}
+</div><!--#nav-->


### PR DESCRIPTION
For a long time the `nav-source: files` option in `_config.yml` hasn't worked. It wasn't really used, but on a recent project it would have been useful, because it's much faster to create a files list than nav yaml. This fixes that ability.

Setting `nav-source: files` in `_config.yml` now builds a flat nav bar based on the page titles of the files listed in a book's `files` list in `meta.yml`. (This only applies to the nav bar in web and app output; it does not affect TOCs.)