### PR TITLE
Add JS to target an element's parent element in CSS

### DIFF
--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -6,6 +6,7 @@ layout: null
 
 {% include_relative polyfills.js %}
 {% include_relative locales.js %}
+{% include_relative mark-parents.js %}
 
 {% if site.data.settings.redact == true %}
     {% include_relative redact.js %}

--- a/assets/js/mark-parents.js
+++ b/assets/js/mark-parents.js
@@ -22,7 +22,7 @@
 
 
 // Options: use a querySelector string
-var ebMarkParentsOfTheseChildren = '.lb-reference';
+var ebMarkParentsOfTheseChildren = '.place';
 
 // Promote
 function ebMarkParent(child) {

--- a/assets/js/mark-parents.js
+++ b/assets/js/mark-parents.js
@@ -1,0 +1,48 @@
+// Give a parent elements a class name based on its child
+// ------------------------------------------------------
+//
+// Useful for targeting an element because it contains
+// a given child element. Currently not possible with CSS,
+// because CSS can't target an element's parent node.
+//
+// E.g. before, we cannot target this h2 just because
+// it contains a .place:
+//
+// <h2>Rebels in Snow
+//     <span class="place">(Hoth)</span>
+// </h2>
+//
+// but, after this script runs, we get:
+//
+// <h2 class="place-parent">Rebels in Snow
+//     <span class="place">(Hoth)</span>
+// </h2>
+//
+// Set the child element's class at Options below.
+
+
+// Options: use a querySelector string
+var ebMarkParentsOfTheseChildren = '.lb-reference';
+
+// Promote
+function ebMarkParent(child) {
+    'use strict';
+
+    // Add a '-parent' class to the child element's parent element
+    var i;
+    for (i = 0; i < child.classList.length; i += 1) {
+        child.parentNode.classList.add(child.classList[i] + '-parent');
+    }
+}
+
+// Loop through the child elements
+function ebMarkParents(query) {
+    'use strict';
+    var children = document.querySelectorAll(query);
+    var i;
+    for (i = 0; i < children.length; i += 1) {
+        ebMarkParent(children[i]);
+    }
+}
+
+ebMarkParents(ebMarkParentsOfTheseChildren);


### PR DESCRIPTION
Just a little helper function, useful for targeting an element when it contains a given child element. You define the child elements whose parents you want to mark as an options setting in the `mark-parents.js` script.

This is not possible with CSS alone, because CSS can't target an element's parent node.

E.g. before, we cannot target this h2 just because it contains a `.place`:

```html
    <h2>Rebels in Snow
        <span class="place">(Hoth)</span>
    </h2>
```

but, after this script runs, we get:

```html
    <h2 class="place-parent">Rebels in Snow
        <span class="place">(Hoth)</span>
    </h2>
```

So now we can target `.place-parent` in CSS.
