### PR TITLE
Convert endnotes to footnotes

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -35,6 +35,24 @@ variants:
   - variant: yourvariant
 
 # ----------------------------------------------------------
+# Print-PDF settings
+# ------------
+print-pdf:
+  # Choose between endnotes or footnotes (endnotes are default)
+  # (You can also set this per markdown file with notes: footnotes,
+  # or per endnote by adding .move-to-footnote to it.)
+  notes: endnotes
+
+# ----------------------------------------------------------
+# Screen-PDF settings
+# ------------
+screen-pdf:
+  # Choose between endnotes or footnotes (endnotes are default)
+  # (You can also set this per markdown file with notes: footnotes,
+  # or per endnote by adding .move-to-footnote to it.)
+  notes: endnotes
+
+# ----------------------------------------------------------
 # Web settings
 # ------------
 web:

--- a/_docs/editing/notes.md
+++ b/_docs/editing/notes.md
@@ -10,18 +10,56 @@ order: 6
 * Page contents
 {:toc}
 
-Our default theme provides three options for notes.
+There are various options for notes.
 
-**Footnotes** appear at the end of a document (web page or book chapter). In book parlance, they are therefore actually endnotes, but we call them footnotes because that's what kramdown calls them. To create them in markdown, follow the [kramdown syntax for footnotes](http://kramdown.gettalong.org/syntax.html#footnotes):
+## Endnotes
+
+Endnotes appear at the end of a document (a web page or book chapter). In kramdown and on the web these are often called footnotes. To create them in markdown, follow the [kramdown syntax for footnotes](http://kramdown.gettalong.org/syntax.html#footnotes):
 
 *	put a `[^1]` where the footnote reference should appear (the `1` there can be any numbers or letters, and should be different for each footnote in a document);
 *	anywhere in the document (we recommend after the paragraph containing the footnote reference), put `[^1]: Your footnote text here.`.
 
-**Sidenotes** appear in a box to the right of the text. On wide screens, they float far right of the text. On narrower screens, the text wraps around them. In print, the text wraps around them, too. To create a sidenote, put a `*` at the start of the sidenote text and `*{:.sidenote}` at the end (with no spaces). (Technically, you're creating an `<em>` span with a kramdown IAL.)
+Endnotes – notes gathered at the end of each web page or book chapter – are the default.
+
+## Footnotes
+
+To create true bottom-of-page footnotes, as opposed to endnotes, use the same syntax as for endnotes above, but then add one of the following options to convert the endnotes to bottom-of-page footnotes.
+
+- To convert all endnotes to footnotes for an **entire project** (a repo, series or collection), specify this in `_data/settings.yml`. E.g. for `print-pdf`:
+
+  ```yaml
+  print-pdf:
+    notes: footnotes
+  ```
+
+- To convert all endnotes to footnotes in a **single markdown document** (e.g. a particular chapter), specify this in the document's YAML page frontmatter. E.g.:
+
+   ``` md
+   ---
+   title: "Chapter One"
+   notes: footnotes
+   ---
+   ```
+
+- To convert a **a specific endnote** to a bottom-of-page footnote, add a `move-to-footnote` class to any part of it. For example, you can apply the class to the first paragraph in a note like this:
+
+  ``` md
+  [^20]: The text of the note.
+         {:.move-to-footnote}
+  ```
+
+> Technically, `footnotes.js` and `_print-notes.scss` convert endnotes completely from kramdown footnotes to [PrinceXML footnotes](https://www.princexml.com/doc-prince/#footnotes). They may look similar by default, but they are different elements and can be styled separately.
+{:.box}
+
+## Sidenotes
+
+**Sidenotes** appear in a box to the side of the text. On wide screens, they float far right of the text. On narrower screens, the text wraps around them. In print, the text wraps around them, too. To create a sidenote, put a `*` at the start of the sidenote text and `*{:.sidenote}` at the end (with no spaces). (Technically, you're creating an `<em>` span with a kramdown IAL.)
 
 In print, you can put **sidenotes at the bottom of the page**. By adding `.bottom` to the `{:.sidenote}` tag, your sidenote sits at the bottom of the page rather than on the right with text wrap, replicating a traditional footnote. So the markdown looks like this: `*This is a sidenote at the bottom of the page in print.*{:.sidenote .bottom}`. On screen, these are just regular sidenotes.
 
-To create footnote-like sidenotes, you can tag a reference and footnote-like text to create the bottom-of-page-footnote effect:
+## Manual footnotes
+
+To create footnote-like sidenotes manually, you can tag a reference and footnote-like text to create the bottom-of-page-footnote effect:
 
 ~~~
 This is body text with a footnote at the end.[1](#fn-1){:.fnref #fnref-1}
@@ -32,4 +70,4 @@ This is body text with a footnote at the end.[1](#fn-1){:.fnref #fnref-1}
 
 This markdown makes `1` a link in the body text, which points to the footnote text (ID `fn-1`). The number `1` at the footnote text is a link to the reference (ID `fnref-1`).
 
-Unlike proper kramdown footnotes, these do not autonumber. You must manage the numbering manually. This means this is only suitable for books that have a few footnotes. The kramdown contributors are [looking into alternative syntax](https://github.com/gettalong/kramdown/issues/208) that will let you place a kramdown footnote anywhere in the text.
+Unlike proper kramdown footnotes, these do not autonumber. You must manage the numbering or otherwise marking them manually. This means this is only suitable for books that have a few footnotes. The kramdown contributors are [looking into alternative syntax](https://github.com/gettalong/kramdown/issues/208) that will let you place a kramdown footnote anywhere in the text.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,7 +28,7 @@
     {% include head-elements %}
 
 </head>
-<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}"{% if page.header %} data-header="{{ page.header }}"{% else %} data-header="{{ page.title }}"{% endif %}{% if page.header-left %} data-header-left="{{ page.header-left }}"{% else %} data-header-left="{{ page.title }}"{% endif %}{% if page.header-right %} data-header-right="{{ page.header-right }}"{% else %} data-header-right="{{ page.title }}"{% endif %} data-page-info="{{ title | truncate: 20 }}: {{ page.title | truncate: 20 }} • {{ page.url | split: "/" | last | split: "." | first }} • {{ site.time | date: "%-d %b %Y, %H:%M" }}">
+<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}"{% if page.header %} data-header="{{ page.header }}"{% else %} data-header="{{ page.title }}"{% endif %}{% if page.header-left %} data-header-left="{{ page.header-left }}"{% else %} data-header-left="{{ page.title }}"{% endif %}{% if page.header-right %} data-header-right="{{ page.header-right }}"{% else %} data-header-right="{{ page.title }}"{% endif %} data-page-info="{{ title | truncate: 20 }}: {{ page.title | truncate: 20 }} • {{ page.url | split: "/" | last | split: "." | first }} • {{ site.time | date: "%-d %b %Y, %H:%M" }}"{% if site.data.settings.print-pdf.notes == "footnotes" or page.notes == "footnotes" %} data-page-footnotes{% endif %}>
 <div id="wrapper">
 
 
@@ -60,7 +60,7 @@
     {% include head-elements %}
 
 </head>
-<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}"{% if page.header %} data-header="{{ page.header }}"{% else %} data-header="{{ page.title }}"{% endif %}{% if page.header-left %} data-header-left="{{ page.header-left }}"{% else %} data-header-left="{{ page.title }}"{% endif %}{% if page.header-right %} data-header-right="{{ page.header-right }}"{% else %} data-header-right="{{ page.title }}"{% endif %}>
+<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}"{% if page.header %} data-header="{{ page.header }}"{% else %} data-header="{{ page.title }}"{% endif %}{% if page.header-left %} data-header-left="{{ page.header-left }}"{% else %} data-header-left="{{ page.title }}"{% endif %}{% if page.header-right %} data-header-right="{{ page.header-right }}"{% else %} data-header-right="{{ page.title }}"{% endif %} data-page-info="{{ title | truncate: 20 }}: {{ page.title | truncate: 20 }} • {{ page.url | split: "/" | last | split: "." | first }} • {{ site.time | date: "%-d %b %Y, %H:%M" }}"{% if site.data.settings.screen-pdf.notes == "footnotes" or page.notes == "footnotes" %} data-page-footnotes{% endif %}>
 <div id="wrapper">
 
 

--- a/_sass/partials/_print-notes.scss
+++ b/_sass/partials/_print-notes.scss
@@ -1,84 +1,119 @@
 $print-notes: true !default;
 @if $print-notes {
 
-	// Footnotes
+    // Footnotes
 
-	// kramdown gives footnote references the class .footnote
-	// and the div containing the footnotes .footnotes
-	// Styling for sup and sub is in base typography
+    // kramdown gives footnote references the class .footnote
+    // and the div containing the footnotes .footnotes.
+    // In books, we call these endnotes. To avoid confusion,
+    // here we will call true footnotes 'page-footnotes'.
+    // Styling for sup and sub is in base typography
 
-	// Single footnote
-	.footnote {
-		line-height: inherit;
-	}
+    // Single footnote
+    .footnote {
+        line-height: inherit;
+    }
 
-	// Footnotes section
-	.footnotes {
-		margin: $line-height-default 0 0 0;
-		font-size: $font-size-default * $font-size-smaller;
-		line-height: $line-height-default * $font-size-smaller;
-		p {
-			text-indent: 0;
-		}
-	}
-	// Hide the link back to the footnote reference from the footnote text.
-	.reversefootnote {
-		display: none;
-	}
+    // Footnotes section
+    .footnotes {
+        margin: $line-height-default 0 0 0;
+        font-size: $font-size-default * $font-size-smaller;
+        line-height: $line-height-default * $font-size-smaller;
+        p {
+            text-indent: 0;
+        }
+    }
+    // Hide the link back to the footnote reference from the footnote text.
+    .reversefootnote {
+        display: none;
+    }
 
-	// Sidenotes
-	.sidenote {
-		clear: both;
-		float: right;
-		font-family: $font-text-secondary;
-		font-size: $font-size-default * $font-size-smaller;
-		line-height: $line-height-default;
-		font-style: inherit;
-		text-indent: 0;
-		max-width: 40%;
-		min-width: 5em;
-		margin: ($line-height-default * 0.75) 0 ($line-height-default * 0.5) ($line-height-default);
-		padding: ($line-height-default * 0.25) 0 0 0;
-		border-top: $rule-thickness solid $color-light;
-		box-sizing: border-box;
-		// Don't text-indent paragraphs that follow sidenotes that follow a heading.
-		// We allow for up to three sidenotes between the heading and paragraph.
-		h1 + & + p,
-		h2 + & + p,
-		h3 + & + p,
-		h4 + & + p,
-		h5 + & + p,
-		h6 + & + p,
-		h1 + & + & + p,
-		h2 + & + & + p,
-		h3 + & + & + p,
-		h4 + & + & + p,
-		h5 + & + & + p,
-		h6 + & + & + p,
-		h1 + & + & + & + p,
-		h2 + & + & + & + p,
-		h3 + & + & + & + p,
-		h4 + & + & + & + p,
-		h5 + & + & + & + p,
-		h6 + & + & + & + p {
-			text-indent: 0;
-		}
-		// Unless we're spacing paras, put back the indent
-		// on paras that follow sidenotes that follow paras.
-		p + & + p {
-			text-indent: $line-height-default;
-		}
-		@if $spaced-paras {
-	        p + & + p {
-	            text-indent: 0;
-	        }
-	    }
-	}
-	// Sidenotes that appear at the bottom of the page, aka footer notes.
-	.bottom {
-		float: bottom;
-		max-width: 100%;
-		margin: ($line-height-default * 0.75) 0 0 0;
-	}
+    // Sidenotes
+    .sidenote {
+        clear: both;
+        float: right;
+        font-family: $font-text-secondary;
+        font-size: $font-size-default * $font-size-smaller;
+        line-height: $line-height-default;
+        font-style: inherit;
+        text-indent: 0;
+        max-width: 40%;
+        min-width: 5em;
+        margin: ($line-height-default * 0.75) 0 ($line-height-default * 0.5) ($line-height-default);
+        padding: ($line-height-default * 0.25) 0 0 0;
+        border-top: $rule-thickness solid $color-light;
+        box-sizing: border-box;
+        // Don't text-indent paragraphs that follow sidenotes that follow a heading.
+        // We allow for up to three sidenotes between the heading and paragraph.
+        h1 + & + p,
+        h2 + & + p,
+        h3 + & + p,
+        h4 + & + p,
+        h5 + & + p,
+        h6 + & + p,
+        h1 + & + & + p,
+        h2 + & + & + p,
+        h3 + & + & + p,
+        h4 + & + & + p,
+        h5 + & + & + p,
+        h6 + & + & + p,
+        h1 + & + & + & + p,
+        h2 + & + & + & + p,
+        h3 + & + & + & + p,
+        h4 + & + & + & + p,
+        h5 + & + & + & + p,
+        h6 + & + & + & + p {
+            text-indent: 0;
+        }
+        // Unless we're spacing paras, put back the indent
+        // on paras that follow sidenotes that follow paras.
+        p + & + p {
+            text-indent: $line-height-default;
+        }
+        @if $spaced-paras {
+            p + & + p {
+                text-indent: 0;
+            }
+        }
+    }
+    // Sidenotes that appear at the bottom of the page, aka footer notes.
+    .bottom {
+        float: bottom;
+        max-width: 100%;
+        margin: ($line-height-default * 0.75) 0 0 0;
+    }
+
+    // True footnotes (we call them page-footnotes for clarity)
+    // For styling see https://www.princexml.com/doc-prince/#footnote-calls
+    .page-footnote {
+        float: footnote;
+        footnote-style-position: inside;
+        text-indent: -($line-height-default * 1.5);
+        margin-left: $line-height-default * 1.5;
+    }
+        // The numbers in front of footnote text
+        *::footnote-marker {
+            float: left;
+            width: $line-height-default * 1.5;
+        }
+
+    // The page-footnotes area
+    @page {
+        @footnotes {
+            margin-top: $line-height-default / 2;
+            padding-top: $line-height-default / 2;
+            font-size: $font-size-default * $font-size-smaller;
+        }
+    }
+
+    // The page-footnote references in body text
+    // Note that other <sup> styling is defined in
+    // _print-base-typography.scss
+    *::footnote-call {
+        content: counter(footnote);
+        font-size: $font-size-default * $font-size-smaller;
+        vertical-align: super;
+        line-height: none;
+    }
 
 }

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -44,6 +44,9 @@ have different behaviour for web or app. {% endcomment %}
     {% comment %}This script helps rotate large figures on the page.{% endcomment %}
     {% include_relative rotate.js %}
 
+    {% comment %}This script moves endnotes to the bottoms of pages.{% endcomment %}
+    {% include_relative footnotes.js %}
+
     {% comment %}This script detects the page number we are on and provides
     the relevant page cross-reference text as generated content.{% endcomment %}
     {% include_relative page-reference.js %}

--- a/assets/js/footnotes.js
+++ b/assets/js/footnotes.js
@@ -1,0 +1,105 @@
+// Move footnotes to bottoms of pages
+
+console.log('Checking for footnotes to move to endnotes...');
+
+function ebFootnotesToMove() {
+    'use strict';
+    // If there are any footnotes...
+    if (document.querySelector('.footnotes')) {
+        // And if the page-footnotes setting is on,
+        // or at least on for one of the footnotes
+        if (document.body.hasAttribute('data-page-footnotes') ||
+                document.querySelector('.footnotes .page-footnote')) {
+            return true;
+        }
+    }
+}
+
+function ebMoveEndnoteToFootnote(noteReference) {
+    'use strict';
+
+    var footnoteReferenceID, endnote, pageFootnote,
+            containingElement, footnoteReferenceContainer;
+
+    // get the footnote ID
+    footnoteReferenceID = noteReference.hash;
+
+    // NOTE: Prince's .hash behaviour is unusual: it strips the # out
+    // So, let's use getElementById instead of querySelector.
+    // If it starts with a hash, chop it out.
+    if (footnoteReferenceID.indexOf('#') === 0) {
+        footnoteReferenceID = footnoteReferenceID.replace('#', '');
+    }
+
+    // Find the li with the ID from the .footnote's href
+    endnote = document.getElementById(footnoteReferenceID);
+
+    // Check that we should actually process this footnote.
+    // If the data-page-footnotes setting isn't applied to this doc...
+    if (!document.body.hasAttribute('data-page-footnotes')) {
+        // ...check whether this particular footnote should be moved.
+        if (!endnote.querySelector('.move-to-footnote')) {
+            return;
+        }
+    }
+
+    // Make a div.page-footnote
+    pageFootnote = document.createElement('div');
+    pageFootnote.className += ' page-footnote';
+    pageFootnote.id = footnoteReferenceID;
+
+    // Get the sup that contains the footnoteReference a.footnote
+    footnoteReferenceContainer = noteReference.parentNode;
+
+    // Get the element that contains the footnote reference
+    containingElement = noteReference.parentNode.parentNode;
+
+    // and add a class to it.
+    containingElement.parentNode.className += ' contains-footnote';
+
+    // Move the endnote contents inside the div.page-footnote
+    pageFootnote.innerHTML = endnote.innerHTML;
+
+    // Insert the new .page-footnote at the reference.
+    // Technically, before the <sup> that contains the reference <a>.
+    // We have to use insertBefore because Prince borks at insertAdjacentElement.
+    containingElement.insertBefore(pageFootnote, footnoteReferenceContainer);
+
+    // Remove the old endnote, and the old reference to it
+    // (Prince creates new references to page-footnotes)
+    endnote.parentNode.removeChild(endnote);
+    footnoteReferenceContainer.parentNode.removeChild(footnoteReferenceContainer);
+
+}
+
+function ebEndnotesToFootnotes() {
+    'use strict';
+
+    // get all the a.footnote links
+    var footnoteReferences = document.querySelectorAll('.footnote');
+
+    // Process all the footnotes
+    var i;
+    for (i = 0; i < footnoteReferences.length; i += 1) {
+        ebMoveEndnoteToFootnote(footnoteReferences[i]);
+
+        // // If page-footnotes are on for the document,
+        // // move all the endnotes to page footnotes
+        // if (document.body.getAttribute('data-page-footnotes')) {
+        //     ebMoveEndnoteToFootnote(footnoteReferences[i]);
+        // } else {
+        //     // If a given endnote contains .move-to-footnote,
+        //     // move that one endnote.
+        //     console.log('footnoteReferences[i].innerHTML: ' + footnoteReferences[i].innerHTML);
+        //     if (footnoteReferences[i].querySelector('.move-to-footnote')) {
+        //         ebMoveEndnoteToFootnote(footnoteReferences[i]);
+        //     }
+        // }
+    }
+}
+
+/// If there are footnotes to move, move them.
+if (ebFootnotesToMove) {
+    console.log('Yes, we have footnotes to move...');
+    ebEndnotesToFootnotes();
+}

--- a/assets/js/page-reference.js
+++ b/assets/js/page-reference.js
@@ -1,3 +1,5 @@
+/*globals window, Prince, pageLanguage, locales */
+
 // Page cross-reference in print
 // Use with css:
 // content: prince-script(pagereference);
@@ -13,18 +15,26 @@ var prePageNumberPhrase = locales[pageLanguage]['cross-references']['pre-page-nu
 var postPageNumberPhrase = locales[pageLanguage]['cross-references']['post-page-number'];
 
 function addPageReferenceFunc() {
+    'use strict';
 
     // exit if we're in phantom; we only want Prince to do this
-    if (typeof window.callPhantom === 'function') return;
+    if (typeof window.callPhantom === 'function') {
+        return;
+    }
 
-    Prince.addScriptFunc("pagereference", function(currentPage, targetPage) {
+    if (!typeof Prince === 'undefined') {
+        console.log('Adding page references in Prince.');
+        Prince.addScriptFunc("pagereference", function (currentPage, targetPage) {
 
-        // if the target is on this page, return blank
-        if (currentPage === targetPage) return '';
+            // if the target is on this page, return blank
+            if (currentPage === targetPage) {
+                return '';
+            }
 
-        // otherwise show a space and the page number in parentheses
-        return '\u00A0' + prePageNumberPhrase + targetPage + postPageNumberPhrase;
-    });
+            // otherwise show a space and the page number in parentheses
+            return '\u00A0' + prePageNumberPhrase + targetPage + postPageNumberPhrase;
+        });
+    }
 }
 
 addPageReferenceFunc();


### PR DESCRIPTION
This adds a mechanism for converting endnotes to true bottom-of-page footnotes. This preference can be set per repo, document, or note (as explained in the new docs here).