### PR TITLE
Translation styles

### DIFF
--- a/_docs/editing/hyphenation.md
+++ b/_docs/editing/hyphenation.md
@@ -26,3 +26,39 @@ To show where a word or word-fragment can hyphenate, you add digits (1 to 9) to 
 *	The higher the number, the more important the rule. That is, a `1` says 'hyphenate here if you must', but a `9` says 'this is the best place to hyphenate'. A 2 says 'don't hyphenate here if you can help it', but an `8` says 'Do not, not, not hyphenate here.'
 
 For user discussion, see [the Prince forums here](http://www.princexml.com/forum/topic/542/prince-hyphenate-patterns-none-url-patterns-url): If you need to hack Prince's built-in hyphenation dictionaries more deeply, see [this forum post](http://www.princexml.com/forum/topic/1474/prince-and-hyphenation).
+
+## Use a custom dictionary
+
+To use a custom dictionary, save the dictionary file to your `styles` folder, and insert its filename in your book's `print-pdf.scss` and/or `screen-pdf.scss` files as the value of the `$hyphenation-dictionary` variable. For example:
+
+``` scss
+$hyphenation-dictionary: "hyphenation.dic";
+```
+
+In `hyphenation.dic`, you can add patterns as described above. If your `hyphenation.doc` starts with three-hyphen YAML frontmatter, Jekyll will process it, and you can use Liquid tags for extra power. For example, you can include other hyphenation pattern files saved alongside `hyphenation.dic`:
+
+{% raw %}
+``` md
+---
+# This YAML frontmatter makes Jekyll process this file.
+# So you can use Liquid tags to include files such as
+# other hyphenation dictionaries, e.g.
+# `{% include_relative hyph-en-gb.pat %}`
+# or to use hyphenation in certain cases, e.g. variants.
+---
+
+{% include_relative hyph-en-gb.pat %}
+```
+{% endraw %}
+
+Or you can use custom hyphenation only in specific [variants](../setup/variants.html) of your book:
+
+{% raw %}
+``` md
+{% if variant == "fantabulous" %}
+.fan3tab5ulous.
+{% endif %}
+```
+{% endraw %}
+
+Also see the guidance on styles in [translations](../setup/translations.html).

--- a/_docs/setup/translations.md
+++ b/_docs/setup/translations.md
@@ -33,7 +33,52 @@ The text files of each translation are saved in a `text` subdirectory. So all te
 
 ## Styles, fonts and images
 
-Translations inherit `styles`, `fonts` and `images` from the parent language, unless those folders exist in the translation directory.
+Translations inherit `styles`, `fonts` and `images` from the parent language, unless files in those folders exist in the translation directory.
+
+### Styles
+
+If you add a stylesheet to a translation's `styles` directory (e.g. `book/fr/styles/print-pdf.scss`), those styles are *added to* the parent CSS. Your pages will load the parent CSS, followed by your translation CSS.
+
+This way, you only need to add to your translation CSS those rules that override parent styles.
+
+You need to create a translation stylesheet for each format that you want to augment, and it must have the same name as its parent: `app.scss`, `epub.scss`, `print-pdf.scss`, `screen-pdf.scss`, and `web.scss`.
+
+For instance, say you've used a large quote mark before all blockquotes in English. In French, you may want to use a guillemet. Your French stylesheets might only contain this:
+
+``` scss
+---
+---
+
+blockquote:before {
+  content: "«";
+}
+
+```
+
+Note the three-hyphen YAML frontmatter, which tells Jekyll to process the file.
+
+An important, advanced example is custom [hyphenation](../editing/hyphenation.html). If your book's parent language is English, and you've used auto hyphenation with a custom hyphenation dictionary, you do not want your French translation to use your English hyphenation patterns. You want different custom hyphenation patterns for French. So in `book/fr/styles` you'll add a stylesheet for each output format, and a new custom hyphenation dictionary.
+
+Your new translation stylesheet might have this content:
+
+``` scss
+---
+# French translation styles
+# These override the parent language
+---
+
+$hyphenation: auto;
+$hyphenation-dictionary: "hyphenation.dic";
+@import 'partials/print-hyphenation'
+```
+
+This snippet:
+
+1. Uses three-hyphen YAML frontmatter so that Jekyll processes the Sass file.
+2. Sets new values for Sass variables `$hyphenation` and `$hyphenation-dictionary` that may be different from your parent-language styles. The `$hyphenation-dictionary` value points to a `hyphenation.dic` file saved alongside the translation stylesheet.
+3. Imports the relevant Sass partial `_print-hyphenation.scss` to override the parent-language version of the same partial.
+
+### Images
 
 This works well if your images contain no text, and all the images are the same in both the parent and translation languages.
 

--- a/_includes/epub-package
+++ b/_includes/epub-package
@@ -118,8 +118,15 @@
 
         <item id="epub-css" 
               media-type="text/css" 
-              href="{% if is-translation and translation-styles-exist %}{{ book-subdirectory }}/{% endif %}styles/{{ epub-stylesheet }}"
+              href="styles/{{ epub-stylesheet }}"
               />
+
+        {% if is-translation and translation-styles-exist %}
+        <item id="epub-css-{{ book-subdirectory }}" 
+              media-type="text/css" 
+              href="{{ book-subdirectory }}/styles/{{ epub-stylesheet }}"
+              />
+        {% endif %}
 
         {% comment %}Add images by looping through static files whose path
         contains the path to epub images.{% endcomment %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,6 +13,13 @@
     </title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {% comment %}If this is a translation with its own styles,
+    load the parent styles first, then translation styles override them.{% endcomment %}
+    {% if is-translation and translation-styles-exist %}
+        <link rel="stylesheet" type="text/css" href="{{ path-to-parent-styles-directory }}/{{ print-pdf-stylesheet }}" />
+    {% endif %}
+
     <link rel="stylesheet" type="text/css" href="{{ path-to-styles-directory }}/{{ print-pdf-stylesheet }}" />
 
     {% if site.mathjax-enabled == true %}
@@ -39,6 +46,13 @@
     </title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {% comment %}If this is a translation with its own styles,
+    load the parent styles first, then translation styles override them.{% endcomment %}
+    {% if is-translation and translation-styles-exist %}
+        <link rel="stylesheet" type="text/css" href="{{ path-to-parent-styles-directory }}/{{ screen-pdf-stylesheet }}" />
+    {% endif %}
+
     <link rel="stylesheet" type="text/css" href="{{ path-to-styles-directory }}/{{ screen-pdf-stylesheet }}" />
 
     {% if site.mathjax-enabled == true %}
@@ -66,6 +80,12 @@
 
     {% comment %}This full meta tag is necessary for Kindle's character encoding to work.{% endcomment %}
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+
+    {% comment %}If this is a translation with its own styles,
+    load the parent styles first, then translation styles override them.{% endcomment %}
+    {% if is-translation and translation-styles-exist %}
+        <link rel="stylesheet" type="text/css" href="{{ path-to-parent-styles-directory }}/{{ epub-stylesheet }}" />
+    {% endif %}
 
     <link rel="stylesheet" type="text/css" href="{{ path-to-styles-directory }}/{{ epub-stylesheet }}" />
     
@@ -137,7 +157,15 @@
         {% break %}
     {% endfor %}
     {% else %}
-    <link rel="stylesheet" type="text/css" media="all" href="{{ path-to-styles-directory }}/{{ app-stylesheet }}" />
+
+    {% comment %}If this is a translation with its own styles,
+    load the parent styles first, then translation styles override them.{% endcomment %}
+    {% if is-translation and translation-styles-exist %}
+        <link rel="stylesheet" type="text/css" href="{{ path-to-parent-styles-directory }}/{{ app-stylesheet }}" />
+    {% endif %}
+
+    <link rel="stylesheet" type="text/css" href="{{ path-to-styles-directory }}/{{ app-stylesheet }}" />
+
     {% endif %}
 
     {% if site.mathjax-enabled == true %}
@@ -209,7 +237,15 @@
         {% break %}
     {% endfor %}
     {% else %}
-    <link rel="stylesheet" type="text/css" media="all" href="{{ path-to-styles-directory }}/{{ web-stylesheet }}" />
+
+    {% comment %}If this is a translation with its own styles,
+    load the parent styles first, then translation styles override them.{% endcomment %}
+    {% if is-translation and translation-styles-exist %}
+        <link rel="stylesheet" type="text/css" href="{{ path-to-parent-styles-directory }}/{{ web-stylesheet }}" />
+    {% endif %}
+
+    <link rel="stylesheet" type="text/css" href="{{ path-to-styles-directory }}/{{ web-stylesheet }}" />
+
     {% endif %}
 
     {% if site.mathjax-enabled == true %}

--- a/_includes/metadata
+++ b/_includes/metadata
@@ -778,6 +778,7 @@ First, the default. Then if a translation, the translation's.{% endcomment %}
     {% endif %}
 
     {% if translation-styles-exist == true %}
+        {% capture path-to-parent-styles-directory %}{{ path-to-styles-directory }}{% endcapture %}
         {% capture path-to-styles-directory %}{{ path-to-book-directory }}{{ book-subdirectory }}/styles{% endcapture %}
     {% endif %}
 {% endif %}

--- a/_sass/partials/_print-hyphenation.scss
+++ b/_sass/partials/_print-hyphenation.scss
@@ -1,5 +1,11 @@
+// Set defaults
 $print-hyphenation: true !default;
-$hyphenation-custom: add !default;
+$hyphenation: manual !default; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)
+$hyphenation-dictionary: "" !default; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
+$hyphenate-after: 3 !default; // Minimum letters on new line after hyphen
+$hyphenate-before: 3 !default; // Minimum letters at end of line before hyphen
+$hyphenate-lines: 2 !default; // Preferred maximum number of consecutive lines ending with hyphens
+
 @if $print-hyphenation {
 
     // Hyphenation
@@ -21,8 +27,8 @@ $hyphenation-custom: add !default;
         }
     }
 
-    // In addition, if we want a custom dictionary to override all Prince
-    // built-in dictionaries, override its :root style.
+    // In addition, if we have a custom dictionary,
+    // override all Prince built-in dictionaries.
     :root,
     :lang(da),
     :lang(de),
@@ -39,7 +45,8 @@ $hyphenation-custom: add !default;
     :lang(ru),
     :lang(sl),
     :lang(sv) {
-        @if $hyphenation-custom == "replace" {
+        @if $hyphenation-dictionary == "" {}
+        @else {
             prince-hyphenate-patterns: url("#{$hyphenation-dictionary}");
         }
     }

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -92,7 +92,6 @@ $rule-thickness: 0.5pt !default;
 // Variables here apply to p, ul, ol, dl
 $hyphenation: manual !default; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)
 $hyphenation-dictionary: "" !default; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
-$hyphenation-custom: add !default; // add or replace. Whether your dictionary adds to or replaces the built-in Prince dictionaries
 $hyphenate-after: 3 !default; // Minimum letters on new line after hyphen
 $hyphenate-before: 3 !default; // Minimum letters at end of line before hyphen
 $hyphenate-lines: 2 !default; // Preferred maximum number of consecutive lines ending with hyphens

--- a/book/styles/print-pdf.scss
+++ b/book/styles/print-pdf.scss
@@ -97,7 +97,6 @@ $rule-thickness: 0.5pt;
 // Variables here apply to p, ul, ol, dl
 $hyphenation: manual; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)
 $hyphenation-dictionary: ""; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
-$hyphenation-custom: add; // add or replace. Whether your dictionary adds to or replaces the built-in Prince dictionaries
 $hyphenate-after: 3; // Minimum letters on new line after hyphen
 $hyphenate-before: 3; // Minimum letters at end of line before hyphen
 $hyphenate-lines: 2; // Preferred maximum number of consecutive lines ending with hyphens

--- a/book/styles/screen-pdf.scss
+++ b/book/styles/screen-pdf.scss
@@ -97,7 +97,6 @@ $rule-thickness: 0.5pt;
 // Variables here apply to p, ul, ol, dl
 $hyphenation: manual; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)
 $hyphenation-dictionary: ""; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
-$hyphenation-custom: add; // add or replace. Whether your dictionary adds to or replaces the built-in Prince dictionaries
 $hyphenate-after: 3; // Minimum letters on new line after hyphen
 $hyphenate-before: 3; // Minimum letters at end of line before hyphen
 $hyphenate-lines: 2; // Preferred maximum number of consecutive lines ending with hyphens

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -377,10 +377,11 @@ You may need to reload the web page once this server is running."
 				else
 					mkdir "$location"/_site/epub/images && cp -a "$location"/_site/$bookfolder/images/. "$location"/_site/epub/images/
 				fi
-				# Copy translation styles if they exist, otherwise
+				# Copy translation styles if they exist, and
 				# copy the parent-language styles.
 				if [ -e "$location"/_site/$bookfolder/$epubsubdirectory/styles/. ]; then
 					mkdir "$location"/_site/epub/$epubsubdirectory/styles && cd "$location"/_site/$bookfolder/$epubsubdirectory/styles && cp -a "$location"/_site/$bookfolder/$epubsubdirectory/styles/. "$location"/_site/epub/$epubsubdirectory/styles/
+					mkdir "$location"/_site/epub/styles && cp -a "$location"/_site/$bookfolder/styles/. "$location"/_site/epub/styles/
 				else
 					mkdir "$location"/_site/epub/styles && cp -a "$location"/_site/$bookfolder/styles/. "$location"/_site/epub/styles/
 				fi
@@ -477,20 +478,17 @@ You may need to reload the web page once this server is running."
 						fi
 					fi
 			fi
-			# Add either the parent styles folder or the translation's styles folder.
-			# If the translation has a styles folder, use it. Otherwise, use the parent's
-			# styles for the translation.
+			# Add the parent styles folder and the translation's styles folder if it exists.
 			if [ "$epubsubdirectory" = "" ]; then
 					if [ -d styles ]; then
 						zip --recurse-paths --quiet "$location/_output/$epubfilename.zip" "styles"
 					fi
 				else
+					if [ -d styles ]; then
+						zip --recurse-paths --quiet "$location/_output/$epubfilename.zip" "styles"
+					fi
 					if [ -d "$epubsubdirectory/styles" ]; then
 						zip --recurse-paths --quiet "$location/_output/$epubfilename.zip" "$epubsubdirectory/styles"
-					else
-						if [ -d styles ]; then
-							zip --recurse-paths --quiet "$location/_output/$epubfilename.zip" "styles"
-						fi
 					fi
 			fi
 			# If MathJax is enabled, copy the MathJax folder.

--- a/run-mac.command
+++ b/run-mac.command
@@ -379,10 +379,11 @@ You may need to reload the web page once this server is running."
 				else
 					mkdir "$location"/_site/epub/images && cp -a "$location"/_site/$bookfolder/images/. "$location"/_site/epub/images/
 				fi
-				# Copy translation styles if they exist, otherwise
+				# Copy translation styles if they exist, and
 				# copy the parent-language styles.
 				if [ -e "$location"/_site/$bookfolder/$epubsubdirectory/styles/. ]; then
 					mkdir "$location"/_site/epub/$epubsubdirectory/styles && cd "$location"/_site/$bookfolder/$epubsubdirectory/styles && cp -a "$location"/_site/$bookfolder/$epubsubdirectory/styles/. "$location"/_site/epub/$epubsubdirectory/styles/
+					mkdir "$location"/_site/epub/styles && cp -a "$location"/_site/$bookfolder/styles/. "$location"/_site/epub/styles/
 				else
 					mkdir "$location"/_site/epub/styles && cp -a "$location"/_site/$bookfolder/styles/. "$location"/_site/epub/styles/
 				fi
@@ -479,20 +480,17 @@ You may need to reload the web page once this server is running."
 						fi
 					fi
 			fi
-			# Add either the parent styles folder or the translation's styles folder.
-			# If the translation has a styles folder, use it. Otherwise, use the parent's
-			# styles for the translation.
+			# Add the parent styles folder and the translation's styles folder if it exists.
 			if [ "$epubsubdirectory" = "" ]; then
 					if [ -d styles ]; then
 						zip --recurse-paths --quiet "$location/_output/$epubfilename.zip" "styles"
 					fi
 				else
+					if [ -d styles ]; then
+						zip --recurse-paths --quiet "$location/_output/$epubfilename.zip" "styles"
+					fi
 					if [ -d "$epubsubdirectory/styles" ]; then
 						zip --recurse-paths --quiet "$location/_output/$epubfilename.zip" "$epubsubdirectory/styles"
-					else
-						if [ -d styles ]; then
-							zip --recurse-paths --quiet "$location/_output/$epubfilename.zip" "styles"
-						fi
 					fi
 			fi
 			# If MathJax is enabled, copy the MathJax folder.

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -439,13 +439,13 @@ set /p process=Enter a number and hit return.
         :epubCopyStyles
             echo Copying styles...
             :: --------------------------
-            :: If original language output: copy only files in fonts/epub
+            :: If original language output: copy original styles files only
             if "%subdirectory%"=="" if not exist %subdirectory%\styles\*.* goto epubOriginalStyles
             :: Translation output, but no translated-styles subdirectory for that translation:
             :: copy the original styles files only
             if not "%subdirectory%"=="" if not exist %subdirectory%\styles\*.* goto epubOriginalStyles
-            :: Translation output, and an styles subdir for that translation exists:
-            :: create folder structure, and copy only the styles in that translation folder
+            :: Translation output, and translation styles for that translation exist:
+            :: create folder structure, and copy the styles in that translation folder, too
             if not "%subdirectory%"=="" if exist %subdirectory%\styles\*.* goto epubTranslationStyles
 
         :: Copy original styles
@@ -455,9 +455,9 @@ set /p process=Enter a number and hit return.
             echo Styles copied.
             goto epubCopyImages
         
-        :: Copy translated styles, after deleting original styles
+        :: Copy translated styles, in addition to original styles
         :epubTranslationStyles
-            rd /s /q styles
+            xcopy /i /q "styles\*.css" "..\epub\styles" > nul
             mkdir "..\epub\%subdirectory%\styles"
             if exist "%subdirectory%\styles\*.css" xcopy /i /q "%subdirectory%\styles\*.css" "..\epub\%subdirectory%\styles" > nul
             :: Done! Move along to moving the text folder

--- a/samples/styles/hyphenation.dic
+++ b/samples/styles/hyphenation.dic
@@ -1,0 +1,8 @@
+---
+# This YAML frontmatter makes Jekyll process this file.
+# So you can use Liquid tags to include files such as
+# other hyphenation dictionaries, e.g.
+# `{% include_relative hyph-en-gb.pat %}`
+# or to use hyphenation in certain cases, e.g. variants.
+---
+

--- a/samples/styles/print-pdf.scss
+++ b/samples/styles/print-pdf.scss
@@ -97,7 +97,6 @@ $rule-thickness: 0.5pt;
 // Variables here apply to p, ul, ol, dl
 $hyphenation: manual; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)
 $hyphenation-dictionary: ""; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
-$hyphenation-custom: add; // add or replace. Whether your dictionary adds to or replaces the built-in Prince dictionaries
 $hyphenate-after: 3; // Minimum letters on new line after hyphen
 $hyphenate-before: 3; // Minimum letters at end of line before hyphen
 $hyphenate-lines: 2; // Preferred maximum number of consecutive lines ending with hyphens

--- a/samples/styles/screen-pdf.scss
+++ b/samples/styles/screen-pdf.scss
@@ -97,7 +97,6 @@ $rule-thickness: 0.5pt;
 // Variables here apply to p, ul, ol, dl
 $hyphenation: manual; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)
 $hyphenation-dictionary: ""; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
-$hyphenation-custom: add; // add or replace. Whether your dictionary adds to or replaces the built-in Prince dictionaries
 $hyphenate-after: 3; // Minimum letters on new line after hyphen
 $hyphenate-before: 3; // Minimum letters at end of line before hyphen
 $hyphenate-lines: 2; // Preferred maximum number of consecutive lines ending with hyphens


### PR DESCRIPTION
This changes translation-styles behaviour. Instead of wholly replacing parent-language styles, translation styles now add to them. This makes it easier to create small translation-styles CSS files that override only what needs overriding from parent styles.

This also provides a simpler mechanism for using custom hyphenation dictionaries in translations (for #290).

Usage documented.

Also, I've removed the `$hyphenation-custom: add; // add | replace` variable. I don't think it ever worked anyway, because you cannot apply two different hyphenation dictionaries/patterns to the same span of text. If you use a custom hyphenation dictionary but want to augment a big, existing one like those Prince ships with, you can just `include_relative` the bigger patterns file in your custom `hyphenation.dic` and add your own patterns below that.

This still needs testing on Mac and Ubuntu (especially changes to the `run-` scripts for epub output).