### PR TITLE
Style refinements

### DIFF
--- a/_includes/toc
+++ b/_includes/toc
@@ -99,7 +99,7 @@ at the top of the toc, put this in a nav element.{% endcomment %}
 <nav epub:type="toc" id="toc"{% if site.data.settings.epub.hide-nav == true %} hidden=""{% endif %}>
 {% endif %}
 
-<ol class="toc-list {% if toc-branch contains current-file %}active{% endif %}">
+<ol class="toc-list{% if include.class %} {{ include.class }}{% endif %}{% if toc-branch contains current-file %} active{% endif %}">
 {% for item in toc-branch | sort: "order" %}
 
     {% comment %}Assume we will use every item in the toc-branch{% endcomment %}

--- a/_sass/partials/_epub-base-typography.scss
+++ b/_sass/partials/_epub-base-typography.scss
@@ -1,6 +1,15 @@
 $epub-base-typography: true !default;
 @if $epub-base-typography {
 
+    // General typography
+
+    html {
+        box-sizing: border-box;
+    }
+    *, *:before, *:after {
+        box-sizing: inherit;
+    }
+
     body {
         margin: $epub-margin;
         padding: 0;

--- a/_sass/partials/_epub-boxes.scss
+++ b/_sass/partials/_epub-boxes.scss
@@ -1,59 +1,64 @@
+// Boxes
+
+@mixin box() {
+    background-color: $color-light;
+    box-sizing: border-box;
+    color: inherit;
+    font-weight: inherit;
+    font-size: inherit;
+    border: $rule-thickness solid $color-light;
+    margin: $line-height-default 0;
+    padding: ($line-height-default / 2);
+    & p:last-of-type {
+        margin-bottom: 0;
+    }
+    // No text-indent on paragraphs after boxes
+    & + p {
+        text-indent: 0;
+    }
+    // No margin above the first headings in a box
+    h1:first-of-type, 
+    h2:first-of-type, 
+    h3:first-of-type, 
+    h4:first-of-type, 
+    h5:first-of-type, 
+    h6:first-of-type {
+        margin-top: 0;
+    }
+    li {
+        // Paragraphs within list items in a box
+        p:last-of-type {
+            margin-bottom: 0;
+        }
+    }
+    // Definition lists inside a box
+    dl {
+        &:first-of-type {
+            margin-top: 0;
+        }
+        &:last-of-type {
+            margin-bottom: 0;
+        }
+    }
+}
+
 $epub-boxes: true !default;
 @if $epub-boxes {
 
-	// Boxes
+    .box {
+        @include box();
+    }
 
-	.box {
-		background-color: $color-light;
-		color: inherit;
-		font-weight: inherit;
-		font-size: inherit;
-		border: $rule-thickness solid $color-light;
-		margin: $line-height-default 0;
-		padding: ($line-height-default / 2);
-		& p:last-of-type {
-			margin-bottom: 0;
-		}
-		// No text-indent on paragraphs after boxes
-		& + p {
-			text-indent: 0;
-		}
-		// No margin above the first headings in a box
-		h1:first-of-type, 
-		h2:first-of-type, 
-		h3:first-of-type, 
-		h4:first-of-type, 
-		h5:first-of-type, 
-		h6:first-of-type {
-			margin-top: 0;
-		}
-		li {
-			// Paragraphs within list items in a box
-			p:last-of-type {
-				margin-bottom: 0;
-			}
-		}
-		// Definition lists inside a box
-		dl {
-			&:first-of-type {
-				margin-top: 0;
-			}
-			&:last-of-type {
-				margin-bottom: 0;
-			}
-		}
-	}
-
-	// A regular paragraph as a box
-	p.box {
-		text-indent: 0;
-	}
-	// A list as a box
-	ol.box,
-	ul.box {
-		padding: ($line-height-default / 2) ($line-height-default);
-	}
-	// A regular list item as a box
-	li.box {}
+    // A regular paragraph as a box
+    p.box {
+        text-indent: 0;
+    }
+    // A list as a box
+    ol.box,
+    ul.box {
+        padding: ($line-height-default / 2) ($line-height-default);
+    }
+    // A regular list item as a box
+    li.box {}
 
 }

--- a/_sass/partials/_print-base-typography.scss
+++ b/_sass/partials/_print-base-typography.scss
@@ -8,6 +8,13 @@ $convert-images-to-color-profile: false !default;
         background-color: $color-background;
     }
 
+    html {
+        box-sizing: border-box;
+    }
+    *, *:before, *:after {
+        box-sizing: inherit;
+    }
+
     body {
         margin: 0;
         padding: 0;

--- a/_sass/partials/_print-boxes.scss
+++ b/_sass/partials/_print-boxes.scss
@@ -1,66 +1,72 @@
+// Boxes
+
+@mixin box() {
+    clear: both; // Don't let hanging sidenotes overlap over boxes
+    background-color: inherit;
+    box-decoration-break: slice; // no bottom border when box crosses page
+    box-sizing: border-box;
+    color: inherit;
+    font-weight: inherit;
+    font-size: inherit;
+    border: $rule-thickness solid $color-accent;
+    margin: $line-height-default 0;
+    padding: $line-height-default;
+    // No text-indent on paragraphs after boxes
+    & + p {
+        text-indent: 0;
+    }
+    // But paragraphs after boxes floated out of the flow must still be indented
+    &.float-top + p,
+    &.float-bottom + p {
+        text-indent: $line-height-default;
+    }
+    // No margin above the first headings in a box
+    h1:first-of-type, 
+    h2:first-of-type, 
+    h3:first-of-type, 
+    h4:first-of-type, 
+    h5:first-of-type, 
+    h6:first-of-type {
+        margin-top: 0;
+    }
+    li {
+        // Paragraphs within list items in a box
+        p:last-of-type {
+            margin-bottom: 0;
+        }
+    }
+    // Definition lists inside a box
+    dl {
+        &:first-of-type {
+            margin-top: 0;
+        }
+        &:last-of-type {
+            margin-bottom: 0;
+        }
+    }
+}
+
 $print-boxes: true !default;
 @if $print-boxes {
 
-	//Boxes
+    .box {
+        @include box();
+    }
 
-	.box {
-		clear: both; // Don't let hanging sidenotes overlap over boxes
-		background-color: inherit;
-		color: inherit;
-		font-weight: inherit;
-		font-size: inherit;
-		border: $rule-thickness solid $color-accent;
-		margin: $line-height-default 0;
-		padding: $line-height-default;
-		// No text-indent on paragraphs after boxes
-		& + p {
-			text-indent: 0;
-		}
-		// But paragraphs after boxes floated out of the flow must still be indented
-		&.float-top + p,
-		&.float-bottom + p {
-			text-indent: $line-height-default;
-		}
-		// No margin above the first headings in a box
-		h1:first-of-type, 
-		h2:first-of-type, 
-		h3:first-of-type, 
-		h4:first-of-type, 
-		h5:first-of-type, 
-		h6:first-of-type {
-			margin-top: 0;
-		}
-		li {
-			// Paragraphs within list items in a box
-			p:last-of-type {
-				margin-bottom: 0;
-			}
-		}
-		// Definition lists inside a box
-		dl {
-			&:first-of-type {
-				margin-top: 0;
-			}
-			&:last-of-type {
-				margin-bottom: 0;
-			}
-		}
-	}
-
-	// A regular paragraph as a box
-	p.box {
-		padding-bottom: $line-height-default;
-		text-indent: 0;
-	}
-	// A list as a box
-	ol.box,
-	ul.box {
-		padding: $line-height-default;
-	}
-	// A regular list item as a box
-	li.box {
-		padding: $line-height-default;
-		margin-left: $line-height-default;
-	}
+    // A regular paragraph as a box
+    p.box {
+        padding-bottom: $line-height-default;
+        text-indent: 0;
+    }
+    // A list as a box
+    ol.box,
+    ul.box {
+        padding: $line-height-default;
+    }
+    // A regular list item as a box
+    li.box {
+        padding: $line-height-default;
+        margin-left: $line-height-default;
+    }
 
 }

--- a/_sass/partials/_print-page-headers-footers-style.scss
+++ b/_sass/partials/_print-page-headers-footers-style.scss
@@ -1,5 +1,6 @@
 // Mixins, which cannot be inside Sass control directives (the @if section below).
 @mixin header-style() {
+  color: $header-text-color;
   font-family: $header-font;
   font-size: $header-font-size;
   font-weight: $header-font-weight;
@@ -11,10 +12,12 @@
   vertical-align: top;
   line-height: 1;
   margin-top: $header-space-from-top;
+  margin-bottom: $header-space-from-text;
   text-align: $header-text-align;
 }
 
 @mixin footer-style() {
+  color: footer-text-color;
   font-family: $footer-font;
   font-size: $footer-font-size;
   font-weight: $footer-font-weight;
@@ -25,6 +28,7 @@
 @mixin footer-position() {
   vertical-align: bottom;
   line-height: 1;
+  margin-top: $footer-space-from-text;
   margin-bottom: $footer-space-from-bottom;
   text-align: $footer-text-align;
 }

--- a/_sass/partials/_web-base-typography.scss
+++ b/_sass/partials/_web-base-typography.scss
@@ -3,6 +3,13 @@ $web-base-typography: true !default;
 
     // General typography
 
+    html {
+        box-sizing: border-box;
+    }
+    *, *:before, *:after {
+        box-sizing: inherit;
+    }
+
     body {
         margin: 0;
         padding: 0;

--- a/_sass/partials/_web-boxes.scss
+++ b/_sass/partials/_web-boxes.scss
@@ -1,59 +1,64 @@
+// Boxes
+
+@mixin box() {
+    background-color: $color-light;
+    box-sizing: border-box;
+    color: inherit;
+    font-weight: inherit;
+    font-size: inherit;
+    border: $rule-thickness solid $color-light;
+    margin: $line-height-default 0;
+    padding: ($line-height-default / 2);
+    & p:last-of-type {
+        margin-bottom: 0;
+    }
+    // No text-indent on paragraphs after boxes
+    & + p {
+        text-indent: 0;
+    }
+    // No margin above the first headings in a box
+    h1:first-of-type, 
+    h2:first-of-type, 
+    h3:first-of-type, 
+    h4:first-of-type, 
+    h5:first-of-type, 
+    h6:first-of-type {
+        margin-top: 0;
+    }
+    li {
+        // Paragraphs within list items in a box
+        p:last-of-type {
+            margin-bottom: 0;
+        }
+    }
+    // Definition lists inside a box
+    dl {
+        &:first-of-type {
+            margin-top: 0;
+        }
+        &:last-of-type {
+            margin-bottom: 0;
+        }
+    }
+}
+
 $web-boxes: true !default;
 @if $web-boxes {
 
-	// Boxes
+    .box {
+        @include box();
+    }
 
-	.box {
-		background-color: $color-light;
-		color: inherit;
-		font-weight: inherit;
-		font-size: inherit;
-		border: $rule-thickness solid $color-light;
-		margin: $line-height-default 0;
-		padding: ($line-height-default / 2);
-		& p:last-of-type {
-			margin-bottom: 0;
-		}
-		// No text-indent on paragraphs after boxes
-		& + p {
-			text-indent: 0;
-		}
-		// No margin above the first headings in a box
-		h1:first-of-type, 
-		h2:first-of-type, 
-		h3:first-of-type, 
-		h4:first-of-type, 
-		h5:first-of-type, 
-		h6:first-of-type {
-			margin-top: 0;
-		}
-		li {
-			// Paragraphs within list items in a box
-			p:last-of-type {
-				margin-bottom: 0;
-			}
-		}
-		// Definition lists inside a box
-		dl {
-			&:first-of-type {
-				margin-top: 0;
-			}
-			&:last-of-type {
-				margin-bottom: 0;
-			}
-		}
-	}
-
-	// A regular paragraph as a box
-	p.box {
-		text-indent: 0;
-	}
-	// A list as a box
-	ol.box,
-	ul.box {
-		padding: ($line-height-default / 2) ($line-height-default);
-	}
-	// A regular list item as a box
-	li.box {}
+    // A regular paragraph as a box
+    p.box {
+        text-indent: 0;
+    }
+    // A list as a box
+    ol.box,
+    ul.box {
+        padding: ($line-height-default / 2) ($line-height-default);
+    }
+    // A regular list item as a box
+    li.box {}
 
 }

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -219,9 +219,13 @@ $footer-case: uppercase !default; // none|capitalize|uppercase|lowercase|initial
 $header-letter-spacing: 0.1em !default;
 $footer-letter-spacing: 0.1em !default;
 $header-space-from-top: $margin-top / 2 + ($line-height-default / 4) !default; // should align with baseline grid
+$header-space-from-text: $line-height-default !default;
 $footer-space-from-bottom: $margin-bottom / 2 !default;
+$footer-space-from-text: $line-height-default !default;
 $header-text-align: center !default;
 $footer-text-align: center !default;
+$header-text-color: $color-text-main !default;
+$footer-text-color: $color-text-main !default;
 
 // Special highlights for temporary debugging/viewing:
 // Specify a colour for highlighting; use 'inherit' for none.

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -219,9 +219,13 @@ $footer-case: uppercase !default; // none|capitalize|uppercase|lowercase|initial
 $header-letter-spacing: 0.1em !default;
 $footer-letter-spacing: 0.1em !default;
 $header-space-from-top: $margin-top / 2 + ($line-height-default / 4) !default; // should align with baseline grid
+$header-space-from-text: $line-height-default !default;
 $footer-space-from-bottom: $margin-bottom / 2 !default;
+$footer-space-from-text: $line-height-default !default;
 $header-text-align: center !default;
 $footer-text-align: center !default;
+$header-text-color: $color-text-main !default;
+$footer-text-color: $color-text-main !default;
 
 // Special highlights for temporary debugging/viewing:
 // Specify a colour for highlighting; use 'inherit' for none.

--- a/book/styles/print-pdf.scss
+++ b/book/styles/print-pdf.scss
@@ -224,10 +224,14 @@ $header-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $footer-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $header-letter-spacing: 0.1em;
 $footer-letter-spacing: 0.1em;
-$header-space-from-top: $margin-top / 2 + ($line-height-default / 4);
+$header-space-from-top: $margin-top / 2 + ($line-height-default / 4); // should align with baseline grid
+$header-space-from-text: $line-height-default;
 $footer-space-from-bottom: $margin-bottom / 2;
+$footer-space-from-text: $line-height-default;
 $header-text-align: center;
 $footer-text-align: center;
+$header-text-color: $color-text-main;
+$footer-text-color: $color-text-main;
 
 // Special highlights for temporary debugging/viewing:
 // Specify a colour for highlighting; use 'inherit' for none.

--- a/book/styles/screen-pdf.scss
+++ b/book/styles/screen-pdf.scss
@@ -224,10 +224,14 @@ $header-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $footer-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $header-letter-spacing: 0.1em;
 $footer-letter-spacing: 0.1em;
-$header-space-from-top: $margin-top / 2 + ($line-height-default / 4);
+$header-space-from-top: $margin-top / 2 + ($line-height-default / 4); // should align with baseline grid
+$header-space-from-text: $line-height-default;
 $footer-space-from-bottom: $margin-bottom / 2;
+$footer-space-from-text: $line-height-default;
 $header-text-align: center;
 $footer-text-align: center;
+$header-text-color: $color-text-main;
+$footer-text-color: $color-text-main;
 
 // Special highlights for temporary debugging/viewing:
 // Specify a colour for highlighting; use 'inherit' for none.

--- a/samples/styles/print-pdf.scss
+++ b/samples/styles/print-pdf.scss
@@ -224,10 +224,14 @@ $header-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $footer-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $header-letter-spacing: 0.1em;
 $footer-letter-spacing: 0.1em;
-$header-space-from-top: $margin-top / 2 + ($line-height-default / 4);
+$header-space-from-top: $margin-top / 2 + ($line-height-default / 4); // should align with baseline grid
+$header-space-from-text: $line-height-default;
 $footer-space-from-bottom: $margin-bottom / 2;
+$footer-space-from-text: $line-height-default;
 $header-text-align: center;
 $footer-text-align: center;
+$header-text-color: $color-text-main;
+$footer-text-color: $color-text-main;
 
 // Special highlights for temporary debugging/viewing:
 // Specify a colour for highlighting; use 'inherit' for none.

--- a/samples/styles/screen-pdf.scss
+++ b/samples/styles/screen-pdf.scss
@@ -224,10 +224,14 @@ $header-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $footer-case: uppercase; // none|capitalize|uppercase|lowercase|initial|inherit;
 $header-letter-spacing: 0.1em;
 $footer-letter-spacing: 0.1em;
-$header-space-from-top: $margin-top / 2 + ($line-height-default / 4);
+$header-space-from-top: $margin-top / 2 + ($line-height-default / 4); // should align with baseline grid
+$header-space-from-text: $line-height-default;
 $footer-space-from-bottom: $margin-bottom / 2;
+$footer-space-from-text: $line-height-default;
 $header-text-align: center;
 $footer-text-align: center;
+$header-text-color: $color-text-main;
+$footer-text-color: $color-text-main;
 
 // Special highlights for temporary debugging/viewing:
 // Specify a colour for highlighting; use 'inherit' for none.


### PR DESCRIPTION
- Allow passing class to TOC include
- Use `box-sizing: border-box` by default ([background](https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/))
- Move box styles to `@mixin box()` for reuse in custom styles
- Add variables for controlling header/footer styling 