### PR TITLE
Add page-info-offset var to book styles for consistency

### DIFF
--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -36,7 +36,7 @@ $margin-inside: 20mm !default;
 $bleed: 3mm !default;
 $trim: 3mm !default;
 $crop-marks: crop !default; // crop | none
-$page-info-offset: 5mm;
+$page-info-offset: 5mm !default;
 $columns-default: 1 !default;
 
 // Optional sidebar setup

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -36,7 +36,7 @@ $margin-inside: 20mm !default;
 $bleed: 0 !default;
 $trim: 0 !default;
 $crop-marks: none !default; // crop | none
-$page-info-offset: 5mm;
+$page-info-offset: 5mm !default;
 $columns-default: 1 !default;
 
 // Optional sidebar setup

--- a/book/styles/print-pdf.scss
+++ b/book/styles/print-pdf.scss
@@ -37,6 +37,7 @@ $margin-inside: 20mm;
 $bleed: 3mm;
 $trim: 3mm;
 $crop-marks: crop; // crop | none
+$page-info-offset: 5mm;
 $columns-default: 1;
 
 // Optional sidebar setup

--- a/book/styles/screen-pdf.scss
+++ b/book/styles/screen-pdf.scss
@@ -37,6 +37,7 @@ $margin-inside: 20mm;
 $bleed: 0;
 $trim: 0;
 $crop-marks: none; // crop | none
+$page-info-offset: 5mm;
 $columns-default: 1;
 
 // Optional sidebar setup

--- a/samples/styles/print-pdf.scss
+++ b/samples/styles/print-pdf.scss
@@ -37,6 +37,7 @@ $margin-inside: 20mm;
 $bleed: 3mm;
 $trim: 3mm;
 $crop-marks: crop; // crop | none
+$page-info-offset: 5mm;
 $columns-default: 1;
 
 // Optional sidebar setup

--- a/samples/styles/screen-pdf.scss
+++ b/samples/styles/screen-pdf.scss
@@ -37,6 +37,7 @@ $margin-inside: 20mm;
 $bleed: 0;
 $trim: 0;
 $crop-marks: none; // crop | none
+$page-info-offset: 5mm;
 $columns-default: 1;
 
 // Optional sidebar setup


### PR DESCRIPTION
I don't expect anyone will need to override this, but it is consistent to have all available variables listed in book styles.