### PR TITLE
Use more specific selectors for default accordion heads

### DIFF
--- a/assets/js/accordion.js
+++ b/assets/js/accordion.js
@@ -8,9 +8,9 @@
 //
 // 1. Use CSS selectors to list the headings that will
 //    define each accordion section, e.g. '#content h2'
-var accordionHeads = '#content h2';
+var accordionHeads = '#content > h2';
 // 2. Which heading's section should we show by default?
-var defaultAccordionHead = '#content h2:first-of-type';
+var defaultAccordionHead = '#content > h2:first-of-type, #content header > h2:first-of-type';
 // --------------------------------------------------------------
 
 function ebAccordionInit() {


### PR DESCRIPTION
This is necessary if there are, say, `h2`s in a box that should not accordify.