### PR TITLE
Fixes and refinements

### DIFF
--- a/_configs/_config.epub.yml
+++ b/_configs/_config.epub.yml
@@ -59,3 +59,14 @@ media-types:
   txt: "text/plain"
   js: "application/x-javascript"
   unknown: "application/octet-stream"
+
+# Since some books in this project might not use MathJax,
+# we disable it by default in epub output, and
+# activate it manually on output from the output script,
+# which will override this setting.
+# (If we don't disable MathJax here, and it is enabled
+# in _config.yml, Jekyll will list the MathJax files
+# in the OPF manifest of all epubs, even if they don't need
+# MathJax, but the output script will not actually copy
+# the MathJax files into the epub package.)
+mathjax-enabled: false

--- a/_configs/_config.live.yml
+++ b/_configs/_config.live.yml
@@ -40,7 +40,7 @@ CHANGELOG.md,
 # -----------------------------------
 /assets/js/heading-titles.js,
 /assets/js/render-mathjax.js,
-/assets/js/render-search-index.js,
+# /assets/js/render-search-index.js, # Needed for generating live-build search index
 # -----------------------------------
 # Book files we don't need for web
 # -----------------------------------

--- a/_docs/editing/figures.md
+++ b/_docs/editing/figures.md
@@ -74,6 +74,7 @@ In the tag for each figure, we can define the following information:
 * a title (can be used to title descriptive text)
 * a description (hidden by default and used at `alt` text on the image; can be displayed and used with custom CSS)
 * a source (appears below the figure)
+* the height of the image in lines
 * a [class](classes.html) (for styling the layout of a given figure).
 
 The template uses that information differently depending on the output format. For instance, on the web and in the epub, the description is the text that screen-readers will read aloud to visually impaired users who can't see an image; and we don't need to display it in print.
@@ -96,6 +97,7 @@ Here is a full example:
    title="My Example Figure"
    description="This should describe what the images look like."
    source="Fire and Lion, 2017"
+   image-height="10"
    class="featured"
 %}
 ```

--- a/_includes/epub-navmap.html
+++ b/_includes/epub-navmap.html
@@ -68,7 +68,7 @@ as the include calls itself for each list of children.
         {% if include-in-toc == true %}
 
             <navLabel>
-                <text>{{ item.label | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}</text>
+                <text>{{ item.label | markdownify | strip_html | strip_newlines }}</text>
             </navLabel>
 
             {% comment %}If the item has no file to link to, use its first child's file,

--- a/_includes/redirect
+++ b/_includes/redirect
@@ -1,4 +1,7 @@
 {% comment %}
+Do not use this include in book files that are in your book's files list
+in _data/meta.yml. It will break search-index builds by redirecting the web scraper.
+
 To call this include, use the following tag with a target to redirect to:
 {% include redirect target="http://example.com" %}
 Thanks to http://insider.zone/tools/client-side-url-redirect-generator/ 

--- a/_sass/epub.scss
+++ b/_sass/epub.scss
@@ -38,7 +38,7 @@ $font-code: monospace !default;
 // These values, especially $line-height-default, are used to compute vertical rhythm
 // for many features in this theme. So do not use a unitless value for line-height,
 // and don't use percentages, which will break layouts computed by multiplying this value.
-$font-size-default: 1.2em !default;
+$font-size-default: 1em !default;
 $line-height-default: 1.5em !default;
 $font-size-smaller: 0.8 !default; // How much smaller than font-size-default for features like sidenotes and footers?
 $font-size-bigger: 2 !default; // How many times bigger than font-size-default for features like headings and pullquotes?

--- a/_sass/partials/_epub-glossaries.scss
+++ b/_sass/partials/_epub-glossaries.scss
@@ -4,17 +4,22 @@ $epub-glossaries: true !default;
     // Definition lists used in a simple glossary
     // Note dl rules are also defined in base typography
 
-    .glossary dl, dl.glossary {
-    	color: inherit;
+    // By default this is commented out of epub.css
+    // because ADE doesn't support pseudo classes
+    .glossary {
+        color: inherit;
+        // dt {
+        //     float: left;
+        //     color: inherit;
+        //     &:after {
+        //         content: ":\00a0";
+        //     }
+        // }
+        // dd {
+        //     ul, ol {
+        //         clear: left;
+        //     }
+        // }
     }
-
-    // // By default this is commented out of epub.css because ADE doesn't support pseudo classes
-    // .glossary dt {
-    // 	float: left;
-    // 	color: inherit;
-    // }
-    // .glossary dt:after {
-    //     content: ":\00a0";
-    // }
 
 }

--- a/_sass/partials/_print-glossaries.scss
+++ b/_sass/partials/_print-glossaries.scss
@@ -4,15 +4,20 @@ $print-glossaries: true !default;
     // Definition lists used in a simple glossary
     // Note dl rules are also defined in base typography
 
-    .glossary dl, dl.glossary {
-    	color: inherit;
-    }
-    .glossary dt {
-    	float: left;
-    	color: inherit;
-    }
-    .glossary dt:after {
-        content: ":\00a0";
+    .glossary {
+        color: inherit;
+        dt {
+            float: left;
+            color: inherit;
+            &:after {
+                content: ":\00a0";
+            }
+        }
+        dd {
+            ul, ol {
+                clear: left;
+            }
+        }
     }
 
 }

--- a/_sass/partials/_print-pdf-view.scss
+++ b/_sass/partials/_print-pdf-view.scss
@@ -13,6 +13,9 @@ $print-pdf-view: true !default;
         prince-pdf-profile: $pdf-profile;
         // Note colour profiles are stored in the non-generated Jekyll root, not in _site
         prince-pdf-output-intent: url("../../../_tools/profiles/#{$color-profile}");
+        @if $output-format == "print-pdf" {
+            prince-filter-resolution: 300dpi;
+        }
     }
 
     // Make the PDF page labels (numbers in PDF navigation) match the numbers of the book pages

--- a/_sass/partials/_web-glossaries.scss
+++ b/_sass/partials/_web-glossaries.scss
@@ -4,15 +4,20 @@ $web-glossaries: true !default;
     // Definition lists used in a simple glossary
     // Note dl rules are also defined in base typography
 
-    .glossary dl, dl.glossary {
-    	color: inherit;
-    }
-    .glossary dt {
-    	float: left;
-    	color: inherit;
-    }
-    .glossary dt:after {
-        content: ":\00a0";
+    .glossary {
+        color: inherit;
+        dt {
+            float: left;
+            color: inherit;
+            &:after {
+                content: ":\00a0";
+            }
+        }
+        dd {
+            ul, ol {
+                clear: left;
+            }
+        }
     }
 
 }

--- a/book/styles/epub.scss
+++ b/book/styles/epub.scss
@@ -39,7 +39,7 @@ $font-code: monospace;
 // These values, especially $line-height-default, are used to compute vertical rhythm
 // for many features in this theme. So do not use a unitless value for line-height,
 // and don't use percentages, which will break layouts computed by multiplying this value.
-$font-size-default: 1.2em;
+$font-size-default: 1em;
 $line-height-default: 1.5em;
 $font-size-smaller: 0.8; // How much smaller than font-size-default for features like sidenotes and footers?
 $font-size-bigger: 2; // How many times bigger than font-size-default for features like headings and pullquotes?

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -897,13 +897,20 @@ You may need to reload the web page once this server is running."
 		searchIndexToRefresh=""
 		read searchIndexToRefresh
 
+		# Ask the user to add any extra Jekyll config files, e.g. _config.live.yml
+		echo "Any extra config files?"
+		echo "Enter filenames (including any relative path), comma separated, no spaces. E.g."
+		echo "_configs/_config.live.yml"
+		echo "If not, just hit return."
+		read searchIndexConfig
+
 		# Generate HTML with Jekyll
 		echo "Generating HTML with Jekyll..."
 		if [ "$searchIndexToRefresh" = "a" ]
 			then
-			bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml"
+			bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,$searchIndexConfig"
 		else
-			bundle exec jekyll build --config="_config.yml,_configs/_config.web.yml"
+			bundle exec jekyll build --config="_config.yml,_configs/_config.web.yml,$searchIndexConfig"
 		fi
 
 		# Run PhantomJS script from scripts directory

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -546,13 +546,13 @@ You may need to reload the web page once this server is running."
 			echo "Epub created!"
 			# Validation
 			echo "To run validation, enter the path to the EpubCheck folder on your machine."
-			echo "Hit enter for the default: /usr/local/bin/epubcheck-4.0.2"
+			echo "Hit enter for the default: /usr/local/bin/epubcheck-4.2.0"
 			echo "(You can get EpubCheck from https://github.com/IDPF/epubcheck/releases"
 			echo "Or go to http://validator.idpf.org to validate online.)"
 			read pathtoepubcheck
 			if [ "$pathtoepubcheck" = "" ]; then
 				echo "Okay, using default EpubCheck location. "
-				pathtoepubcheck="/usr/local/bin/epubcheck-4.0.2"
+				pathtoepubcheck="/usr/local/bin/epubcheck-4.2.0"
 			fi
 			java -jar "$pathtoepubcheck"/epubcheck.jar "$epubfilename".epub
 			# Open file browser to see epub

--- a/run-mac.command
+++ b/run-mac.command
@@ -897,13 +897,20 @@ You may need to reload the web page once this server is running."
 		searchIndexToRefresh=""
 		read searchIndexToRefresh
 
+		# Ask the user to add any extra Jekyll config files, e.g. _config.live.yml
+		echo "Any extra config files?"
+		echo "Enter filenames (including any relative path), comma separated, no spaces. E.g."
+		echo "_configs/_config.live.yml"
+		echo "If not, just hit return."
+		read searchIndexConfig
+
 		# Generate HTML with Jekyll
 		echo "Generating HTML with Jekyll..."
 		if [ "$searchIndexToRefresh" = "a" ]
 			then
-			bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml"
+			bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,$searchIndexConfig"
 		else
-			bundle exec jekyll build --config="_config.yml,_configs/_config.web.yml"
+			bundle exec jekyll build --config="_config.yml,_configs/_config.web.yml,$searchIndexConfig"
 		fi
 
 		# Run PhantomJS script from scripts directory

--- a/run-mac.command
+++ b/run-mac.command
@@ -548,13 +548,13 @@ You may need to reload the web page once this server is running."
 			echo "Epub created!"
 			# Validation
 			echo "To run validation, enter the path to the EpubCheck folder on your machine."
-			echo "Hit enter for the default: /usr/local/bin/epubcheck-4.0.2"
+			echo "Hit enter for the default: /usr/local/bin/epubcheck-4.2.0"
 			echo "(You can get EpubCheck from https://github.com/IDPF/epubcheck/releases"
 			echo "Or go to http://validator.idpf.org to validate online.)"
 			read pathtoepubcheck
 			if [ "$pathtoepubcheck" = "" ]; then
 				echo "Okay, using default EpubCheck location. "
-				pathtoepubcheck="/usr/local/bin/epubcheck-4.0.2"
+				pathtoepubcheck="/usr/local/bin/epubcheck-4.2.0"
 			fi
 			java -jar "$pathtoepubcheck"/epubcheck.jar "$epubfilename".epub
 			# Open file browser to see epub

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -974,18 +974,31 @@ set /p process=Enter a number and hit return.
         echo To refresh the app search index, type a and press enter.
         set /p searchIndexToRefresh=
 
+
+        :: Ask the user to add any extra Jekyll config files,
+        :: e.g. _config.live.yml
+        :searchIndexOtherConfigs
+            echo.
+            echo Any extra config files?
+            echo Enter filenames (including any relative path), comma separated, no spaces. E.g.
+            echo _configs/_config.live.yml
+            echo If not, just hit return.
+            echo.
+            set /p searchIndexConfig=
+            echo.
+
         :: Generate HTML with Jekyll
         echo Generating HTML with Jekyll...
         if "%searchIndexToRefresh%"=="a" goto buildForAppSearchIndex
 
         :buildForWebSearchIndex
 
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.web.yml"
+            call bundle exec jekyll build --config="_config.yml,_configs/_config.web.yml,%searchIndexConfig%"
             goto refreshSearchIndexRenderWithPhantom
 
         :buildForAppSearchIndex
 
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml"
+            call bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,%searchIndexConfig%"
             goto refreshSearchIndexRenderWithPhantom
 
         :: Run phantomjs script from scripts directory

--- a/samples/styles/epub.scss
+++ b/samples/styles/epub.scss
@@ -39,7 +39,7 @@ $font-code: monospace;
 // These values, especially $line-height-default, are used to compute vertical rhythm
 // for many features in this theme. So do not use a unitless value for line-height,
 // and don't use percentages, which will break layouts computed by multiplying this value.
-$font-size-default: 1.2em;
+$font-size-default: 1em;
 $line-height-default: 1.5em;
 $font-size-smaller: 0.8; // How much smaller than font-size-default for features like sidenotes and footers?
 $font-size-bigger: 2; // How many times bigger than font-size-default for features like headings and pullquotes?


### PR DESCRIPTION
- Exclude MathJax in epub config
- Use latest Epubcheck by default
- Allow live-build search-engine rendering
- Avoid HTML in toc.ncx XML
- Clear floats at lists in glossaries
- Do not enlarge epub font size by default
- Set Prince filter resolution high on print-pdf output
- Document image-height setting in figures
- Add important comment to redirect include 