### PR TITLE
Avoid Firefox bug where tapping selects SVG as text

### DIFF
--- a/_sass/partials/_web-language-select.scss
+++ b/_sass/partials/_web-language-select.scss
@@ -40,6 +40,9 @@ $web-language-select: true !default;
 
     // Globe icon (_includes/globe-icon)
     svg.language-select-icon {
+        // Avoid Firefox bug where tapping selects SVG as text
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1286882
+        -moz-user-select: none;
         path {
             fill: $language-select-icon-color;
         }


### PR DESCRIPTION
Our language-select icon was affected by a bug in Firefox that triggers a text-selection when the icon is tapped. This is the workaround.

- Original bug report: https://bugzilla.mozilla.org/show_bug.cgi?id=1286882
- Workaround credit: https://github.com/metricsgraphics/metrics-graphics/issues/852#issuecomment-391355405)