### PR TITLE
Add on/off partial switches for select/gap-fill

### DIFF
--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -209,6 +209,7 @@ $web-verse: true !default;
 $web-video: true !default;
 $web-pagination: true !default;
 $web-questions: true !default;
+$web-select-questions: true !default;
 
 // Docs
 $web-docs: true !default;

--- a/_sass/epub.scss
+++ b/_sass/epub.scss
@@ -146,6 +146,7 @@ $epub-letters: true !default;
 $epub-verse: true !default;
 $epub-video: true !default;
 $epub-questions: true !default;
+$epub-select-questions: true !default;
 
 // Type-control classes
 $epub-smallcaps: true !default;

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -334,6 +334,7 @@ $print-sources: true !default;
 $print-openers: true !default;
 $print-index: true !default;
 $print-questions: true !default;
+$print-select-questions: true !default;
 $print-cross-refs: true !default;
 $print-sidebar: false !default; // Note that this is disabled by default
 $print-reset-sequences: true !default; // Resets p indents, margins after other elements. Must be last @import in list.

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -334,6 +334,7 @@ $print-sources: true !default;
 $print-openers: true !default;
 $print-index: true !default;
 $print-questions: true !default;
+$print-select-questions: true !default;
 $print-cross-refs: true !default;
 $print-sidebar: false !default; // Note that this is disabled by default
 $print-reset-sequences: true !default; // Resets p indents, margins after other elements. Must be last @import in list.

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -209,6 +209,7 @@ $web-verse: true !default;
 $web-video: true !default;
 $web-pagination: true !default;
 $web-questions: true !default;
+$web-select-questions: true !default;
 
 // Docs
 $web-docs: true !default;

--- a/book/styles/app.scss
+++ b/book/styles/app.scss
@@ -210,6 +210,7 @@ $web-verse: true;
 $web-video: true;
 $web-pagination: true;
 $web-questions: true;
+$web-select-questions: true;
 
 // Docs
 $web-docs: true;

--- a/book/styles/epub.scss
+++ b/book/styles/epub.scss
@@ -147,6 +147,7 @@ $epub-letters: true;
 $epub-verse: true;
 $epub-video: true;
 $epub-questions: true;
+$epub-select-questions: true;
 
 // Type-control classes
 $epub-smallcaps: true;

--- a/book/styles/print-pdf.scss
+++ b/book/styles/print-pdf.scss
@@ -340,6 +340,7 @@ $print-sources: true;
 $print-openers: true;
 $print-index: true;
 $print-questions: true;
+$print-select-questions: true;
 $print-cross-refs: true;
 $print-reset-sequences: true; // Resets p indents, margins after other elements. Must be last @import in list.
 $print-page-headers-footers-content: true; // Sets content for headers and footers

--- a/book/styles/screen-pdf.scss
+++ b/book/styles/screen-pdf.scss
@@ -340,6 +340,7 @@ $print-sources: true;
 $print-openers: true;
 $print-index: true;
 $print-questions: true;
+$print-select-questions: true;
 $print-cross-refs: true;
 $print-reset-sequences: true; // Resets p indents, margins after other elements. Must be last @import in list.
 $print-page-headers-footers-content: true; // Sets content for headers and footers

--- a/book/styles/web.scss
+++ b/book/styles/web.scss
@@ -210,6 +210,7 @@ $web-verse: true;
 $web-video: true;
 $web-pagination: true;
 $web-questions: true;
+$web-select-questions: true;
 
 // Docs
 $web-docs: true;

--- a/samples/styles/app.scss
+++ b/samples/styles/app.scss
@@ -210,6 +210,7 @@ $web-verse: true;
 $web-video: true;
 $web-pagination: true;
 $web-questions: true;
+$web-select-questions: true;
 
 // Docs
 $web-docs: true;

--- a/samples/styles/epub.scss
+++ b/samples/styles/epub.scss
@@ -147,6 +147,7 @@ $epub-letters: true;
 $epub-verse: true;
 $epub-video: true;
 $epub-questions: true;
+$epub-select-questions: true;
 
 // Type-control classes
 $epub-smallcaps: true;

--- a/samples/styles/print-pdf.scss
+++ b/samples/styles/print-pdf.scss
@@ -340,6 +340,7 @@ $print-sources: true;
 $print-openers: true;
 $print-index: true;
 $print-questions: true;
+$print-select-questions: true;
 $print-cross-refs: true;
 $print-reset-sequences: true; // Resets p indents, margins after other elements. Must be last @import in list.
 $print-page-headers-footers-content: true; // Sets content for headers and footers

--- a/samples/styles/screen-pdf.scss
+++ b/samples/styles/screen-pdf.scss
@@ -340,6 +340,7 @@ $print-sources: true;
 $print-openers: true;
 $print-index: true;
 $print-questions: true;
+$print-select-questions: true;
 $print-cross-refs: true;
 $print-reset-sequences: true; // Resets p indents, margins after other elements. Must be last @import in list.
 $print-page-headers-footers-content: true; // Sets content for headers and footers

--- a/samples/styles/web.scss
+++ b/samples/styles/web.scss
@@ -210,6 +210,7 @@ $web-verse: true;
 $web-video: true;
 $web-pagination: true;
 $web-questions: true;
+$web-select-questions: true;
 
 // Docs
 $web-docs: true;


### PR DESCRIPTION
This should have been included in #389. It lets us exclude the gap-fill CSS for books if we don't need it.