### PR TITLE
Hide breadcrumbs on small screens

### DIFF
--- a/_includes/breadcrumbs
+++ b/_includes/breadcrumbs
@@ -36,9 +36,9 @@ The crumbs-array is created empty in _includes/metadata.
         along the way.{% endcomment %}
         {% if item.file == current-file %}
             {% for crumb in include.crumbs-array %}
-                <li>{{ crumb | strip | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}</li>
+                <li class="masthead-breadcrumb">{{ crumb | strip | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}</li>
             {% endfor %}
-            <li>{{ item.label | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines | strip }}</li>
+            <li class="masthead-breadcrumb">{{ item.label | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines | strip }}</li>
             {% comment %}We don't break here because some files
             appear more than once in nav/breadcrumbs.{% endcomment %}
         {% else %}

--- a/_sass/partials/_web-masthead.scss
+++ b/_sass/partials/_web-masthead.scss
@@ -21,49 +21,29 @@ $web-masthead: true !default;
         ul {
             list-style-type: none;
             margin: 0 auto;
+            min-height: $line-height-default;
             padding: 0.5em 0;
             li {
-                display: inline-block;
-                margin: 0 0.25em 0 0;
-                // The divider between project and book title
-                // Should not show if there is only one work,
-                // and therefore no project title in masthead.
-                &:after {
-                    content: "\2044"; // 2044 is a fraction slash
-                    color: $masthead-text-color;
-                    margin-left: 0.5em;
-                }
-                // No symbol after last item
-                &:last-of-type:after {
-                    content: normal;
-                }
-                // On small screens, only show the book title.
-                // But see below...
-                @media only screen
-                and (max-width: $max-width-default) {
-                    &:nth-of-type(2):before {
-                        content: normal;
+                display: none; // hide masthead breadcrumbs as mobile-first default
+                @media only screen and (min-width: $max-width-default) {
+                    display: inline-block;
+                    margin: 0 0.25em 0 0;
+                    // The divider between project and book title
+                    // Should not show if there is only one work,
+                    // and therefore no project title in masthead.
+                    &:after {
+                        content: $masthead-breadcrumb-divider;
+                        color: $masthead-text-color;
+                        margin-left: 0.5em;
                     }
-                    &.masthead-project-name {
-                        display: none;
+                    // No symbol after last item
+                    &:last-of-type:after {
+                        content: normal;
                     }
                 }
             }
         }
 
-        // Possible future styles for these classes.
-        .masthead-project-name {}
-        .masthead-book-title {}
-
     } // .masthead
-
-    // ...unless it's the home page, and we're on a small screen,
-    // in which case do show the project name.
-    @media only screen
-    and (max-width: $max-width-default) {
-        body.home .masthead li.masthead-project-name {
-            display: inline-block !important;
-        }
-    }
 
 }

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -102,6 +102,7 @@ $footer-border-color: $color-accent !default;
 $masthead-text-color: $color-light !default;
 $masthead-background-color: $color-accent !default;
 $masthead-border-color: $color-light !default;
+$masthead-breadcrumb-divider: "\2044"; // 2044 is a fraction slash
 
 // Website sidebar/navigation
 $nav-bar-text-size: 0.8em !default;


### PR DESCRIPTION
Because they always end up overlapping with the Contents nav button, and aren't useful enough to justify that. Resolves #83.