### PR TITLE
Minor fixes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,7 +28,7 @@
     {% include head-elements %}
 
 </head>
-<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}"{% if page.header %} data-header="{{ page.header }}"{% else %} data-header="{{ page.title }}"{% endif %}{% if page.header-left %} data-header-left="{{ page.header-left }}"{% else %} data-header-left="{{ page.title }}"{% endif %}{% if page.header-right %} data-header-right="{{ page.header-right }}"{% else %} data-header-right="{{ page.title }}"{% endif %} data-page-info="{% unless site.data.settings.redact == true %}{{ title | truncate: 20 }}: {{ page.title | truncate: 20 }} • {{ page.url | split: "/" | last | split: "." | first }} • {% endunless %}{{ site.time | date: "%-d %b %Y, %H:%M" }}"{% if site.data.settings.print-pdf.notes == "footnotes" or page.notes == "footnotes" %} data-page-footnotes{% endif %}>
+<body class="{{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}"{% if page.header %} data-header="{{ page.header }}"{% else %} data-header="{{ page.title }}"{% endif %}{% if page.header-left %} data-header-left="{{ page.header-left }}"{% else %} data-header-left="{{ page.title }}"{% endif %}{% if page.header-right %} data-header-right="{{ page.header-right }}"{% else %} data-header-right="{{ page.title }}"{% endif %} data-page-info="{% unless site.data.settings.redact == true %}{{ title | truncate: 20 }}: {{ page.title | truncate: 20 }} • {{ page.url | split: "/" | last | split: "." | first | truncate: 20 }} • {% endunless %}{{ site.time | date: "%-d %b %Y, %H:%M" }}"{% if site.data.settings.print-pdf.notes == "footnotes" or page.notes == "footnotes" %} data-page-footnotes{% endif %}>
 <div id="wrapper">
 
 

--- a/_sass/partials/_epub-base-typography.scss
+++ b/_sass/partials/_epub-base-typography.scss
@@ -90,7 +90,9 @@ $epub-base-typography: true !default;
     dl {
         margin: $line-height-default 0;
     }
-    dt {}
+    dt {
+        font-weight: bold;
+    }
     dd {
         margin: 0 0 $line-height-default 0;
     }

--- a/_sass/partials/_print-base-typography.scss
+++ b/_sass/partials/_print-base-typography.scss
@@ -141,6 +141,7 @@ $convert-images-to-color-profile: false !default;
     }
     dt {
         page-break-after: avoid;
+        font-weight: bold;
     }
     dd {
         margin: 0 0 $line-height-default $line-height-default;

--- a/_sass/partials/_print-font-faces.scss
+++ b/_sass/partials/_print-font-faces.scss
@@ -109,7 +109,7 @@ $print-font-faces: true !default;
     }
     @font-face {
         font-family: "Ubuntu Mono";
-        src: url(../../assets/fonts/UbuntuMono-I.ttf);
+        src: url(../../assets/fonts/UbuntuMono-RI.ttf);
         font-style: italic;
     }
     @font-face {

--- a/_sass/partials/_print-hide-non-printing.scss
+++ b/_sass/partials/_print-hide-non-printing.scss
@@ -12,5 +12,18 @@ $print-hide-non-printing: true !default;
         display: none;
     }
 
+    // Indent paras that appear consecutively after non-printing elements
+    p + .non-printing + p,
+    p + .non-printing + .non-printing + p,
+    p + .non-printing + .non-printing + .non-printing + p {
+        text-indent: $line-height-default;
+    }
+    @if $spaced-paras {
+        p + .non-printing + p,
+        p + .non-printing + .non-printing + p,
+        p + .non-printing + .non-printing + .non-printing + p {
+            text-indent: 0;
+        }
+    }
 
 }

--- a/_sass/partials/_print-toc.scss
+++ b/_sass/partials/_print-toc.scss
@@ -52,10 +52,9 @@ $print-toc: true !default;
 			li {
 				margin: 0;
 				ol, ul {
-					margin-bottom: $line-height-default;
-					li {
-						margin-left: $line-height-default;
-					}
+					list-style-type: none;
+					margin-bottom: 0;
+					margin-left: $line-height-default;
 				}
 			}
 		a::after {

--- a/_sass/partials/_web-base-typography.scss
+++ b/_sass/partials/_web-base-typography.scss
@@ -90,7 +90,9 @@ $web-base-typography: true !default;
     dl {
         margin: $line-height-default 0;
     }
-    dt {}
+    dt {
+        font-weight: bold;
+    }
     dd {
         margin: 0 0 $line-height-default 0;
     }

--- a/assets/js/page-reference.js
+++ b/assets/js/page-reference.js
@@ -22,7 +22,7 @@ function addPageReferenceFunc() {
         return;
     }
 
-    if (!typeof Prince === 'undefined') {
+    if (Prince) {
         console.log('Adding page references in Prince.');
         Prince.addScriptFunc("pagereference", function (currentPage, targetPage) {
 


### PR DESCRIPTION
- Truncate page filenames in page info
- Make definition terms bold
- Fix typo in filename that breaks output on case-sensitive Linux systems
- Indent paras that appear consecutively after non-printing elements
- Fix print TOC indentation issue
- Fix/improve syntax for checking for Prince 