### PR TITLE
Add variables for content and style in side-margin boxes

### DIFF
--- a/_sass/partials/_print-page-headers-footers-content.scss
+++ b/_sass/partials/_print-page-headers-footers-content.scss
@@ -90,6 +90,24 @@ $print-page-headers-footers-content: true !default;
     @bottom-right-corner {
       content: $verso-bottom-right-corner;
     }
+    @left {
+      content: $verso-left;
+    }
+    @left-top {
+      content: $verso-left-top;
+    }
+    @left-bottom {
+      content: $verso-left-bottom;
+    }
+    @right {
+      content: $verso-right;
+    }
+    @right-top {
+      content: $verso-right-top;
+    }
+    @right-bottom {
+      content: $verso-right-bottom;
+    }
   }
 
   // Recto
@@ -124,6 +142,24 @@ $print-page-headers-footers-content: true !default;
     @bottom-right-corner {
       content: $recto-bottom-right-corner;
     }
+    @left {
+      content: $recto-left;
+    }
+    @left-top {
+      content: $recto-left-top;
+    }
+    @left-bottom {
+      content: $recto-left-bottom;
+    }
+    @right {
+      content: $recto-right;
+    }
+    @right-top {
+      content: $recto-right-top;
+    }
+    @right-bottom {
+      content: $recto-right-bottom;
+    }
   }
 
   // No headers on first pages of chapters
@@ -136,6 +172,12 @@ $print-page-headers-footers-content: true !default;
     @top-right { content: normal; }
     @top-left-corner { content: normal; }
     @top-right-corner { content: normal; }
+    @left { content: normal; }
+    @left-top { content: normal; }
+    @left-bottom { content: normal; }
+    @right { content: normal; }
+    @right-top { content: normal; }
+    @right-bottom { content: normal; }
   }
 
   // No headers or footers on blank pages of chapters
@@ -150,6 +192,12 @@ $print-page-headers-footers-content: true !default;
     @bottom-right { content: normal; }
     @bottom-left-corner { content: normal; }
     @bottom-right-corner { content: normal; }
+    @left { content: normal; }
+    @left-top { content: normal; }
+    @left-bottom { content: normal; }
+    @right { content: normal; }
+    @right-top { content: normal; }
+    @right-bottom { content: normal; }
   }
 
   // Now we place our content for `.frontmatter` pages
@@ -186,6 +234,24 @@ $print-page-headers-footers-content: true !default;
     @bottom-right-corner {
       content: $verso-bottom-right-corner-frontmatter;
     }
+    @left {
+      content: $verso-left-frontmatter;
+    }
+    @left-top {
+      content: $verso-left-top-frontmatter;
+    }
+    @left-bottom {
+      content: $verso-left-bottom-frontmatter;
+    }
+    @right {
+      content: $verso-right-frontmatter;
+    }
+    @right-top {
+      content: $verso-right-top-frontmatter;
+    }
+    @right-bottom {
+      content: $verso-right-bottom-frontmatter;
+    }
   }
 
   // Recto
@@ -220,6 +286,24 @@ $print-page-headers-footers-content: true !default;
     @bottom-right-corner {
       content: $recto-bottom-right-corner-frontmatter;
     }
+    @left {
+      content: $recto-left-frontmatter;
+    }
+    @left-top {
+      content: $recto-left-top-frontmatter;
+    }
+    @left-bottom {
+      content: $recto-left-bottom-frontmatter;
+    }
+    @right {
+      content: $recto-right-frontmatter;
+    }
+    @right-top {
+      content: $recto-right-top-frontmatter;
+    }
+    @right-bottom {
+      content: $recto-right-bottom-frontmatter;
+    }
   }
 
   // No headers on first pages of frontmatter
@@ -232,6 +316,12 @@ $print-page-headers-footers-content: true !default;
     @top-right { content: normal; }
     @top-left-corner { content: normal; }
     @top-right-corner { content: normal; }
+    @left { content: normal; }
+    @left-top { content: normal; }
+    @left-bottom { content: normal; }
+    @right { content: normal; }
+    @right-top { content: normal; }
+    @right-bottom { content: normal; }
   }
 
   // No headers or footers on blank pages of frontmatter
@@ -246,6 +336,12 @@ $print-page-headers-footers-content: true !default;
     @bottom-right { content: normal; }
     @bottom-left-corner { content: normal; }
     @bottom-right-corner { content: normal; }
+    @left { content: normal; }
+    @left-top { content: normal; }
+    @left-bottom { content: normal; }
+    @right { content: normal; }
+    @right-top { content: normal; }
+    @right-bottom { content: normal; }
   }
 
   // Reset page numbering to 1

--- a/_sass/partials/_print-page-headers-footers-style.scss
+++ b/_sass/partials/_print-page-headers-footers-style.scss
@@ -33,6 +33,40 @@
   text-align: $footer-text-align;
 }
 
+@mixin left-margin-style() {
+  font-family: $left-margin-font;
+  font-size: $left-margin-font-size;
+  font-weight: $left-margin-font-weight;
+  text-transform: $left-margin-case;
+  letter-spacing: $left-margin-letter-spacing;
+  writing-mode: vertical-rl; // should be vertical-lr but prince doesn't support it
+}
+
+@mixin left-margin-position() {
+  vertical-align: $left-margin-alignment;
+  line-height: 1;
+  padding-left: $left-margin-space-from-edge;
+  margin-right: $left-margin-space-from-text;
+  text-align: $left-margin-text-align;
+}
+
+@mixin right-margin-style() {
+  font-family: $right-margin-font;
+  font-size: $right-margin-font-size;
+  font-weight: $right-margin-font-weight;
+  text-transform: $right-margin-case;
+  letter-spacing: $right-margin-letter-spacing;
+  writing-mode: vertical-rl;
+}
+
+@mixin right-margin-position() {
+  vertical-align: $right-margin-alignment;
+  line-height: 1;
+  padding-right: $right-margin-space-from-edge;
+  margin-left: $right-margin-space-from-text;
+  text-align: $right-margin-text-align;
+}
+
 $print-page-headers-footers-style: true !default;
 @if $print-page-headers-footers-style {
 
@@ -85,6 +119,30 @@ $print-page-headers-footers-style: true !default;
       @include footer-style();
       @include footer-position();
     }
+    @left {
+      @include left-margin-style
+      @include left-margin-position();
+    }
+    @left-top {
+      @include left-margin-style
+      @include left-margin-position();
+    }
+    @left-bottom {
+      @include left-margin-style
+      @include left-margin-position();
+    }
+    @right {
+      @include right-margin-style
+      @include right-margin-position();
+    }
+    @right-top {
+      @include right-margin-style
+      @include right-margin-position();
+    }
+    @right-bottom {
+      @include right-margin-style
+      @include right-margin-position();
+    }
   }
 
   // Recto
@@ -128,6 +186,30 @@ $print-page-headers-footers-style: true !default;
     @bottom-right-corner {
       @include footer-style();
       @include footer-position();
+    }
+    @left {
+      @include left-margin-style
+      @include left-margin-position();
+    }
+    @left-top {
+      @include left-margin-style
+      @include left-margin-position();
+    }
+    @left-bottom {
+      @include left-margin-style
+      @include left-margin-position();
+    }
+    @right {
+      @include right-margin-style
+      @include right-margin-position();
+    }
+    @right-top {
+      @include right-margin-style
+      @include right-margin-position();
+    }
+    @right-bottom {
+      @include right-margin-style
+      @include right-margin-position();
     }
   }
 
@@ -173,6 +255,30 @@ $print-page-headers-footers-style: true !default;
       @include footer-style();
       @include footer-position();
     }
+    @left {
+      @include left-margin-style
+      @include left-margin-position();
+    }
+    @left-top {
+      @include left-margin-style
+      @include left-margin-position();
+    }
+    @left-bottom {
+      @include left-margin-style
+      @include left-margin-position();
+    }
+    @right {
+      @include right-margin-style
+      @include right-margin-position();
+    }
+    @right-top {
+      @include right-margin-style
+      @include right-margin-position();
+    }
+    @right-bottom {
+      @include right-margin-style
+      @include right-margin-position();
+    }
   }
 
   // Recto
@@ -216,6 +322,30 @@ $print-page-headers-footers-style: true !default;
     @bottom-right-corner {
       @include footer-style();
       @include footer-position();
+    }
+    @left {
+      @include left-margin-style
+      @include left-margin-position();
+    }
+    @left-top {
+      @include left-margin-style
+      @include left-margin-position();
+    }
+    @left-bottom {
+      @include left-margin-style
+      @include left-margin-position();
+    }
+    @right {
+      @include right-margin-style
+      @include right-margin-position();
+    }
+    @right-top {
+      @include right-margin-style
+      @include right-margin-position();
+    }
+    @right-bottom {
+      @include right-margin-style
+      @include right-margin-position();
     }
   }
 

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -171,6 +171,12 @@ $verso-bottom-left: normal !default;
 $verso-bottom-right: normal !default;
 $verso-bottom-left-corner: normal !default;
 $verso-bottom-right-corner: normal !default;
+$verso-left: normal !default;
+$verso-left-top: normal !default;
+$verso-left-bottom: normal !default;
+$verso-right: normal !default;
+$verso-right-top: normal !default;
+$verso-right-bottom: normal !default;
 
 // Recto (right-hand-page)
 $recto-top: string(h2-text, last) !default;
@@ -183,6 +189,12 @@ $recto-bottom-left: normal !default;
 $recto-bottom-right: normal !default;
 $recto-bottom-left-corner: normal !default;
 $recto-bottom-right-corner: normal !default;
+$recto-left: normal !default;
+$recto-left-top: normal !default;
+$recto-left-bottom: normal !default;
+$recto-right: normal !default;
+$recto-right-top: normal !default;
+$recto-right-bottom: normal !default;
 
 // Verso (left-hand-page) for .frontmatter pages (`style: frontmatter`)
 $verso-top-frontmatter: string(page-header) !default;
@@ -195,6 +207,12 @@ $verso-bottom-left-frontmatter: normal !default;
 $verso-bottom-right-frontmatter: normal !default;
 $verso-bottom-left-corner-frontmatter: normal !default;
 $verso-bottom-right-corner-frontmatter: normal !default;
+$verso-left-frontmatter: normal !default;
+$verso-left-top-frontmatter: normal !default;
+$verso-left-bottom-frontmatter: normal !default;
+$verso-right-frontmatter: normal !default;
+$verso-right-top-frontmatter: normal !default;
+$verso-right-bottom-frontmatter: normal !default;
 
 // Recto (right-hand-page) for .frontmatter pages (`style: frontmatter`)
 $recto-top-frontmatter: string(h2-text, last) !default;
@@ -207,6 +225,12 @@ $recto-bottom-left-frontmatter: normal !default;
 $recto-bottom-right-frontmatter: normal !default;
 $recto-bottom-left-corner-frontmatter: normal !default;
 $recto-bottom-right-corner-frontmatter: normal !default;
+$recto-left-frontmatter: normal !default;
+$recto-left-top-frontmatter: normal !default;
+$recto-left-bottom-frontmatter: normal !default;
+$recto-right-frontmatter: normal !default;
+$recto-right-top-frontmatter: normal !default;
+$recto-right-bottom-frontmatter: normal !default;
 
 // Set styles for headers and footers
 $header-font: $font-text-secondary !default;
@@ -227,6 +251,26 @@ $header-text-align: center !default;
 $footer-text-align: center !default;
 $header-text-color: $color-text-main !default;
 $footer-text-color: $color-text-main !default;
+$left-margin-font: $header-font !default;
+$left-margin-font-size: $header-font-size !default;
+$left-margin-font-weight: $header-font-weight !default;
+$left-margin-case: $header-case !default;
+$left-margin-letter-spacing: $header-letter-spacing !default;
+$left-margin-alignment: top !default;
+$left-margin-space-from-edge: $margin-outside / 2 !default;
+$left-margin-space-from-text: $margin-outside / 2 - $left-margin-font-size !default;
+$left-margin-text-align: $header-text-align !default;
+$left-margin-text-color: $color-text-main !default;
+$right-margin-font: $header-font !default;
+$right-margin-font-size: $header-font-size !default;
+$right-margin-font-weight: $header-font-weight !default;
+$right-margin-case: $header-case !default;
+$right-margin-letter-spacing: $header-letter-spacing !default;
+$right-margin-alignment: top !default;
+$right-margin-space-from-edge: $margin-outside / 2 + $right-margin-font-size !default;
+$right-margin-space-from-text: $margin-outside / 2 - $right-margin-font-size !default;
+$right-margin-text-align: $header-text-align !default;
+$right-margin-text-color: $color-text-main !default;
 
 // Special highlights for temporary debugging/viewing:
 // Specify a colour for highlighting; use 'inherit' for none.

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -171,6 +171,12 @@ $verso-bottom-left: normal !default;
 $verso-bottom-right: normal !default;
 $verso-bottom-left-corner: normal !default;
 $verso-bottom-right-corner: normal !default;
+$recto-left: normal !default;
+$recto-left-top: normal !default;
+$recto-left-bottom: normal !default;
+$recto-right: normal !default;
+$recto-right-top: normal !default;
+$recto-right-bottom: normal !default;
 
 // Recto (right-hand-page)
 $recto-top: string(h2-text, last) !default;
@@ -183,6 +189,12 @@ $recto-bottom-left: normal !default;
 $recto-bottom-right: normal !default;
 $recto-bottom-left-corner: normal !default;
 $recto-bottom-right-corner: normal !default;
+$recto-left: normal !default;
+$recto-left-top: normal !default;
+$recto-left-bottom: normal !default;
+$recto-right: normal !default;
+$recto-right-top: normal !default;
+$recto-right-bottom: normal !default;
 
 // Verso (left-hand-page) for .frontmatter pages (`style: frontmatter`)
 $verso-top-frontmatter: string(page-header) !default;
@@ -195,6 +207,12 @@ $verso-bottom-left-frontmatter: normal !default;
 $verso-bottom-right-frontmatter: normal !default;
 $verso-bottom-left-corner-frontmatter: normal !default;
 $verso-bottom-right-corner-frontmatter: normal !default;
+$verso-left-frontmatter: normal !default;
+$verso-left-top-frontmatter: normal !default;
+$verso-left-bottom-frontmatter: normal !default;
+$verso-right-frontmatter: normal !default;
+$verso-right-top-frontmatter: normal !default;
+$verso-right-bottom-frontmatter: normal !default;
 
 // Recto (right-hand-page) for .frontmatter pages (`style: frontmatter`)
 $recto-top-frontmatter: string(h2-text, last) !default;
@@ -207,6 +225,12 @@ $recto-bottom-left-frontmatter: normal !default;
 $recto-bottom-right-frontmatter: normal !default;
 $recto-bottom-left-corner-frontmatter: normal !default;
 $recto-bottom-right-corner-frontmatter: normal !default;
+$recto-left-frontmatter: normal !default;
+$recto-left-top-frontmatter: normal !default;
+$recto-left-bottom-frontmatter: normal !default;
+$recto-right-frontmatter: normal !default;
+$recto-right-top-frontmatter: normal !default;
+$recto-right-bottom-frontmatter: normal !default;
 
 // Set styles for headers and footers
 $header-font: $font-text-secondary !default;
@@ -227,6 +251,26 @@ $header-text-align: center !default;
 $footer-text-align: center !default;
 $header-text-color: $color-text-main !default;
 $footer-text-color: $color-text-main !default;
+$left-margin-font: $header-font !default;
+$left-margin-font-size: $header-font-size !default;
+$left-margin-font-weight: $header-font-weight !default;
+$left-margin-case: $header-case !default;
+$left-margin-letter-spacing: $header-letter-spacing !default;
+$left-margin-alignment: top !default;
+$left-margin-space-from-edge: $margin-outside / 2 !default;
+$left-margin-space-from-text: $margin-outside / 2 - $left-margin-font-size !default;
+$left-margin-text-align: $header-text-align !default;
+$left-margin-text-color: $color-text-main !default;
+$right-margin-font: $header-font !default;
+$right-margin-font-size: $header-font-size !default;
+$right-margin-font-weight: $header-font-weight !default;
+$right-margin-case: $header-case !default;
+$right-margin-letter-spacing: $header-letter-spacing !default;
+$right-margin-alignment: top !default;
+$right-margin-space-from-edge: $margin-outside / 2 + $right-margin-font-size !default;
+$right-margin-space-from-text: $margin-outside / 2 - $right-margin-font-size !default;
+$right-margin-text-align: $header-text-align !default;
+$right-margin-text-color: $color-text-main !default;
 
 // Special highlights for temporary debugging/viewing:
 // Specify a colour for highlighting; use 'inherit' for none.

--- a/book/styles/print-pdf.scss
+++ b/book/styles/print-pdf.scss
@@ -177,6 +177,12 @@ $verso-bottom-left: normal;
 $verso-bottom-right: normal;
 $verso-bottom-left-corner: normal;
 $verso-bottom-right-corner: normal;
+$verso-left: normal;
+$verso-left-top: normal;
+$verso-left-bottom: normal;
+$verso-right: normal;
+$verso-right-top: normal;
+$verso-right-bottom: normal;
 
 // Recto (right-hand-page)
 $recto-top: string(h2-text, last);
@@ -189,6 +195,12 @@ $recto-bottom-left: normal;
 $recto-bottom-right: normal;
 $recto-bottom-left-corner: normal;
 $recto-bottom-right-corner: normal;
+$recto-left: normal;
+$recto-left-top: normal;
+$recto-left-bottom: normal;
+$recto-right: normal;
+$recto-right-top: normal;
+$recto-right-bottom: normal;
 
 // Verso (left-hand-page) for .frontmatter pages (`style: frontmatter`)
 $verso-top-frontmatter: string(page-header);
@@ -201,6 +213,12 @@ $verso-bottom-left-frontmatter: normal;
 $verso-bottom-right-frontmatter: normal;
 $verso-bottom-left-corner-frontmatter: normal;
 $verso-bottom-right-corner-frontmatter: normal;
+$verso-left-frontmatter: normal;
+$verso-left-top-frontmatter: normal;
+$verso-left-bottom-frontmatter: normal;
+$verso-right-frontmatter: normal;
+$verso-right-top-frontmatter: normal;
+$verso-right-bottom-frontmatter: normal;
 
 // Recto (right-hand-page) for .frontmatter pages (`style: frontmatter`)
 $recto-top-frontmatter: string(h2-text, last);
@@ -213,6 +231,12 @@ $recto-bottom-left-frontmatter: normal;
 $recto-bottom-right-frontmatter: normal;
 $recto-bottom-left-corner-frontmatter: normal;
 $recto-bottom-right-corner-frontmatter: normal;
+$recto-left-frontmatter: normal;
+$recto-left-top-frontmatter: normal;
+$recto-left-bottom-frontmatter: normal;
+$recto-right-frontmatter: normal;
+$recto-right-top-frontmatter: normal;
+$recto-right-bottom-frontmatter: normal;
 
 // Set styles for headers and footers
 $header-font: $font-text-secondary;
@@ -233,6 +257,26 @@ $header-text-align: center;
 $footer-text-align: center;
 $header-text-color: $color-text-main;
 $footer-text-color: $color-text-main;
+$left-margin-font: $header-font;
+$left-margin-font-size: $header-font-size;
+$left-margin-font-weight: $header-font-weight;
+$left-margin-case: $header-case;
+$left-margin-letter-spacing: $header-letter-spacing;
+$left-margin-alignment: top;
+$left-margin-space-from-edge: $margin-outside / 2;
+$left-margin-space-from-text: $margin-outside / 2 - $left-margin-font-size;
+$left-margin-text-align: $header-text-align;
+$left-margin-text-color: $color-text-main;
+$right-margin-font: $header-font;
+$right-margin-font-size: $header-font-size;
+$right-margin-font-weight: $header-font-weight;
+$right-margin-case: $header-case;
+$right-margin-letter-spacing: $header-letter-spacing;
+$right-margin-alignment: top;
+$right-margin-space-from-edge: $margin-outside / 2 + $right-margin-font-size;
+$right-margin-space-from-text: $margin-outside / 2 - $right-margin-font-size;
+$right-margin-text-align: $header-text-align;
+$right-margin-text-color: $color-text-main;
 
 // Special highlights for temporary debugging/viewing:
 // Specify a colour for highlighting; use 'inherit' for none.

--- a/book/styles/screen-pdf.scss
+++ b/book/styles/screen-pdf.scss
@@ -177,6 +177,12 @@ $verso-bottom-left: normal;
 $verso-bottom-right: normal;
 $verso-bottom-left-corner: normal;
 $verso-bottom-right-corner: normal;
+$verso-left: normal;
+$verso-left-top: normal;
+$verso-left-bottom: normal;
+$verso-right: normal;
+$verso-right-top: normal;
+$verso-right-bottom: normal;
 
 // Recto (right-hand-page)
 $recto-top: string(h2-text, last);
@@ -189,6 +195,12 @@ $recto-bottom-left: normal;
 $recto-bottom-right: normal;
 $recto-bottom-left-corner: normal;
 $recto-bottom-right-corner: normal;
+$recto-left: normal;
+$recto-left-top: normal;
+$recto-left-bottom: normal;
+$recto-right: normal;
+$recto-right-top: normal;
+$recto-right-bottom: normal;
 
 // Verso (left-hand-page) for .frontmatter pages (`style: frontmatter`)
 $verso-top-frontmatter: string(page-header);
@@ -201,6 +213,12 @@ $verso-bottom-left-frontmatter: normal;
 $verso-bottom-right-frontmatter: normal;
 $verso-bottom-left-corner-frontmatter: normal;
 $verso-bottom-right-corner-frontmatter: normal;
+$verso-left-frontmatter: normal;
+$verso-left-top-frontmatter: normal;
+$verso-left-bottom-frontmatter: normal;
+$verso-right-frontmatter: normal;
+$verso-right-top-frontmatter: normal;
+$verso-right-bottom-frontmatter: normal;
 
 // Recto (right-hand-page) for .frontmatter pages (`style: frontmatter`)
 $recto-top-frontmatter: string(h2-text, last);
@@ -213,6 +231,12 @@ $recto-bottom-left-frontmatter: normal;
 $recto-bottom-right-frontmatter: normal;
 $recto-bottom-left-corner-frontmatter: normal;
 $recto-bottom-right-corner-frontmatter: normal;
+$recto-left-frontmatter: normal;
+$recto-left-top-frontmatter: normal;
+$recto-left-bottom-frontmatter: normal;
+$recto-right-frontmatter: normal;
+$recto-right-top-frontmatter: normal;
+$recto-right-bottom-frontmatter: normal;
 
 // Set styles for headers and footers
 $header-font: $font-text-secondary;
@@ -233,6 +257,26 @@ $header-text-align: center;
 $footer-text-align: center;
 $header-text-color: $color-text-main;
 $footer-text-color: $color-text-main;
+$left-margin-font: $header-font;
+$left-margin-font-size: $header-font-size;
+$left-margin-font-weight: $header-font-weight;
+$left-margin-case: $header-case;
+$left-margin-letter-spacing: $header-letter-spacing;
+$left-margin-alignment: top;
+$left-margin-space-from-edge: $margin-outside / 2;
+$left-margin-space-from-text: $margin-outside / 2 - $left-margin-font-size;
+$left-margin-text-align: $header-text-align;
+$left-margin-text-color: $color-text-main;
+$right-margin-font: $header-font;
+$right-margin-font-size: $header-font-size;
+$right-margin-font-weight: $header-font-weight;
+$right-margin-case: $header-case;
+$right-margin-letter-spacing: $header-letter-spacing;
+$right-margin-alignment: top;
+$right-margin-space-from-edge: $margin-outside / 2 + $right-margin-font-size;
+$right-margin-space-from-text: $margin-outside / 2 - $right-margin-font-size;
+$right-margin-text-align: $header-text-align;
+$right-margin-text-color: $color-text-main;
 
 // Special highlights for temporary debugging/viewing:
 // Specify a colour for highlighting; use 'inherit' for none.

--- a/samples/styles/print-pdf.scss
+++ b/samples/styles/print-pdf.scss
@@ -177,6 +177,12 @@ $verso-bottom-left: normal;
 $verso-bottom-right: normal;
 $verso-bottom-left-corner: normal;
 $verso-bottom-right-corner: normal;
+$verso-left: normal;
+$verso-left-top: normal;
+$verso-left-bottom: normal;
+$verso-right: normal;
+$verso-right-top: normal;
+$verso-right-bottom: normal;
 
 // Recto (right-hand-page)
 $recto-top: string(h2-text, last);
@@ -189,6 +195,12 @@ $recto-bottom-left: normal;
 $recto-bottom-right: normal;
 $recto-bottom-left-corner: normal;
 $recto-bottom-right-corner: normal;
+$recto-left: normal;
+$recto-left-top: normal;
+$recto-left-bottom: normal;
+$recto-right: normal;
+$recto-right-top: normal;
+$recto-right-bottom: normal;
 
 // Verso (left-hand-page) for .frontmatter pages (`style: frontmatter`)
 $verso-top-frontmatter: string(page-header);
@@ -201,6 +213,12 @@ $verso-bottom-left-frontmatter: normal;
 $verso-bottom-right-frontmatter: normal;
 $verso-bottom-left-corner-frontmatter: normal;
 $verso-bottom-right-corner-frontmatter: normal;
+$verso-left-frontmatter: normal;
+$verso-left-top-frontmatter: normal;
+$verso-left-bottom-frontmatter: normal;
+$verso-right-frontmatter: normal;
+$verso-right-top-frontmatter: normal;
+$verso-right-bottom-frontmatter: normal;
 
 // Recto (right-hand-page) for .frontmatter pages (`style: frontmatter`)
 $recto-top-frontmatter: string(h2-text, last);
@@ -213,6 +231,12 @@ $recto-bottom-left-frontmatter: normal;
 $recto-bottom-right-frontmatter: normal;
 $recto-bottom-left-corner-frontmatter: normal;
 $recto-bottom-right-corner-frontmatter: normal;
+$recto-left-frontmatter: normal;
+$recto-left-top-frontmatter: normal;
+$recto-left-bottom-frontmatter: normal;
+$recto-right-frontmatter: normal;
+$recto-right-top-frontmatter: normal;
+$recto-right-bottom-frontmatter: normal;
 
 // Set styles for headers and footers
 $header-font: $font-text-secondary;
@@ -233,6 +257,26 @@ $header-text-align: center;
 $footer-text-align: center;
 $header-text-color: $color-text-main;
 $footer-text-color: $color-text-main;
+$left-margin-font: $header-font;
+$left-margin-font-size: $header-font-size;
+$left-margin-font-weight: $header-font-weight;
+$left-margin-case: $header-case;
+$left-margin-letter-spacing: $header-letter-spacing;
+$left-margin-alignment: top;
+$left-margin-space-from-edge: $margin-outside / 2;
+$left-margin-space-from-text: $margin-outside / 2 - $left-margin-font-size;
+$left-margin-text-align: $header-text-align;
+$left-margin-text-color: $color-text-main;
+$right-margin-font: $header-font;
+$right-margin-font-size: $header-font-size;
+$right-margin-font-weight: $header-font-weight;
+$right-margin-case: $header-case;
+$right-margin-letter-spacing: $header-letter-spacing;
+$right-margin-alignment: top;
+$right-margin-space-from-edge: $margin-outside / 2 + $right-margin-font-size;
+$right-margin-space-from-text: $margin-outside / 2 - $right-margin-font-size;
+$right-margin-text-align: $header-text-align;
+$right-margin-text-color: $color-text-main;
 
 // Special highlights for temporary debugging/viewing:
 // Specify a colour for highlighting; use 'inherit' for none.

--- a/samples/styles/screen-pdf.scss
+++ b/samples/styles/screen-pdf.scss
@@ -177,6 +177,12 @@ $verso-bottom-left: normal;
 $verso-bottom-right: normal;
 $verso-bottom-left-corner: normal;
 $verso-bottom-right-corner: normal;
+$verso-left: normal;
+$verso-left-top: normal;
+$verso-left-bottom: normal;
+$verso-right: normal;
+$verso-right-top: normal;
+$verso-right-bottom: normal;
 
 // Recto (right-hand-page)
 $recto-top: string(h2-text, last);
@@ -189,6 +195,12 @@ $recto-bottom-left: normal;
 $recto-bottom-right: normal;
 $recto-bottom-left-corner: normal;
 $recto-bottom-right-corner: normal;
+$recto-left: normal;
+$recto-left-top: normal;
+$recto-left-bottom: normal;
+$recto-right: normal;
+$recto-right-top: normal;
+$recto-right-bottom: normal;
 
 // Verso (left-hand-page) for .frontmatter pages (`style: frontmatter`)
 $verso-top-frontmatter: string(page-header);
@@ -201,6 +213,12 @@ $verso-bottom-left-frontmatter: normal;
 $verso-bottom-right-frontmatter: normal;
 $verso-bottom-left-corner-frontmatter: normal;
 $verso-bottom-right-corner-frontmatter: normal;
+$verso-left-frontmatter: normal;
+$verso-left-top-frontmatter: normal;
+$verso-left-bottom-frontmatter: normal;
+$verso-right-frontmatter: normal;
+$verso-right-top-frontmatter: normal;
+$verso-right-bottom-frontmatter: normal;
 
 // Recto (right-hand-page) for .frontmatter pages (`style: frontmatter`)
 $recto-top-frontmatter: string(h2-text, last);
@@ -213,6 +231,12 @@ $recto-bottom-left-frontmatter: normal;
 $recto-bottom-right-frontmatter: normal;
 $recto-bottom-left-corner-frontmatter: normal;
 $recto-bottom-right-corner-frontmatter: normal;
+$recto-left-frontmatter: normal;
+$recto-left-top-frontmatter: normal;
+$recto-left-bottom-frontmatter: normal;
+$recto-right-frontmatter: normal;
+$recto-right-top-frontmatter: normal;
+$recto-right-bottom-frontmatter: normal;
 
 // Set styles for headers and footers
 $header-font: $font-text-secondary;
@@ -233,6 +257,26 @@ $header-text-align: center;
 $footer-text-align: center;
 $header-text-color: $color-text-main;
 $footer-text-color: $color-text-main;
+$left-margin-font: $header-font;
+$left-margin-font-size: $header-font-size;
+$left-margin-font-weight: $header-font-weight;
+$left-margin-case: $header-case;
+$left-margin-letter-spacing: $header-letter-spacing;
+$left-margin-alignment: top;
+$left-margin-space-from-edge: $margin-outside / 2;
+$left-margin-space-from-text: $margin-outside / 2 - $left-margin-font-size;
+$left-margin-text-align: $header-text-align;
+$left-margin-text-color: $color-text-main;
+$right-margin-font: $header-font;
+$right-margin-font-size: $header-font-size;
+$right-margin-font-weight: $header-font-weight;
+$right-margin-case: $header-case;
+$right-margin-letter-spacing: $header-letter-spacing;
+$right-margin-alignment: top;
+$right-margin-space-from-edge: $margin-outside / 2 + $right-margin-font-size;
+$right-margin-space-from-text: $margin-outside / 2 - $right-margin-font-size;
+$right-margin-text-align: $header-text-align;
+$right-margin-text-color: $color-text-main;
 
 // Special highlights for temporary debugging/viewing:
 // Specify a colour for highlighting; use 'inherit' for none.


### PR DESCRIPTION
Previously, we could only set the style and content of top and bottom margin boxes from a project or book's PDF Sass variables. This change adds variables to set left and right margin boxes.

I suspect these will need refining (especially positioning of text in side-margin boxes), which is best done while working on real-world projects using them.
