### PR TITLE
Minor CSS fixes

### DIFF
--- a/_sass/partials/_print-fitting.scss
+++ b/_sass/partials/_print-fitting.scss
@@ -12,12 +12,17 @@ $print-fitting: true !default;
   .float-bottom#{$edition-suffix} {
     float: bottom;
   }
+  .float-top-next#{$edition-suffix} {
+    float: top next;
+  }
   // If a paragraph would normally be flush left after an element, 
   // but that element is floated away, it should get its indent back.
-  .float-top#{$edition-suffix} + p, .float-bottom#{$edition-suffix} + p {
+  .float-top#{$edition-suffix} + p,
+  .float-bottom#{$edition-suffix} + p,
+  .float-top-next#{$edition-suffix} + p {
     text-indent: $line-height-default;
   }
-   
+
   // These classes control letter-spacing (tracking), usually to save widows and orphans.
   @for $i from 1 through 100 {
     $add-space: $i * 0.001em;

--- a/_sass/partials/_print-notes.scss
+++ b/_sass/partials/_print-notes.scss
@@ -58,9 +58,11 @@ $print-notes: true !default;
 @if $print-notes {
 
 
-    // Single footnote
+    // Footnote reference in text
     .footnote {
         line-height: inherit;
+        // Ensure footnote refs in headings are small
+        font-size: $font-size-default * $font-size-smaller;
     }
 
     // Footnotes section

--- a/_sass/partials/_print-page-headers-footers-content.scss
+++ b/_sass/partials/_print-page-headers-footers-content.scss
@@ -344,9 +344,11 @@ $print-page-headers-footers-content: true !default;
     @right-bottom { content: normal; }
   }
 
-  // Reset page numbering to 1
-  .page-1 {
-    counter-reset: page 1;
+  // Allow page-n to start page numbering at a given page
+  @for $i from 1 through 1200 {
+    .page-#{$i} {
+      counter-reset: page #{$i};
+    }
   }
 
   // Add page info to trim area

--- a/book/styles/epub.scss
+++ b/book/styles/epub.scss
@@ -93,7 +93,7 @@ $hyphenate-lines: 1; // Maximum number of consecutive lines ending with hyphens
 // If using an image, set $text-divider-image in CSS URL syntax, e.g.
 // $text-divider-image: url('../images/epub/text-divider.jpg');
 $text-divider-text: ""; // Empty leaves space. \2022 is a bullet
-$text-divider-image: url('../images/epub/publisher-logo.jpg');
+$text-divider-image: "";
 $text-divider-image-width: $line-height-default;
 
 // ---------------------------------

--- a/book/styles/print-pdf.scss
+++ b/book/styles/print-pdf.scss
@@ -130,8 +130,8 @@ $hyphenate-lines: 2; // Preferred maximum number of consecutive lines ending wit
 // For breaks created with *** in markdown.
 // If using an image, set $text-divider-image in CSS URL syntax, e.g.
 // $text-divider-image: url('../images/epub/text-divider.jpg');
-$text-divider-text: "*"; // Empty leaves space. \2022 is a bullet
-$text-divider-image: url('../images/print-pdf/publisher-logo.jpg');
+$text-divider-text: ""; // Empty leaves space. \2022 is a bullet
+$text-divider-image: "";
 $text-divider-image-height: $line-height-default;
 
 // Should chapters start on a right-hand page (recto) or on any page?

--- a/samples/styles/epub.scss
+++ b/samples/styles/epub.scss
@@ -93,7 +93,7 @@ $hyphenate-lines: 1; // Maximum number of consecutive lines ending with hyphens
 // If using an image, set $text-divider-image in CSS URL syntax, e.g.
 // $text-divider-image: url('../images/epub/text-divider.jpg');
 $text-divider-text: ""; // Empty leaves space. \2022 is a bullet
-$text-divider-image: url('../images/epub/publisher-logo.jpg');
+$text-divider-image: "";
 $text-divider-image-width: $line-height-default;
 
 // ---------------------------------

--- a/samples/styles/screen-pdf.scss
+++ b/samples/styles/screen-pdf.scss
@@ -43,7 +43,7 @@ $columns-default: 1;
 // Optional sidebar setup
 // If you want a sidebar, set these values and change
 // $print-sidebar to 'true' (it is disabled by default).
-$print-sidebar: true;
+$print-sidebar: false;
 // For guidance on sidebar variables, see partials/_pdf-sidebar.scss.
 // 1. Set the margin between the page edge and the sidebar:
 $sidebar-margin-outside: 10mm;

--- a/samples/styles/web.scss
+++ b/samples/styles/web.scss
@@ -102,9 +102,9 @@ $hyphenate-lines: 1; // Maximum number of consecutive lines ending with hyphens
 // For breaks created with *** in markdown.
 // If using an image, set $text-divider-image in CSS URL syntax, e.g.
 // $text-divider-image: url('../images/epub/text-divider.jpg');
-$text-divider-text: "—"; // Empty leaves space. \2022 is a bullet
-$text-divider-image: url('../images/web/publisher-logo.jpg');
-$text-divider-image-width: $line-height-default;
+$text-divider-text: ""; // Empty leaves space. \2022 is a bullet
+$text-divider-image: "";
+$text-divider-image-width: $line-height-default * 2;
 
 // Footer
 $footer-text-color: $color-text-main;


### PR DESCRIPTION
- Add and refine syntax for PDF float classes
- Fix for footnote-reference size in headings
- Allow setting a starting page number for any page 1–1200
- Do not activate sidebar by default
- Fix inconsistent default text dividers