### PR TITLE
Annotator fixes

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -66,7 +66,7 @@ web:
   # You can have annotation on for development and/or for live.
   # Set each to either true or false
   annotator:
-    development: true
+    development: false
     live: false
 
 # ----------------------------------------------------------

--- a/_includes/annotator.html
+++ b/_includes/annotator.html
@@ -11,9 +11,9 @@ https://h.readthedocs.io/projects/client/en/latest/publishers/config/
         enableExperimentalNewNoteButton: true,
         externalContainerSelector: '.annotator',
         branding: {
-            accentColor: 'black',
+            accentColor: getComputedStyle(document.body,null).getPropertyValue("background-color"),
             appBackgroundColor: 'white',
-            ctaBackgroundColor: 'black',
+            ctaBackgroundColor: getComputedStyle(document.body,null).getPropertyValue("background-color"),
             ctaTextColor: 'white',
             annotationFontFamily: 'sans-serif',
             selectionFontFamily: 'serif'

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -18,7 +18,9 @@ layout: null
 
 {% endif %}
 
-{% if site.output == "web" and site.data.settings.web.annotator == true %}
+{% if site.output == "web" and site.build != "live" and site.data.settings.web.annotator.development == true %}
+    {% include_relative annotation.js %}
+{% elsif site.output == "web" and site.build == "live" and site.data.settings.web.annotator.live == true %}
     {% include_relative annotation.js %}
 {% endif %}
 


### PR DESCRIPTION
- Turn annotator off by default.
- Use body `background-color`, which is usually the accent colour, for Hypothesis accent and CTA colour.
- Fix logic for loading annotator script to builds based on settings.
