### PR TITLE
Localise home-page title element in locales

### DIFF
--- a/_data/locales.yml
+++ b/_data/locales.yml
@@ -129,6 +129,7 @@ en:
   project:
     # Project items are set for the parent language
     # in meta.yml and can be overridden here.
+    # Project 'name' also sets the HTML title on the home page.
     organisation: ""
     url: ""
     email: ""

--- a/assets/js/locales.js
+++ b/assets/js/locales.js
@@ -35,10 +35,19 @@ if (getParameterByName('lang')) {
 
 function localiseText() {
 
+    // Localise HTML title element on home page
+    var titleElement = document.querySelector('title');
+    if (titleElement
+        && document.querySelector('body.home') !== undefined
+        && locales[pageLanguage].project.name
+        && locales[pageLanguage].project.name !== '') {
+        titleElement.innerHTML = locales[pageLanguage].project.name;
+    }
+
     // Localise masthead
     var mastheadProjectName = document.querySelector('.masthead .masthead-series-name a');
-    if (mastheadProjectName && 
-        locales[pageLanguage].project.name && 
+    if (mastheadProjectName &&
+        locales[pageLanguage].project.name &&
         locales[pageLanguage].project.name !== '') {
         mastheadProjectName.innerHTML = locales[pageLanguage].project.name;
     }


### PR DESCRIPTION
With this change, by setting the `project` `name` in `locales.yml`, you also set the `<title>` element on the home page. This is useful for multi-lingual projects. Now, when the URL ends with a language setting, e.g. `?lang=fr`, the home-page title (and therefore browser-tab text) will be the project name in the relevant language.

If the project name isn't set for a given locale, then as before the home-page title element will show the project name in the parent-language, as set in `meta.yml`, and the page `title` of the root `index.md` file, as `Project Name: Page Title`.
