### PR TITLE
PDF build refinements

### DIFF
--- a/_configs/_config.print-pdf.yml
+++ b/_configs/_config.print-pdf.yml
@@ -23,6 +23,23 @@ exclude:
   - package-lock.json
   - CNAME
   # Exclude files we don't need for print-pdf
+  - search*
+  - index*
+  - /assets/*.jpg
+  - /assets/js/accordion.js
+  - /assets/js/annotation.js
+  - /assets/js/elasticlunr-setup.js
+  - /assets/js/elasticlunr.min.js
+  - /assets/js/mark.min.js
+  - /assets/js/mcqs.js
+  - /assets/js/nav.js
+  - /assets/js/render-search-index.js
+  - /assets/js/search-engine.js
+  - /assets/js/search-index.js
+  - /assets/js/search-results.js
+  - /assets/js/search-store.js
+  - /assets/js/search-terms.js
+  - /assets/js/videos.js
   - /*/package.opf
   - /*/toc.ncx
   - /*/styles/screen-pdf.scss
@@ -34,6 +51,14 @@ exclude:
   - /*/images/web
   - /*/images/epub
   - /*/images/app
+# Temporarily exclude these and keep_files them below
+# for faster builds where you don't need to refresh these.
+  # - /assets/fonts
+  # - /book/fonts
+  # - /book/styles
 # Populate the keep_files list for temporary faster builds
 # or to keep previously generated files for other formats.
-keep_files: []
+keep_files:
+  # - /assets/fonts
+  # - /book/fonts
+  # - /book/styles

--- a/_configs/_config.screen-pdf.yml
+++ b/_configs/_config.screen-pdf.yml
@@ -23,6 +23,23 @@ exclude:
   - package-lock.json
   - CNAME
   # Exclude files we don't need for screen-pdf
+  - search*
+  - index*
+  - /assets/*.jpg
+  - /assets/js/accordion.js
+  - /assets/js/annotation.js
+  - /assets/js/elasticlunr-setup.js
+  - /assets/js/elasticlunr.min.js
+  - /assets/js/mark.min.js
+  - /assets/js/mcqs.js
+  - /assets/js/nav.js
+  - /assets/js/render-search-index.js
+  - /assets/js/search-engine.js
+  - /assets/js/search-index.js
+  - /assets/js/search-results.js
+  - /assets/js/search-store.js
+  - /assets/js/search-terms.js
+  - /assets/js/videos.js
   - /*/package.opf
   - /*/toc.ncx
   - /*/styles/print-pdf.scss
@@ -34,6 +51,14 @@ exclude:
   - /*/images/web
   - /*/images/epub
   - /*/images/app
+# Temporarily exclude these and keep_files them below
+# for faster builds where you don't need to refresh these.
+  # - /assets/fonts
+  # - /book/fonts
+  # - /book/styles
 # Populate the keep_files list for temporary faster builds
 # or to keep previously generated files for other formats.
-keep_files: []
+keep_files:
+  # - /assets/fonts
+  # - /book/fonts
+  # - /book/styles

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -29,7 +29,7 @@
     {% include head-elements %}
 
 </head>
-<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}"{% if page.header %} data-header="{{ page.header }}"{% else %} data-header="{{ page.title }}"{% endif %}{% if page.header-left %} data-header-left="{{ page.header-left }}"{% else %} data-header-left="{{ page.title }}"{% endif %}{% if page.header-right %} data-header-right="{{ page.header-right }}"{% else %} data-header-right="{{ page.title }}"{% endif %}>
+<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}"{% if page.header %} data-header="{{ page.header }}"{% else %} data-header="{{ page.title }}"{% endif %}{% if page.header-left %} data-header-left="{{ page.header-left }}"{% else %} data-header-left="{{ page.title }}"{% endif %}{% if page.header-right %} data-header-right="{{ page.header-right }}"{% else %} data-header-right="{{ page.title }}"{% endif %} data-page-info="{{ title | truncate: 20 }}: {{ page.title | truncate: 20 }} • {{ page.url | split: "/" | last | split: "." | first }} • {{ site.time | date: "%-d %b %Y, %H:%M" }}">
 <div id="wrapper">
 
 

--- a/_sass/partials/_print-page-headers-footers-content.scss
+++ b/_sass/partials/_print-page-headers-footers-content.scss
@@ -12,7 +12,8 @@ $print-page-headers-footers-content: true !default;
     string-set:
       page-header attr(data-header),
       page-header-left attr(data-header-left),
-      page-header-right attr(data-header-right);
+      page-header-right attr(data-header-right),
+      page-info attr(data-page-info);
   }
 
   // Assign strings to use in headers and footers for each level of heading (h1-h6),
@@ -250,6 +251,17 @@ $print-page-headers-footers-content: true !default;
   // Reset page numbering to 1
   .page-1 {
     counter-reset: page 1;
+  }
+
+  // Add page info to trim area
+  @page {
+    @prince-overlay {
+      color: #bbbbbb;
+      content: string(page-info);
+      font-family: sans-serif;
+      font-size: 7pt;
+      margin-top: $page-height + $bleed;
+    }
   }
 
 }


### PR DESCRIPTION
This excludes some files we don't need from PDF builds, for faster build times, and adds page-info to the trim area of print-PDF output for reference (similar to InDesign).