### PR TITLE
Add easy way to set favicon

### DIFF
--- a/_docs/images/add-favicon.md
+++ b/_docs/images/add-favicon.md
@@ -1,0 +1,9 @@
+---
+title: Adding a favicon
+categories: images
+order: 5
+---
+
+# Adding a favicon
+
+To add a favicon (the icon in your browser tab in web output), just add a PNG image called `favicon.png` to the `assets` folder. We recommend using a very small, simple image, 64px square.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -192,10 +192,15 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    {% comment %}Set canonical URL{% endcomment %}
     {% if site.canonical-url and site.canonical-url != "" %}
         <link rel="canonical" href="{{ site.canonical-url }}">
     {% endif %}
 
+    {% comment %}Add favicon{% endcomment %}
+    <link rel="icon" type="image/png" href="{{ path-to-root-directory }}assets/favicon.png">
+
+    {% comment %}OpenGraph metadata{% endcomment %}
     <meta property="og:title" content="{{ page.title }}" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="{{ site.canonical-url}}{{ site.baseurl }}{{ page.url }}" />


### PR DESCRIPTION
Thanks to @ChristinaRookie for proposing this. 

There are more robust ways to include icons for other outputs (e.g. our approach in [Jekyll Starter](https://github.com/electricbookworks/jekyll-starter/blob/master/images/icons/README.txt)), but this works well for web output and is super easy.