### PR TITLE
Enable setting relative size of maths in PDF as a variable

### DIFF
--- a/_sass/partials/_print-maths.scss
+++ b/_sass/partials/_print-maths.scss
@@ -35,6 +35,6 @@ $print-maths: true !default;
     // This may be a magic number to adjust,
     // depending on your body text font.
     .mjpage * {
-        font-size: 75%;
+        font-size: $math-size-percent;
     }
 }

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -100,6 +100,7 @@ $text-align: justify !default; // left or right or inside or outside or justify 
 $orphans: 1 !default; // Minimum number of lines that must be left at the bottom of the first page
 $widows: 1 !default; // Minimum number of lines that must be left at the top of the second page
 $letter-spacing-text: 0em !default; // Default letter-spacing for p, ul, ol, dl. Set in ems, e.g. 0.01em for 10/1000s of an em.
+$math-size-percent: 85%; // Adjust this to make math character size match your body font
 
 // Do you want space between paragraphs, rather than a text-indent? true or false
 $spaced-paras: false !default;

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -100,6 +100,7 @@ $text-align: justify !default; // left or right or inside or outside or justify 
 $orphans: 1 !default; // Minimum number of lines that must be left at the bottom of the first page
 $widows: 1 !default; // Minimum number of lines that must be left at the top of the second page
 $letter-spacing-text: 0em !default; // Default letter-spacing for p, ul, ol, dl. Set in ems, e.g. 0.01em for 10/1000s of an em.
+$math-size-percent: 85%; // Adjust this to make math character size match your body font
 
 // Do you want space between paragraphs, rather than a text-indent? true or false
 $spaced-paras: false !default;

--- a/book/styles/print-pdf.scss
+++ b/book/styles/print-pdf.scss
@@ -106,6 +106,7 @@ $text-align: justify; // left or right or inside or outside or justify or center
 $orphans: 1; // Minimum number of lines that must be left at the bottom of the first page
 $widows: 1; // Minimum number of lines that must be left at the top of the second page
 $letter-spacing-text: 0em; // Default letter-spacing for p, ul, ol, dl. Set in ems, e.g. 0.01em for 10/1000s of an em.
+$math-size-percent: 85%; // Adjust this to make math character size match your body font
 
 // Do you want space between paragraphs, rather than a text-indent? true or false
 $spaced-paras: false;

--- a/book/styles/screen-pdf.scss
+++ b/book/styles/screen-pdf.scss
@@ -106,6 +106,7 @@ $text-align: justify; // left or right or inside or outside or justify or center
 $orphans: 1; // Minimum number of lines that must be left at the bottom of the first page
 $widows: 1; // Minimum number of lines that must be left at the top of the second page
 $letter-spacing-text: 0em; // Default letter-spacing for p, ul, ol, dl. Set in ems, e.g. 0.01em for 10/1000s of an em.
+$math-size-percent: 85%; // Adjust this to make math character size match your body font
 
 // Do you want space between paragraphs, rather than a text-indent? true or false
 $spaced-paras: false;

--- a/samples/styles/print-pdf.scss
+++ b/samples/styles/print-pdf.scss
@@ -106,6 +106,7 @@ $text-align: justify; // left or right or inside or outside or justify or center
 $orphans: 1; // Minimum number of lines that must be left at the bottom of the first page
 $widows: 1; // Minimum number of lines that must be left at the top of the second page
 $letter-spacing-text: 0em; // Default letter-spacing for p, ul, ol, dl. Set in ems, e.g. 0.01em for 10/1000s of an em.
+$math-size-percent: 85%; // Adjust this to make math character size match your body font
 
 // Do you want space between paragraphs, rather than a text-indent? true or false
 $spaced-paras: false;

--- a/samples/styles/screen-pdf.scss
+++ b/samples/styles/screen-pdf.scss
@@ -106,6 +106,7 @@ $text-align: justify; // left or right or inside or outside or justify or center
 $orphans: 1; // Minimum number of lines that must be left at the bottom of the first page
 $widows: 1; // Minimum number of lines that must be left at the top of the second page
 $letter-spacing-text: 0em; // Default letter-spacing for p, ul, ol, dl. Set in ems, e.g. 0.01em for 10/1000s of an em.
+$math-size-percent: 85%; // Adjust this to make math character size match your body font
 
 // Do you want space between paragraphs, rather than a text-indent? true or false
 $spaced-paras: false;


### PR DESCRIPTION
The size of MathJax maths in PDF must be adjusted depending on your choice of fonts and their sizes. (We've learned through much experimentation that this is better than managing size via the MathJax config in our gulpfile.)

Previously, this was hard-coded into our PDF partials. This change lets you set this relative size (as a percentage) in a project or book's PDF Sass files as a variable.