### PR TITLE
 Add the ability to hide content behind a show-hide button

### DIFF
--- a/_data/locales.yml
+++ b/_data/locales.yml
@@ -145,6 +145,8 @@ en:
   input:
     submit: "Submit"
     send: "Send"
+    show: "Show"
+    hide: "Hide"
   search:
     search-title: "Search"
     placeholder: "Search"
@@ -219,6 +221,8 @@ fr:
   input:
     submit: "Soumettre"
     send: "Envoyer"
+    show: "Montrer"
+    hide: "Cacher"
   search:
     search-title: "Recherche"
     placeholder: "Recherche"

--- a/_docs/editing/show-hide-buttons.md
+++ b/_docs/editing/show-hide-buttons.md
@@ -1,0 +1,31 @@
+---
+title: Show-hide buttons
+categories: editing
+order: 16
+---
+
+# Show-hide buttons
+
+Sometimes you want to hide some content until a user clicks a button. For instance, you might want to hide the answer to a question until the user clicks a 'Show answer' button.
+
+To hide any element, add a `.show-hide` class to it, For instance:
+
+```md
+The answer is 42.
+{:.box .show-hide}
+```
+
+The answer is 42.
+{:.box .show-hide}
+
+You can set the default text on the button in `_data/locales.yml` at `input` > `show` and `input` > `hide`. And you can override this text for a specific button by adding a `data-show-text` and/or `data-hide-text` attribute to the element you're hiding. For example:
+
+```md
+The answer is 42.
+{:.box .show-hide data-show-text="The answer to everything is..." data-hide-text="Thanks for all the fish."}
+```
+
+The answer is 42.
+{:.box .show-hide data-show-text="The answer to everything is..." data-hide-text="Thanks for all the fish."}
+
+This works in web and app formats by default. The `show-hide` class has no effect in PDF and epub outputs. To enable this behaviour in epub output, you will need to copy the `assets/js/show-hide.js` to your [epub scripts](../advanced/javascript.html#adding-scripts-to-epubs).

--- a/_sass/epub.scss
+++ b/_sass/epub.scss
@@ -70,6 +70,7 @@ $color-mid: #9c9c9c !default;
 $color-accent: #000000 !default;
 $color-links: #5f738c !default;
 $color-buttons: #5f738c !default;
+$color-buttons-hover: darken( $color-buttons, 20% ) !default;
 $color-highlight: #ffd54d !default;
 $color-notification-low-text: $color-light !default;
 $color-notification-medium-text: $color-light !default;

--- a/_sass/partials/_epub-buttons.scss
+++ b/_sass/partials/_epub-buttons.scss
@@ -1,29 +1,38 @@
+@mixin button($text-color: $color-background, $button-color: $color-buttons, $button-hover-color: $color-buttons-hover) {
+    display: inline-block;
+    font-family: $font-text-secondary;
+    color: $text-color;
+    line-height: 100%;
+    text-decoration: none;
+    background-color: $button-color;
+    padding: 0.2em 0.4em;
+    margin: 0;
+    text-align: center;
+    text-indent: 0;
+    border-radius: $button-border-radius;
+    cursor: pointer;
+    border: none;
+    &:hover {
+        background-color: $button-hover-color;
+    }
+}
+
 $epub-buttons: true !default;
 @if $epub-buttons {
 
-	// Buttons
+    // Buttons
+
+    button {
+        font-size: initial; // override browsers that shrink button font sizes
+        @include button();
+    }
 
     // Applied to inline elements
     a.button,
     em.button,
     strong.button,
     span.button, {
-        display: inline-block;
-		font-family: $font-text-secondary;
-		color: $color-background;
-		line-height: 100%;
-        text-decoration: none;
-		background-color: $color-buttons;
-		padding: 0.2em 0.4em;
-		margin: 0;
-		text-align: center;
-        text-indent: 0;
-		border-radius: $button-border-radius;
-		box-shadow: 0.02em 0.02em 0.02em 0.02em $color-buttons;
-		cursor: pointer;
-		&:hover {
-			background-color: darken( $color-buttons, 5% );
-		}
+        @include button();
     }
 
     // Applied to block-level elements
@@ -42,21 +51,9 @@ $epub-buttons: true !default;
     h6.button, {
         text-indent: 0;
         a {
-            display: inline-block;
-            font-family: $font-text-secondary;
-            color: $color-background;
-            background-color: $color-buttons;
+            @include button();
             padding: 0.5em;
             margin: $line-height-default 0;
-            line-height: 1;
-			text-align: center;
-            text-decoration: none;
-            border-radius: $button-border-radius;
-			box-shadow: 0.02em 0.02em 0.02em 0.02em $color-buttons;
-			cursor: pointer;
-			&:hover {
-				background-color: darken( $color-buttons, 5% );
-			}
         }
         & + p {
             text-indent: 0;
@@ -83,6 +80,10 @@ $epub-buttons: true !default;
                 margin: 0;
             }
         }
+    }
+
+    button.show-hide-hidden {
+        margin-bottom: $line-height-default;
     }
 
 }

--- a/_sass/partials/_epub-helpers.scss
+++ b/_sass/partials/_epub-helpers.scss
@@ -2,7 +2,7 @@ $epub-helpers: true !default;
 @if $epub-helpers {
 
     .visuallyhidden {
-        // We dont use the best-practice technique in web partials
+        // We don't use the best-practice technique in web partials
         // because that requires moving the element out of the flow
         // with position absolute or fixed, but epubcheck throws
         // warnings if we use those.

--- a/_sass/partials/_web-buttons.scss
+++ b/_sass/partials/_web-buttons.scss
@@ -1,90 +1,89 @@
+@mixin button($text-color: $color-background, $button-color: $color-buttons, $button-hover-color: $color-buttons-hover) {
+    display: inline-block;
+    font-family: $font-text-secondary;
+    color: $text-color;
+    line-height: 100%;
+    text-decoration: none;
+    background-color: $button-color;
+    padding: 0.2em 0.4em;
+    margin: 0;
+    text-align: center;
+    text-indent: 0;
+    border-radius: $button-border-radius;
+    cursor: pointer;
+    border: none;
+    &:hover {
+        background-color: $button-hover-color;
+    }
+}
+
 $web-buttons: true !default;
 @if $web-buttons {
 
-	// Buttons
+    // Buttons
 
-	button {
-		font-size: initial; // override browsers that shrink button font sizes
-	}
+    button {
+        font-size: initial; // override browsers that shrink button font sizes
+        @include button();
+    }
 
-	// Applied to inline elements
-	a.button,
-	em.button,
-	strong.button,
-	span.button, {
-		display: inline-block;
-		font-family: $font-text-secondary;
-		color: $color-background;
-		line-height: 100%;
-		text-decoration: none;
-		background-color: $color-buttons;
-		padding: 0.2em 0.4em;
-		margin: 0;
-		text-align: center;
-		text-indent: 0;
-		border-radius: $button-border-radius;
-		cursor: pointer;
-		&:hover {
-			background-color: $color-buttons-hover;
-		}
-	}
+    // Applied to inline elements
+    a.button,
+    em.button,
+    strong.button,
+    span.button, {
+        @include button();
+    }
 
-	// Applied to block-level elements
-	p.button,
-	ol.button,
-	ul.button,
-	li.button,
-	blockquote.button,
-	table.button,
-	div.button,
-	h1.button,
-	h2.button,
-	h3.button,
-	h4.button,
-	h5.button,
-	h6.button, {
-		text-indent: 0;
-		a {
-			display: inline-block;
-			font-family: $font-text-secondary;
-			color: $color-background;
-			background-color: $color-buttons;
-			padding: 0.5em;
-			margin: $line-height-default 0;
-			line-height: 1;
-			text-align: center;
-			text-decoration: none;
-			border-radius: $button-border-radius;
-			cursor: pointer;
-			&:hover {
-				background-color: $color-buttons-hover;
-			}
-		}
-		& + p {
-			text-indent: 0;
-		}
-	}
+    // Applied to block-level elements
+    p.button,
+    ol.button,
+    ul.button,
+    li.button,
+    blockquote.button,
+    table.button,
+    div.button,
+    h1.button,
+    h2.button,
+    h3.button,
+    h4.button,
+    h5.button,
+    h6.button, {
+        text-indent: 0;
+        a {
+            @include button();
+            padding: 0.5em;
+            margin: $line-height-default 0;
+        }
+        & + p {
+            text-indent: 0;
+        }
+    }
 
-	// An option to change the default text-indented paragraphs
-	// and close-up lists etc. to have space-between instead.
-	@if $spaced-paras {
-		p.button,
-		ol.button,
-		ul.button,
-		li.button,
-		blockquote.button,
-		table.button,
-		div.button,
-		h1.button,
-		h2.button,
-		h3.button,
-		h4.button,
-		h5.button,
-		h6.button, {
-			a {
-				margin: 0;
-			}
-		}
-	}
-	
+    // An option to change the default text-indented paragraphs
+    // and close-up lists etc. to have space-between instead.
+    @if $spaced-paras {
+        p.button,
+        ol.button,
+        ul.button,
+        li.button,
+        blockquote.button,
+        table.button,
+        div.button,
+        h1.button,
+        h2.button,
+        h3.button,
+        h4.button,
+        h5.button,
+        h6.button, {
+            a {
+                margin: 0;
+            }
+        }
+    }
+
+    button.show-hide-hidden {
+        margin-bottom: $line-height-default;
+    }
+
 }

--- a/_sass/partials/_web-nav-bar.scss
+++ b/_sass/partials/_web-nav-bar.scss
@@ -252,6 +252,7 @@ $nav-bar-back-button-hide: false !default;
         }
         &:hover {
             cursor: pointer;
+            background-color: transparent;
         }
         &:after {
             color: $nav-bar-children-prompt-color;

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -23,6 +23,7 @@ layout: null
     {% include_relative select-list.js %}
     {% include_relative tables.js %}
     {% include_relative footnote-popups.js %}
+    {% include_relative show-hide.js %}
 
     {% if site.data.settings.web.svg.inject == true %}
         {% include_relative svg-inject.min.js %}

--- a/assets/js/show-hide.js
+++ b/assets/js/show-hide.js
@@ -1,0 +1,82 @@
+/*jslint browser */
+/*globals locales, pageLanguage */
+
+// Options
+// -------
+var ebShowHideOptions = {
+    elementsToHide: '.show-hide', // a querySelectorAll string
+    buttonShowText: locales[pageLanguage].input.show, // will be overriden if set in HTML as data-show-text
+    buttonHideText: locales[pageLanguage].input.hide // will be overriden if set in HTML as data-hide-text
+};
+
+// Toggle visuallyhidden
+function ebToggleNextSiblingVisibility(event) {
+    'use strict';
+    var button = event.target;
+    var elementToHide = button.nextElementSibling;
+    if (elementToHide.classList.contains('visuallyhidden')) {
+        elementToHide.classList.remove('visuallyhidden');
+        button.classList.remove('show-hide-hidden');
+        button.classList.add('show-hide-visible');
+
+        // If button text has been set in the HTML, use that,
+        // otherwise use our default from ebShowHideOptions above.
+        if (elementToHide.getAttribute('data-hide-text')) {
+            button.innerHTML = elementToHide.getAttribute('data-hide-text');
+        } else {
+            button.innerHTML = ebShowHideOptions.buttonHideText;
+        }
+    } else {
+        elementToHide.classList.add('visuallyhidden');
+        button.classList.remove('show-hide-visible');
+        button.classList.add('show-hide-hidden');
+
+        // If button text has been set in the HTML, use that,
+        // otherwise use our default from ebShowHideOptions above.
+        if (elementToHide.getAttribute('data-show-text')) {
+            button.innerHTML = elementToHide.getAttribute('data-show-text');
+        } else {
+            button.innerHTML = ebShowHideOptions.buttonShowText;
+        }
+    }
+}
+
+// Add a show/hide button
+function ebShowHideAddButton(elementToHide) {
+    'use strict';
+    var button = document.createElement('button');
+    button.classList.add('show-hide');
+    button.classList.add('show-hide-hidden');
+    elementToHide.insertAdjacentElement('beforebegin', button);
+
+    // If button text has been set in the HTML, use that,
+    // otherwise use our default from ebShowHideOptions above.
+    if (elementToHide.getAttribute('data-show-text')) {
+        button.innerHTML = elementToHide.getAttribute('data-show-text');
+    } else {
+        button.innerHTML = ebShowHideOptions.buttonShowText;
+    }
+
+    // Add a listener to the button
+    button.addEventListener('click', ebToggleNextSiblingVisibility, false);
+}
+
+// Hide element
+function ebShowHideHideInitially(elementToHide) {
+    'use strict';
+    elementToHide.classList.add('visuallyhidden');
+}
+
+// Process all show-hides
+function ebShowHide() {
+    'use strict';
+    var ebShowHideElements = document.querySelectorAll(ebShowHideOptions.elementsToHide);
+    var i;
+    for (i = 0; i < ebShowHideElements.length; i += 1) {
+        ebShowHideHideInitially(ebShowHideElements[i]);
+        ebShowHideAddButton(ebShowHideElements[i]);
+    }
+}
+
+// Go!
+ebShowHide();

--- a/book/styles/epub.scss
+++ b/book/styles/epub.scss
@@ -71,6 +71,7 @@ $color-mid: #9c9c9c;
 $color-accent: #000000;
 $color-links: #5f738c;
 $color-buttons: #5f738c;
+$color-buttons-hover: darken( $color-buttons, 20% );
 $color-highlight: #ffd54d;
 $color-notification-low-text: $color-light;
 $color-notification-medium-text: $color-light;

--- a/samples/styles/epub.scss
+++ b/samples/styles/epub.scss
@@ -71,6 +71,7 @@ $color-mid: #9c9c9c;
 $color-accent: #000000;
 $color-links: #5f738c;
 $color-buttons: #5f738c;
+$color-buttons-hover: darken( $color-buttons, 20% );
 $color-highlight: #ffd54d;
 $color-notification-low-text: $color-light;
 $color-notification-medium-text: $color-light;


### PR DESCRIPTION
We've been asked on a few projects for the ability to hide content till a user clicks a button. This bakes that into the template. To hide any element, add a `.show-hide` class to it. More detail in the docs.