### PR TITLE
Add a variable for output format

### DIFF
--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -17,6 +17,9 @@
 // Set variables
 // -------------
 
+// Provide a variable for site output
+$output-format: "app" !default;
+
 // Edition suffix: identifies this edition in certain classes (e.g. in _epub-fitting.scss).
 $edition-suffix: null !default;
 

--- a/_sass/epub.scss
+++ b/_sass/epub.scss
@@ -17,6 +17,9 @@
 // Set variables
 // -------------
 
+// Provide a variable for site output
+$output-format: "epub" !default;
+
 // Edition suffix: identifies this edition in certain classes (e.g. in _epub-fitting.scss).
 $edition-suffix: null !default;
 

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -17,6 +17,9 @@
 // Set variables
 // -------------
 
+// Provide a variable for site output
+$output-format: "print-pdf" !default;
+
 // Edition suffix: identifies this edition in page-fitting classes (in _print-fitting.scss).
 // For instance, a .tighten class in HTML might apply to your bookshop edition, but not the schools edition.
 // A suffix '-schools-edn' would mean only tags with that suffix would apply to that edition, e.g. {:.tighten-schools-edn}

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -17,6 +17,9 @@
 // Set variables
 // -------------
 
+// Provide a variable for site output
+$output-format: "screen-pdf" !default;
+
 // Edition suffix: identifies this edition in page-fitting classes (in _print-fitting.scss).
 // For instance, a .tighten class in HTML might apply to your bookshop edition, but not the schools edition.
 // A suffix '-schools-edn' would mean only tags with that suffix would apply to that edition, e.g. {:.tighten-schools-edn}
@@ -95,7 +98,6 @@ $rule-thickness: 0.5pt !default;
 // Variables here apply to p, ul, ol, dl
 $hyphenation: manual !default; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)
 $hyphenation-dictionary: "" !default; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
-$hyphenation-custom: add !default; // add or replace. Whether your dictionary adds to or replaces the built-in Prince dictionaries
 $hyphenate-after: 3 !default; // Minimum letters on new line after hyphen
 $hyphenate-before: 3 !default; // Minimum letters at end of line before hyphen
 $hyphenate-lines: 2 !default; // Preferred maximum number of consecutive lines ending with hyphens

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -17,6 +17,9 @@
 // Set variables
 // -------------
 
+// Provide a variable for site output
+$output-format: "web" !default;
+
 // Edition suffix: identifies this edition in certain classes (e.g. in _epub-fitting.scss).
 $edition-suffix: null !default;
 


### PR DESCRIPTION
This is useful when creating custom partials where CSS depends on the output format.

For instance, if you have a `_colours.scss` partial for all outputs, you may want greyscale colours for print-PDF output. E.g.:

``` scss
$orange: #f7901e;
$green: #7dc242;

@if $output-format == "print-pdf" {
    $orange: grayscale(#f7901e);
    $green: grayscale(#7dc242);
}
```