### PR TITLE
Nav label div, and large image

### DIFF
--- a/_includes/image
+++ b/_includes/image
@@ -6,11 +6,11 @@
 Let user use `file` or `src` for the image file,
 defaulting to src. {% endcomment %}
 {% if include.file %}
-	{% assign image = include.file | split: "." | first %}
-	{% assign file-extension = include.file | split: "." | last %}
+    {% assign image = include.file | split: "." | first %}
+    {% assign file-extension = include.file | split: "." | last %}
 {% elsif include.src %}
-	{% assign image = include.src | split: "." | first %}
-	{% assign file-extension = include.src | split: "." | last %}
+    {% assign image = include.src | split: "." | first %}
+    {% assign file-extension = include.src | split: "." | last %}
 {% endif %}
 
 {% comment %} Capture and clean any alt text. {% endcomment %}
@@ -40,7 +40,8 @@ https://builtvisible.com/responsive-images-for-busy-people-a-quick-primer/ {% en
     sizes="auto"
     srcset="{{ images }}/{{ image }}-320.{{ file-extension }} 320w,
     {{ images }}/{{ image }}-640.{{ file-extension }} 640w,
-    {{ images }}/{{ image }}-1024.{{ file-extension }} 1024w"
+    {{ images }}/{{ image }}-1024.{{ file-extension }} 1024w,
+    {{ images }}/{{ image }}-2048.{{ file-extension }} 2048w"
     {% endunless %}
     {% endif %}
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,16 +3,16 @@
         {% comment %}If we're neither in a book or a docs page,
         show the project name.{% endcomment %}
         {% if is-book-subdirectory != true and is-docs-page != true %}
-        <h2>{{ project-name }}</h2>
+        <div class="nav-title">{{ project-name }}</div>
 
         {% comment %}If docs are generating, and we're on a docs page
         show a docs heading and version number{% endcomment %}
         {% elsif output-docs == true and is-docs-page == true %}
-        <h2>Electric Book docs (v{{ site.version }})</h2>
+        <div class="nav-title">Electric Book docs (v{{ site.version }})</div>
 
         {% comment %}Otherwise show the book title{% endcomment %}
         {% else %}
-        <h2>{{ title }}</h2>
+        <div class="nav-title">{{ title }}</div>
         {% endif %}
 
         {% comment %}Add the search box.{% endcomment %}

--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -126,6 +126,7 @@ $nav-bar-scrollbar: true !default;
 $nav-bar-width: 15em !default;
 $nav-bar-fixed: true !default; // fixed is not fully supported on many mobile browsers
 $nav-bar-back-button-hide: false !default;
+$nav-bar-title-color: $color-text-secondary !default;
 $nav-bar-label-color: $color-light !default;
 $nav-bar-label-background-color: $masthead-background-color !default;
 $nav-bar-label-border-color: transparent !default;

--- a/_sass/partials/_web-nav-bar.scss
+++ b/_sass/partials/_web-nav-bar.scss
@@ -226,7 +226,11 @@ $nav-bar-back-button-hide: false !default;
             margin: 0 -17px 0 0; // Fills width of container-with-hidden-scrollbar
         } // .widgets
 
-        h2 {
+        .nav-title {
+            color: $nav-bar-title-color;
+            font-size: $font-size-default * 1.5;
+            line-height: $line-height-default * 0.75;
+            margin: ($line-height-default) 0 ($line-height-default * 0.5) 0;
             padding-left: 0.4em;
         }
 

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -126,6 +126,7 @@ $nav-bar-scrollbar: true !default;
 $nav-bar-width: 15em !default;
 $nav-bar-fixed: true !default; // fixed is not fully supported on many mobile browsers
 $nav-bar-back-button-hide: true !default;
+$nav-bar-title-color: $color-text-secondary !default;
 $nav-bar-label-color: $color-light !default;
 $nav-bar-label-background-color: $masthead-background-color !default;
 $nav-bar-label-border-color: transparent !default;

--- a/book/styles/app.scss
+++ b/book/styles/app.scss
@@ -127,6 +127,7 @@ $nav-bar-scrollbar: true;
 $nav-bar-width: 15em;
 $nav-bar-fixed: true;
 $nav-bar-back-button-hide: false;
+$nav-bar-title-color: $color-text-secondary;
 $nav-bar-label-color: $color-light;
 $nav-bar-label-background-color: $masthead-background-color;
 $nav-bar-label-border-color: transparent !default;

--- a/book/styles/web.scss
+++ b/book/styles/web.scss
@@ -127,6 +127,7 @@ $nav-bar-scrollbar: true;
 $nav-bar-width: 15em;
 $nav-bar-fixed: true;
 $nav-bar-back-button-hide: true;
+$nav-bar-title-color: $color-text-secondary;
 $nav-bar-label-color: $color-light;
 $nav-bar-label-background-color: $masthead-background-color;
 $nav-bar-label-border-color: transparent !default;

--- a/samples/styles/app.scss
+++ b/samples/styles/app.scss
@@ -127,6 +127,7 @@ $nav-bar-scrollbar: true;
 $nav-bar-width: 15em;
 $nav-bar-fixed: true;
 $nav-bar-back-button-hide: false;
+$nav-bar-title-color: $color-text-secondary;
 $nav-bar-label-color: $color-light;
 $nav-bar-label-background-color: $masthead-background-color;
 $nav-bar-label-border-color: transparent !default;

--- a/samples/styles/web.scss
+++ b/samples/styles/web.scss
@@ -127,6 +127,7 @@ $nav-bar-scrollbar: true;
 $nav-bar-width: 15em;
 $nav-bar-fixed: true;
 $nav-bar-back-button-hide: true;
+$nav-bar-title-color: $color-text-secondary;
 $nav-bar-label-color: $color-light;
 $nav-bar-label-background-color: $masthead-background-color;
 $nav-bar-label-border-color: transparent !default;


### PR DESCRIPTION
Two distinct commits got into this one branch by mistake:

1. Add large-format image to src-set for feature images on big screens
2. Use a div, not a heading, for the site name in nav.
