### PR TITLE
Don't force a blank baseurl on web output

### DIFF
--- a/run-linux.sh
+++ b/run-linux.sh
@@ -225,7 +225,7 @@ Enter a number and hit enter. "
 		echo "If not, just hit return."
 		read config
 		# Ask the user to set a baseurl if needed
-		echo "Do you need a baseurl?"
+		echo "Do you need to set a baseurl?"
 		echo "If yes, enter it with no slashes at the start or end, e.g."
 		echo "my/base"
 		read baseurl
@@ -249,7 +249,7 @@ You may need to reload the web page once this server is running."
 			# ...and run Jekyll
 			if [ "$baseurl" = "" ]
 				then
-				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,$config" --baseurl=""
+				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,$config"
 			else
 				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,$config" --baseurl="/$baseurl"
 			fi

--- a/run-mac.command
+++ b/run-mac.command
@@ -227,7 +227,7 @@ Enter a number and hit enter. "
 		echo "If not, just hit return."
 		read config
 		# Ask the user to set a baseurl if needed
-		echo "Do you need a baseurl?"
+		echo "Do you need to set a baseurl?"
 		echo "If yes, enter it with no slashes at the start or end, e.g."
 		echo "my/base"
 		read baseurl
@@ -251,7 +251,7 @@ You may need to reload the web page once this server is running."
 			# ...and run Jekyll
 			if [ "$baseurl" = "" ]
 				then
-				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,$config" --baseurl=""
+				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,$config"
 			else
 				bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,$config" --baseurl="/$baseurl"
 			fi

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -287,7 +287,7 @@ set /p process=Enter a number and hit return.
         echo.
 
         :: Ask the user to set a baseurl if needed
-        echo Do you need a baseurl?
+        echo Do you need to set a baseurl?
         echo If yes, enter it with no slashes at the start or end, e.g.
         echo my/base
         echo.
@@ -335,10 +335,10 @@ set /p process=Enter a number and hit return.
 
                 :: Run Jekyll, with MathJax enabled if necessary
                 if not "%webmathjax%"=="y" goto webnomathjax
-                call bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,_configs/_config.mathjax-enabled.yml,%config%" --baseurl=""
+                call bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,_configs/_config.mathjax-enabled.yml,%config%"
                 goto webjekyllservednobaseurl
                 :webnomathjax
-                call bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,%config%" --baseurl=""
+                call bundle exec jekyll serve --config="_config.yml,_configs/_config.web.yml,%config%"
 
                 :webjekyllservednobaseurl
 


### PR DESCRIPTION
Previously, if you did not set a baseurl when using the output scripts, we forced a blank baseurl. This is fine for local testing, but complicates outputs when you're using a specific config. 

For instance, if you're using `_configs/_config.live.yml` to build for production, and that config sets a baseurl specific to the live website, you'd have to remember to *also* specify that baseurl when building with the output script. Otherwise the script would use `--baseurl=""` to force a blank baseurl.

With the change in this PR, if you do not set a baseurl when using the output script, Jekyll will only use the baseurl set in your config file(s).