### PR TITLE
Add ability to use gap-fill questions

### DIFF
--- a/_data/locales.yml
+++ b/_data/locales.yml
@@ -166,6 +166,8 @@ en:
     feedback-correct: "Correct!"
     feedback-incorrect: "Incorrect"
     feedback-unfinished: "You haven't selected all the correct answers."
+    mark-correct: "&#10003;" # check mark
+    mark-incorrect: "&#10007;" # ballot x
   quiz:
     total: "Total"
   cross-references:
@@ -238,6 +240,8 @@ fr:
     feedback-correct: "Correct!"
     feedback-incorrect: "Incorrect"
     feedback-unfinished: "Vous n'avez pas sélectionné toutes les bonnes réponses."
+    mark-correct: "&#10003;" # check mark
+    mark-incorrect: "&#10007;" # ballot x
   quiz:
     total: "Total"
   cross-references:

--- a/_docs/editing/questions.md
+++ b/_docs/editing/questions.md
@@ -135,3 +135,15 @@ You can create a quiz group in one of two ways:
    </div>
     ```
     {% endraw %}
+
+## Fill-in-the-blanks
+
+A simple kind of question is a fill-in-the-blank or gap-fill, where users can select an answer from options in a dropdown list. You can add one anywhere with the `include select` tag, like this:
+
+{% raw %}
+``` liquid
+{% include select options="apples | pears | oranges" correct="apples" %}
+```
+{% endraw %}
+
+By default, in web and app outputs, users will get feedback on whether their selections are correct or not. In PDF, you will see an underlined space to represent the blank. In epub, the options should be visible (depending on the ereader) but will not get feedback unless you add the `select-list.js` script to your [epub scripts](../advanced/javascript.html#adding-scripts-to-epubs).

--- a/_includes/select
+++ b/_includes/select
@@ -1,0 +1,46 @@
+{% capture select-html %}
+
+{% comment %}Clean up the options list, and then
+turn it into an array.{% endcomment %}
+{% capture select-options-list %}{{ include.options | replace: " |", "|" | replace: "| ", "|" }}{% endcapture %}
+{% assign select-options = select-options-list | split: "|" %}
+
+<select class="select-list">
+
+    {% comment %}Blank option to start the list{% endcomment %}
+    <option>
+        {% if include.placeholder and include.placeholder != "" %}
+            {{ include.placeholder }}
+        {% else %}
+            {% comment %}Use at least a no-break space
+            so that Prince gives the select box its width,
+            and does not collapse the empty element.
+            Use a decimal entity for valid EPUB3.{% endcomment %}
+            &#160;
+        {% endif %}
+    </option>
+
+    {% for option in select-options %}
+
+        {% comment %}Generate obfuscated answer code.
+        If the answer is correct, the fifth character will be
+        a number, not a letter.{% endcomment %}
+        {% capture select-option-code %}
+            {% include random length=4 %}
+            {% if option == include.correct %}
+                {% include random length=1 type="numbers" %}
+            {% else %}
+                {% include random length=1 type="letters" %}
+            {% endif %}
+            {% include random length=3 %}
+        {% endcapture %}
+        {% capture select-option-code %}{{ select-option-code | replace: " ", "" | strip_newlines | strip }}{% endcapture %}
+
+        {% comment %}Generate option HTML{% endcomment %}
+        <option data-select-code="{{ select-option-code }}">{{ option }}</option>
+
+    {% endfor %}
+
+</select>
+
+{% endcapture %}{{ select-html | strip_newlines | strip }}

--- a/_includes/select
+++ b/_includes/select
@@ -5,42 +5,45 @@ turn it into an array.{% endcomment %}
 {% capture select-options-list %}{{ include.options | replace: " |", "|" | replace: "| ", "|" }}{% endcapture %}
 {% assign select-options = select-options-list | split: "|" %}
 
-<select class="select-list">
+{% comment %}Wrap the select element for extra CSS control.{% endcomment %}
+<span class="select-list-wrapper">
+    <select class="select-list">
 
-    {% comment %}Blank option to start the list{% endcomment %}
-    <option>
-        {% if include.placeholder and include.placeholder != "" %}
-            {{ include.placeholder }}
-        {% else %}
-            {% comment %}Use at least a no-break space
-            so that Prince gives the select box its width,
-            and does not collapse the empty element.
-            Use a decimal entity for valid EPUB3.{% endcomment %}
-            &#160;
-        {% endif %}
-    </option>
-
-    {% for option in select-options %}
-
-        {% comment %}Generate obfuscated answer code.
-        If the answer is correct, the fifth character will be
-        a number, not a letter.{% endcomment %}
-        {% capture select-option-code %}
-            {% include random length=4 %}
-            {% if option == include.correct %}
-                {% include random length=1 type="numbers" %}
+        {% comment %}Blank option to start the list{% endcomment %}
+        <option>
+            {% if include.placeholder and include.placeholder != "" %}
+                {{ include.placeholder }}
             {% else %}
-                {% include random length=1 type="letters" %}
+                {% comment %}Use at least a no-break space
+                so that Prince gives the select box its width,
+                and does not collapse the empty element.
+                Use a decimal entity for valid EPUB3.{% endcomment %}
+                &#160;
             {% endif %}
-            {% include random length=3 %}
-        {% endcapture %}
-        {% capture select-option-code %}{{ select-option-code | replace: " ", "" | strip_newlines | strip }}{% endcapture %}
+        </option>
 
-        {% comment %}Generate option HTML{% endcomment %}
-        <option data-select-code="{{ select-option-code }}">{{ option }}</option>
+        {% for option in select-options %}
 
-    {% endfor %}
+            {% comment %}Generate obfuscated answer code.
+            If the answer is correct, the fifth character will be
+            a number, not a letter.{% endcomment %}
+            {% capture select-option-code %}
+                {% include random length=4 %}
+                {% if option == include.correct %}
+                    {% include random length=1 type="numbers" %}
+                {% else %}
+                    {% include random length=1 type="letters" %}
+                {% endif %}
+                {% include random length=3 %}
+            {% endcapture %}
+            {% capture select-option-code %}{{ select-option-code | replace: " ", "" | strip_newlines | strip }}{% endcapture %}
 
-</select>
+            {% comment %}Generate option HTML{% endcomment %}
+            <option data-select-code="{{ select-option-code }}">{{ option }}</option>
+
+        {% endfor %}
+
+    </select>
+</span>
 
 {% endcapture %}{{ select-html | strip_newlines | strip }}

--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -284,6 +284,7 @@ $web-reset-sequences: true !default; // This should stay last in the @import lis
 @import "partials/web-video";
 @import "partials/web-pagination";
 @import "partials/web-questions";
+@import "partials/web-select-questions";
 
 // Docs
 @import "partials/web-docs";

--- a/_sass/epub.scss
+++ b/_sass/epub.scss
@@ -71,6 +71,12 @@ $color-accent: #000000 !default;
 $color-links: #5f738c !default;
 $color-buttons: #5f738c !default;
 $color-highlight: #ffd54d !default;
+$color-notification-low-text: $color-light !default;
+$color-notification-medium-text: $color-light !default;
+$color-notification-high-text: $color-light !default;
+$color-notification-low-background: #009E7F !default;
+$color-notification-medium-background: #ffe388 !default;
+$color-notification-high-background: #ff7c4d !default;
 
 // Set the default start-depth of pages.
 // This is the distance from the top of the page to the first element on the first page.
@@ -186,8 +192,8 @@ $epub-reset-sequences: true !default;
 @import "partials/epub-code";
 @import "partials/epub-dialogue";
 @import "partials/epub-figures";
-@import "partials/epub-glossaries"; //
-@import "partials/epub-highlighter"; //
+@import "partials/epub-glossaries";
+@import "partials/epub-highlighter";
 @import "partials/epub-index";
 @import "partials/epub-maths";
 @import "partials/epub-notes";
@@ -197,8 +203,9 @@ $epub-reset-sequences: true !default;
 @import "partials/epub-tables";
 @import "partials/epub-letters";
 @import "partials/epub-verse";
-@import "partials/epub-video"; //
-@import "partials/epub-questions"; //
+@import "partials/epub-video";
+@import "partials/epub-questions";
+@import "partials/epub-select-questions";
 
 // Type-control classes
 @import "partials/epub-smallcaps";

--- a/_sass/partials/_epub-base-typography.scss
+++ b/_sass/partials/_epub-base-typography.scss
@@ -203,6 +203,24 @@ $epub-base-typography: true !default;
             width: auto;
         }
     }
+    select {
+        padding: 0.75em 0.75em;
+        font-family: $font-text-secondary;
+        font-size: inherit;
+        color: inherit;
+        border: $rule-thickness solid $color-mid;
+        margin: $line-height-default 0;
+        box-sizing: border-box;
+        // Inline
+        p > &,
+        li > &,
+        dd > & {
+            font-family: inherit;
+            line-height: 1;
+            margin: 0;
+            padding: 0;
+        }
+    }
     textarea {
         min-height: $line-height-default * 3;
     }

--- a/_sass/partials/_epub-base-typography.scss
+++ b/_sass/partials/_epub-base-typography.scss
@@ -214,7 +214,10 @@ $epub-base-typography: true !default;
         // Inline
         p > &,
         li > &,
-        dd > & {
+        dd > &,
+        td > &,
+        th > &,
+        span > & {
             font-family: inherit;
             line-height: 1;
             margin: 0;

--- a/_sass/partials/_epub-select-questions.scss
+++ b/_sass/partials/_epub-select-questions.scss
@@ -1,11 +1,14 @@
 @mixin select-list-marker($color-background: $color-light, $color-text: $color-text-main) {
     background-color: $color-background;
-    border-radius: $box-border-radius;
+    border-radius: $line-height-default;
     color: $color-text;
     height: $line-height-default;
+    line-height: 1.3; // magic number :(
     margin: 0 ($line-height-default / 4);
     padding: ($line-height-default / 8) ($line-height-default / 4);
     position: absolute;
+    right: -($line-height-default * 0.7);
+    top: -($line-height-default / 2);
 }
 
 $epub-select-questions: true !default;
@@ -13,15 +16,18 @@ $epub-select-questions: true !default;
 
     // Select lists
 
-    .select-list {
-        &.select-option-correct {
-            & + .select-list-marker {
-                @include select-list-marker($color-notification-low-background, $color-notification-low-text);
+    .select-list-wrapper {
+        position: relative;
+        .select-list {
+            &.select-option-correct {
+                & + .select-list-marker {
+                    @include select-list-marker($color-notification-low-background, $color-notification-low-text);
+                }
             }
-        }
-        &.select-option-incorrect {
-            & + .select-list-marker {
-                @include select-list-marker($color-notification-high-background, $color-notification-high-text);
+            &.select-option-incorrect {
+                & + .select-list-marker {
+                    @include select-list-marker($color-notification-high-background, $color-notification-high-text);
+                }
             }
         }
     }

--- a/_sass/partials/_epub-select-questions.scss
+++ b/_sass/partials/_epub-select-questions.scss
@@ -1,0 +1,29 @@
+@mixin select-list-marker($color-background: $color-light, $color-text: $color-text-main) {
+    background-color: $color-background;
+    border-radius: $box-border-radius;
+    color: $color-text;
+    height: $line-height-default;
+    margin: 0 ($line-height-default / 4);
+    padding: ($line-height-default / 8) ($line-height-default / 4);
+    position: absolute;
+}
+
+$epub-select-questions: true !default;
+@if $epub-select-questions {
+
+    // Select lists
+
+    .select-list {
+        &.select-option-correct {
+            & + .select-list-marker {
+                @include select-list-marker($color-notification-low-background, $color-notification-low-text);
+            }
+        }
+        &.select-option-incorrect {
+            & + .select-list-marker {
+                @include select-list-marker($color-notification-high-background, $color-notification-high-text);
+            }
+        }
+    }
+
+}

--- a/_sass/partials/_print-base-typography.scss
+++ b/_sass/partials/_print-base-typography.scss
@@ -203,7 +203,10 @@ $convert-images-to-color-profile: false !default;
         // Inline
         p > &,
         li > &,
-        dd > & {
+        dd > &,
+        td > &,
+        th > &,
+        span > & {
             font-family: inherit;
             line-height: 1;
             margin: 0;

--- a/_sass/partials/_print-base-typography.scss
+++ b/_sass/partials/_print-base-typography.scss
@@ -190,6 +190,27 @@ $convert-images-to-color-profile: false !default;
         }
     }
 
+    // Forms
+
+    select {
+        padding: $line-height-default / 2;
+        font-family: $font-text-secondary;
+        font-size: inherit;
+        color: inherit;
+        border: $rule-thickness solid $color-mid;
+        margin: $line-height-default 0;
+        box-sizing: border-box;
+        // Inline
+        p > &,
+        li > &,
+        dd > & {
+            font-family: inherit;
+            line-height: 1;
+            margin: 0;
+            padding: 0;
+        }
+    }
+
     // Images
     // Also see figures partial
 

--- a/_sass/partials/_print-select-questions.scss
+++ b/_sass/partials/_print-select-questions.scss
@@ -1,0 +1,12 @@
+$print-select-questions: true !default;
+@if $print-select-questions {
+
+    // Select lists
+
+    .select-list {
+        width: $line-height-default * 3;
+        border: 0;
+        border-bottom: $rule-thickness solid $color-text-main;
+    }
+
+}

--- a/_sass/partials/_web-base-typography.scss
+++ b/_sass/partials/_web-base-typography.scss
@@ -186,6 +186,24 @@ $web-base-typography: true !default;
             width: auto;
         }
     }
+    select {
+        padding: 0.75em 0.75em;
+        font-family: $font-text-secondary;
+        font-size: inherit;
+        color: inherit;
+        border: $rule-thickness solid $color-mid;
+        margin: $line-height-default 0;
+        box-sizing: border-box;
+        // Inline
+        p > &,
+        li > &,
+        dd > & {
+            font-family: inherit;
+            line-height: 1;
+            margin: 0;
+            padding: 0;
+        }
+    }
     textarea {
         min-height: $line-height-default * 3;
     }

--- a/_sass/partials/_web-base-typography.scss
+++ b/_sass/partials/_web-base-typography.scss
@@ -197,7 +197,10 @@ $web-base-typography: true !default;
         // Inline
         p > &,
         li > &,
-        dd > & {
+        dd > &,
+        td > &,
+        th > &,
+        span > & {
             font-family: inherit;
             line-height: 1;
             margin: 0;

--- a/_sass/partials/_web-select-questions.scss
+++ b/_sass/partials/_web-select-questions.scss
@@ -1,0 +1,29 @@
+@mixin select-list-marker($color-background: $color-light, $color-text: $color-text-main) {
+    background-color: $color-background;
+    border-radius: $box-border-radius;
+    color: $color-text;
+    height: $line-height-default;
+    margin: 0 ($line-height-default / 4);
+    padding: ($line-height-default / 8) ($line-height-default / 4);
+    position: absolute;
+}
+
+$web-select-questions: true !default;
+@if $web-select-questions {
+
+    // Select lists
+
+    .select-list {
+        &.select-option-correct {
+            & + .select-list-marker {
+                @include select-list-marker($color-notification-low-background, $color-notification-low-text);
+            }
+        }
+        &.select-option-incorrect {
+            & + .select-list-marker {
+                @include select-list-marker($color-notification-high-background, $color-notification-high-text);
+            }
+        }
+    }
+
+}

--- a/_sass/partials/_web-select-questions.scss
+++ b/_sass/partials/_web-select-questions.scss
@@ -1,11 +1,14 @@
 @mixin select-list-marker($color-background: $color-light, $color-text: $color-text-main) {
     background-color: $color-background;
-    border-radius: $box-border-radius;
+    border-radius: $line-height-default;
     color: $color-text;
     height: $line-height-default;
+    line-height: 1.3; // magic number :(
     margin: 0 ($line-height-default / 4);
     padding: ($line-height-default / 8) ($line-height-default / 4);
     position: absolute;
+    right: -($line-height-default * 0.7);
+    top: -($line-height-default / 2);
 }
 
 $web-select-questions: true !default;
@@ -13,15 +16,18 @@ $web-select-questions: true !default;
 
     // Select lists
 
-    .select-list {
-        &.select-option-correct {
-            & + .select-list-marker {
-                @include select-list-marker($color-notification-low-background, $color-notification-low-text);
+    .select-list-wrapper {
+        position: relative;
+        .select-list {
+            &.select-option-correct {
+                & + .select-list-marker {
+                    @include select-list-marker($color-notification-low-background, $color-notification-low-text);
+                }
             }
-        }
-        &.select-option-incorrect {
-            & + .select-list-marker {
-                @include select-list-marker($color-notification-high-background, $color-notification-high-text);
+            &.select-option-incorrect {
+                & + .select-list-marker {
+                    @include select-list-marker($color-notification-high-background, $color-notification-high-text);
+                }
             }
         }
     }

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -401,6 +401,7 @@ $print-page-setup-lightning-source: false !default; // Removes crop marks and se
 @import "partials/print-openers";
 @import "partials/print-index";
 @import "partials/print-questions";
+@import "partials/print-select-questions";
 @import "partials/print-cross-refs";
 @import "partials/print-sidebar";
 @import "partials/print-reset-sequences"; // Resets p indents, margins after other elements. Must be last @import in list.

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -400,6 +400,7 @@ $print-page-headers-footers-style: true !default; // Sets styling for headers an
 @import "partials/print-openers";
 @import "partials/print-index";
 @import "partials/print-questions";
+@import "partials/print-select-questions";
 @import "partials/print-cross-refs";
 @import "partials/print-sidebar";
 @import "partials/print-reset-sequences"; // Resets p indents, margins after other elements. Must be last @import in list.

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -284,6 +284,7 @@ $web-reset-sequences: true !default; // This should stay last in the @import lis
 @import "partials/web-video";
 @import "partials/web-pagination";
 @import "partials/web-questions";
+@import "partials/web-select-questions";
 
 // Docs
 @import "partials/web-docs";

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -20,6 +20,7 @@ layout: null
     {% include_relative nav.js %}
     {% include_relative videos.js %}
     {% include_relative mcqs.js %}
+    {% include_relative select-list.js %}
     {% include_relative tables.js %}
     {% include_relative footnote-popups.js %}
 

--- a/assets/js/select-list.js
+++ b/assets/js/select-list.js
@@ -1,0 +1,90 @@
+/*jslint browser */
+/*globals locales, pageLanguage */
+
+// Which select elements will this script apply to?
+var selects = document.querySelectorAll('select.select-list');
+
+// Polyfill for IE (thanks, MDN)
+Number.isInteger = Number.isInteger || function (value) {
+    'use strict';
+
+    return typeof value === 'number' &&
+            isFinite(value) &&
+            Math.floor(value) === value;
+};
+
+// Check if an option's code means it is correct or incorrect,
+// returning true for correct and false for incorrect.
+function ebSelectCheckCode(code) {
+    'use strict';
+
+    // Get the fifth character in the code,
+    // and try to convert it to a number.
+    var keyCharacter = Number(code.charAt(4));
+
+    // If it is a number, this returns true.
+    return Number.isInteger(keyCharacter);
+}
+
+function ebSelectAddMarker(selectElement, markerContent) {
+    'use strict';
+
+    // If a marker already exists from a previous attempt,
+    // remove it.
+    if (selectElement.nextElementSibling && selectElement.nextElementSibling.classList.contains('select-list-marker')) {
+        var oldMarker = selectElement.nextElementSibling;
+        oldMarker.remove();
+    }
+
+    // Add new marker
+    var newMarker = document.createElement('span');
+    newMarker.classList.add('select-list-marker');
+    newMarker.innerHTML = markerContent;
+    selectElement.insertAdjacentElement('afterend', newMarker);
+}
+
+// Mark a selected option as correct or incorrect.
+function ebSelectMarkResult(event) {
+    'use strict';
+
+    // Get the selected option and its code.
+    var selectedOption = event.target.options[event.target.selectedIndex];
+    var optionCode = selectedOption.getAttribute('data-select-code');
+    var selectList = selectedOption.parentNode;
+
+    // Mark whether the option is correct or incorrect.
+    // Since we can't style options, only select elements,
+    // we mark the parent select element and add a span after it
+    // that we can style.
+    if (optionCode && ebSelectCheckCode(optionCode)) {
+        selectList.classList.remove('select-option-incorrect');
+        selectList.classList.add('select-option-correct');
+        ebSelectAddMarker(selectList, locales[pageLanguage].questions['mark-correct']);
+    } else {
+        selectList.classList.remove('select-option-correct');
+        selectList.classList.add('select-option-incorrect');
+        ebSelectAddMarker(selectList, locales[pageLanguage].questions['mark-incorrect']);
+    }
+}
+
+// Listen for changes on a select element,
+// to mark the result when the user changes the option.
+function ebSelectListener(selectElement) {
+    'use strict';
+    selectElement.addEventListener('change', ebSelectMarkResult, false);
+}
+
+// Add a listener to each select element.
+function ebSelects(selects) {
+    'use strict';
+
+    if (selects.length > 0) {
+        var i;
+        for (i = 0; i < selects.length; i += 1) {
+            ebSelectListener(selects[i]);
+        }
+    }
+}
+
+// Go!
+ebSelects(selects);

--- a/book/styles/epub.scss
+++ b/book/styles/epub.scss
@@ -72,6 +72,12 @@ $color-accent: #000000;
 $color-links: #5f738c;
 $color-buttons: #5f738c;
 $color-highlight: #ffd54d;
+$color-notification-low-text: $color-light;
+$color-notification-medium-text: $color-light;
+$color-notification-high-text: $color-light;
+$color-notification-low-background: #009E7F;
+$color-notification-medium-background: #ffe388;
+$color-notification-high-background: #ff7c4d;
 
 // Set the default start-depth of pages.
 // This is the distance from the top of the page to the first element on the first page.

--- a/samples/styles/epub.scss
+++ b/samples/styles/epub.scss
@@ -72,6 +72,12 @@ $color-accent: #000000;
 $color-links: #5f738c;
 $color-buttons: #5f738c;
 $color-highlight: #ffd54d;
+$color-notification-low-text: $color-light;
+$color-notification-medium-text: $color-light;
+$color-notification-high-text: $color-light;
+$color-notification-low-background: #009E7F;
+$color-notification-medium-background: #ffe388;
+$color-notification-high-background: #ff7c4d;
 
 // Set the default start-depth of pages.
 // This is the distance from the top of the page to the first element on the first page.

--- a/samples/text/01-10-questions.md
+++ b/samples/text/01-10-questions.md
@@ -9,3 +9,5 @@ You can add questions to your book like this one.
 {% include question file="question-01" %}
 
 See the docs for how to add quizzes and create exams.
+
+You can also add {% include select options="fill-in-the-blank | essay question | mind-reading" correct="fill-in-the-blank" %} spaces (aka gap-fill or cloze questions), that give users feedback in web and app outputs.


### PR DESCRIPTION
This adds a simple fill-in-the-blank or gap-fill, where users can select an answer from options in a dropdown list. You can add one anywhere with the `include select` tag, like this:

``` liquid
{% include select options="apples | pears | oranges" correct="apples" %}
```

By default, in web and app outputs, users will get feedback on whether their selections are correct or not. In PDF, you will see an underlined space to represent the blank. In epub, the options should be visible (depending on the ereader) but will not get feedback unless you add the `select-list.js` script to your epub scripts.