### PR TITLE
Maths in Word export

### DIFF
--- a/_configs/_config.math-disabled.yml
+++ b/_configs/_config.math-disabled.yml
@@ -1,0 +1,4 @@
+# Disable processing of LaTeX for MathJax completely.
+# This will leave `$$E=mc^2$$` in your HTML as in your markdown.
+kramdown:
+  math_engine: nil

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -736,13 +736,6 @@ You may need to reload the web page once this server is running."
 		# Ask if we're outputting the files from a subdirectory (e.g. a translation)
 		echo "If you're outputting files in a subdirectory (e.g. a translation), type its name. Otherwise, hit enter. "
 		read wordsubdirectory
-		# Ask whether we're processing MathJax, to know whether to pre-process the HTML
-		wordmathjax="unknown"
-		until [ "$wordmathjax" = "" ] || [ "$wordmathjax" = "y" ]
-		do
-			echo "Does this book use MathJax? If no, hit enter. If yes, enter y."
-			read wordmathjax
-		done
 		# Ask user which output format to work from
 		echo "Which format are we converting from? Enter a number or hit enter for the default 'print-pdf'. "
 		echo "1. Print PDF (default)"
@@ -791,24 +784,10 @@ You may need to reload the web page once this server is running."
 		do
 			# let the user know we're on it!
 			echo "Generating HTML..."
-			# ...and run Jekyll to build new HTML
-			# with MathJax enabled if necessary
-			if [ "$wordmathjax" = "" ]; then
-				bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,$config"
-			else
-				bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,_configs/_config.mathjax-enabled.yml,$config"
-			fi
-			# If using, MathJax, preprocess the HTML
-			if [ "$wordmathjax" = "" ]; then
-				echo "No MathJax required."
-			else
-				echo "Processing MathJax in HTML."
-				if [ "$wordsubdirectory" = "" ]; then
-					gulp mathjax --book $bookfolder
-				else
-					gulp mathjax --book $bookfolder --language $wordsubdirectory
-				fi
-			fi
+			# ...and run Jekyll to build new HTML.
+			# We turn off the math engine so that we get raw TeX output,
+            # and because Pandoc does not support SVG output anyway.
+			bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,_configs/_config.math-disabled.yml,$config"
 			# Navigate into the book's text folder in _site
 			if [ "$wordsubdirectory" = "" ]; then
 				cd _site/$bookfolder/text

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -786,7 +786,7 @@ You may need to reload the web page once this server is running."
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML.
 			# We turn off the math engine so that we get raw TeX output,
-            # and because Pandoc does not support SVG output anyway.
+			# and because Pandoc does not support SVG output anyway.
 			bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,_configs/_config.math-disabled.yml,$config"
 			# Navigate into the book's text folder in _site
 			if [ "$wordsubdirectory" = "" ]; then

--- a/run-mac.command
+++ b/run-mac.command
@@ -736,13 +736,6 @@ You may need to reload the web page once this server is running."
 		# Ask if we're outputting the files from a subdirectory (e.g. a translation)
 		echo "If you're outputting files in a subdirectory (e.g. a translation), type its name. Otherwise, hit enter. "
 		read wordsubdirectory
-		# Ask whether we're processing MathJax, to know whether to pre-process the HTML
-		wordmathjax="unknown"
-		until [ "$wordmathjax" = "" ] || [ "$wordmathjax" = "y" ]
-		do
-			echo "Does this book use MathJax? If no, hit enter. If yes, enter y."
-			read wordmathjax
-		done
 		# Ask user which output format to work from
 		echo "Which format are we converting from? Enter a number or hit enter for the default 'print-pdf'. "
 		echo "1. Print PDF (default)"
@@ -791,24 +784,10 @@ You may need to reload the web page once this server is running."
 		do
 			# let the user know we're on it!
 			echo "Generating HTML..."
-			# ...and run Jekyll to build new HTML
-			# with MathJax enabled if necessary
-			if [ "$wordmathjax" = "" ]; then
-				bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,$config"
-			else
-				bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,_configs/_config.mathjax-enabled.yml,$config"
-			fi
-			# If using, MathJax, preprocess the HTML
-			if [ "$wordmathjax" = "" ]; then
-				echo "No MathJax required."
-			else
-				echo "Processing MathJax in HTML."
-				if [ "$wordsubdirectory" = "" ]; then
-					gulp mathjax --book $bookfolder
-				else
-					gulp mathjax --book $bookfolder --language $wordsubdirectory
-				fi
-			fi
+			# ...and run Jekyll to build new HTML.
+			# We turn off the math engine so that we get raw TeX output,
+            # and because Pandoc does not support SVG output anyway.
+			bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,_configs/_config.math-disabled.yml,$config"
 			# Navigate into the book's text folder in _site
 			if [ "$wordsubdirectory" = "" ]; then
 				cd _site/$bookfolder/text

--- a/run-mac.command
+++ b/run-mac.command
@@ -786,7 +786,7 @@ You may need to reload the web page once this server is running."
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML.
 			# We turn off the math engine so that we get raw TeX output,
-            # and because Pandoc does not support SVG output anyway.
+			# and because Pandoc does not support SVG output anyway.
 			bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,_configs/_config.math-disabled.yml,$config"
 			# Navigate into the book's text folder in _site
 			if [ "$wordsubdirectory" = "" ]; then

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -845,37 +845,16 @@ set /p process=Enter a number and hit return.
         set /p config=
         echo.
 
-        :: Ask if we're processing MathJax, so we know whether to process the HTML
-        echo Does this book use MathJax? If yes, enter y. If no, just hit enter. 
-        set /p word-mathjax=
-
         :: Loop back to this point to refresh the build again
         :wordrefresh
 
             :: let the user know we're on it!
             echo Generating HTML...
 
-            :: ...and run Jekyll to build new HTML
-            :: with MathJax enabled if necessary
-            if not "%word-mathjax%"=="y" goto wordnomathjax
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.%fromformat%.yml,_configs/_config.mathjax-enabled.yml,%config%"
-            goto wordjekylldone
-
-            :: Build Jekyll without MathJax
-            :wordnomathjax
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.%fromformat%.yml,%config%"
-
-            :wordjekylldone
-
-            :: Skip the next step if we're not using MathJax.
-            if not "%word-mathjax%"=="y" goto wordaftermathjax
-
-            :: Convert all MathJax LaTeX to MathML
-            if "%subdirectory%"=="" call gulp mathjax --book %bookfolder%
-            if not "%subdirectory%"=="" call gulp mathjax --book %bookfolder% --language %subdirectory%
-            cd "%location%"
-
-            :wordaftermathjax
+            :: ...and run Jekyll to build new HTML.
+            :: We turn off the math engine so that we get raw TeX output,
+            :: and because Pandoc does not support SVG output anyway.
+            call bundle exec jekyll build --config="_config.yml,_configs/_config.%fromformat%.yml,_configs/_config.math-disabled.yml,%config%"
 
             :: Navigate to the HTML we just generated
             if "%subdirectory%"=="" cd _site\%bookfolder%\text


### PR DESCRIPTION
This addresses #302, where the problem is that Word export doesn't include any maths. Explained [here](https://github.com/electricbookworks/electric-book/issues/302#issuecomment-444513268).

I've added a config that turns off kramdown's math engine entirely, leaving raw TeX in the output HTML. I've then added this config to the Word-output's Jekyll build, and removed any math preprocessing there.