### PR TITLE
Nav and TOC fixes

### DIFF
--- a/_docs/setup/tocs.md
+++ b/_docs/setup/tocs.md
@@ -86,6 +86,20 @@ in a markdown file. This tag generates a table of contents. In the default templ
 
 Epubs have special TOC needs. See the [epub output section on metadata](../output/epub-output#metadata-and-settings).
 
+## TOCs outside of books
+
+Sometimes you may want to place the TOC of a book on a page that isn't inside that book's directly – on the home page, for instance. To do this, you need to tell the `toc` include which book's TOC you're generating, like this:
+
+{% raw %}
+
+``` liquid
+{% include toc book="moon-potatoes" %}
+```
+
+{% endraw %}
+
+By default, the `toc` include will generate the TOC of the book in the `book`folder.
+
 ## TOCs of book parts
 
 Sometimes you may want to output a TOC of only part of a book. For instance, say your book has four parts, each containing several chapters. You may want each part page to include a TOC of its chapters.
@@ -100,10 +114,14 @@ It can take some advanced technical know-how to write the 'address' of that node
 
 We need to add the following two lines to our part page's markdown file. The first assigns the `children` node's data to a variable. The second includes the TOC on the page, using that variable:
 
+{% raw %}
+
 ```liquid
 {% assign my-chapter-list = site.data.meta.works[0].products[site.output].toc[4].children %}
 {% include toc start=my-chapter-list %}
 ```
+
+{% endraw %}
 
 If you want to know how that works, let's break it down. In `site.data.meta.works[0].products[site.output].toc[4].children`, each dot or `[` means we're drilling down into the data by one level:
 

--- a/_docs/setup/tocs.md
+++ b/_docs/setup/tocs.md
@@ -24,7 +24,11 @@ The `_data/meta.yml` file includes all of the metadata of your book, from the se
 3. For each navigation or table of contents entry, add a line for each of `file: ""`, `label: ""` and, optionally, `id: ""` and `class: ""`, for each TOC entry. The first line in the TOC entry should have a `-`, like a bullet point.
 4. To nest entries beneath an entry, give the parent entry a `children:` line, then indented on the next line add `file: ""`, `label: ""`, and so on.
 
-The `label` can be anything you want, but is usually the heading of the section you are including in the table of contents, since the label is what displays in the table of contents or navigation. The `file` is the filename of the file that the item will link to, without a file extension. The optional `id` is usually the slug of the heading (the heading stripped of spaces, punctuation, and uppercase letters).
+The `label` can be anything you want, but is usually the heading of the section you are including in the table of contents, since the label is what displays in the table of contents or navigation.
+
+The `file` is the filename of the file that the item will link to, without a file extension.
+
+The optional `id` is usually the slug of the heading (the heading stripped of spaces, punctuation, and uppercase letters).
 
 Here is an example:
 
@@ -47,9 +51,9 @@ If you only add a `toc` for print or web output, the template will try to read t
 
 For PDFs, `id`s ensure that the TOC contains accurate page numbers in books where chapters start with a blank left-hand page.
 
-Note that within a file, an `id` can only be used once, as `id`s are unique. So, for example, if you have two subsections in one file both titled ‘Extra Information’, the `id`s will likely be ‘extra-information-1’ and ‘extra-information-2’.
+Note that within a file, an `id` can only be used once, as `id`s are unique. So, for example, if you have two subsections in one file both titled ‘Extra Information’, the `id`s will likely be `extra-information` and `extra-information-1`.
 
-If you are having trouble finding the slug for the `id`: generate a web version of your book, go to the heading, right click on it and choose ‘Inspect’ (you may need Cmd Shift C on Mac to get element-specific information). In the Elements box you should see a line of code that gives you the element’s `id`. For a heading level 1 called ‘Chapter 5: Animals’, the `id` is shown in this line of code followed by the label:
+If you are having trouble finding the slug for the `id`: generate a web version of your book, go to the heading, right click on it and choose ‘Inspect’ (you may need Cmd Shift C on Mac to get element-specific information). In the Elements box you should see a line of code that gives you the element’s `id`. For a level-1 heading called ‘Chapter 5: Animals’, the `id` is shown in this line of code followed by the label:
 
 ``` html
 <h1 id="chapter-5-animals">Chapter 5: Animals</h1>
@@ -62,32 +66,54 @@ Note that to see files in website navigation at all, they must be included in yo
 
 ## Adding classes to control design
 
-You can optionally add a `class` line to specify the [class](classes.html) of an element. For example, frontmatter in the book (such as a preface, whose entry in the TOC which you might want to look different from chapter content) can be given a different style by adding the line `class: "frontmatter-reference"` to the node of the metadata where you defined its `label`, `file` and `id`.
+You can optionally add a `class` line to specify the [class](../editing/classes.html) of an element. For example, frontmatter in the book (such as a preface, whose entry in the TOC which you might want to look different from chapter content) can be given a different style by adding the line `class: "frontmatter-reference"` to the node of the metadata where you defined its `label`, `file` and `id`.
 
-By default, `frontmatter-reference` in PDF output can provide a lower-roman-numeral page number, if `lower-roman` has been set in the `$frontmatter-reference-style` variable in your book's `-pdf.scss` stylesheets.
+By default, `frontmatter-reference` in PDF output can provide a lower-roman-numeral page number, if `lower-roman` has been set in the `$frontmatter-reference-style` variable in your book's `print-pdf.scss` and/or `screen-pdf.scss` stylesheets.
 
 ## Generating the TOC
 
 Once you have constructed your metadata for all of the outputs of the book that you're outputting (for example, print PDF and web formats), use:
 
 {% raw %}
-
 ``` liquid
 {% include toc %}
 ```
+{% endraw %}
 
 in a markdown file. This tag generates a table of contents. In the default template you can see this in the `0-3-contents.md` file.
-
-Note that for the `include toc` tag to work (and many other tags, such as `{{ images }}`), somewhere earlier in the document you must include this tag:
-
-``` liquid
-{% include metadata %}
-```
-
-We recommend including this `include metadata` tag at the start of all markdown files, so that tags are available.
-
-{% endraw %}
 
 ## Epub TOCs
 
 Epubs have special TOC needs. See the [epub output section on metadata](../output/epub-output#metadata-and-settings).
+
+## TOCs of book parts
+
+Sometimes you may want to output a TOC of only part of a book. For instance, say your book has four parts, each containing several chapters. You may want each part page to include a TOC of its chapters.
+
+In `_data/meta.yml`, the chapters you want are listed within each part's `children` node.
+
+To list only those in TOC, you need to tell the `toc` include to start there, with the part's `children`.
+
+To do this, you add a `start` parameter to the include tag, pointing to that `children` node.
+
+It can take some advanced technical know-how to write the 'address' of that node of data. Here is an example.
+
+We need to add the following two lines to our part page's markdown file. The first assigns the `children` node's data to a variable. The second includes the TOC on the page, using that variable:
+
+```liquid
+{% assign my-chapter-list = site.data.meta.works[0].products[site.output].toc[4].children %}
+{% include toc start=my-chapter-list %}
+```
+
+If you want to know how that works, let's break it down. In `site.data.meta.works[0].products[site.output].toc[4].children`, each dot or `[` means we're drilling down into the data by one level:
+
+- `'site.data.meta` refers to all the data in `_data/meta.yml`.
+- `.works` refers to the `works` node in that file.
+- `[0]` refers to the first work in the `works` node – that is, the first book in your project. If you wanted the second book in your project, you'd use [1]. The numbering of nodes in data starts at 0.
+- `.products` refers to the products – or output formats – of the work.
+- `[site.output]` refers to the current site output format, which will be one of the child nodes of `products`.
+- `.toc` refers to that output format's `toc` node.
+- `[4]` refers to the fifth item in the `toc` node, which in our example is the part for which we want to list the chapters.
+- `.children` refers to the list of chapters inside that `toc[4]` part. That's what we want for our TOC!
+
+Finally, in `start=my-chapter-list` we're telling the TOC include to start listing chapters at the `my-chapter-list` we just defined.

--- a/_includes/nav-list
+++ b/_includes/nav-list
@@ -50,18 +50,19 @@ defined in meta.yml. This is defined in _config.yml as nav-source.
   and we're not on a docs page, create the full book nav.{% endcomment %}
   {% else %}
 
-    {% comment %}Get an array of all the pages we're listing to check against{% endcomment %}
+    {% comment %}Get an array of existing pages to check against{% endcomment %}
+    {% assign site-pages-in-book = site.pages | where_exp: 'p', 'p.path contains book-directory' %}
     {% assign nav-tree-page-list = "" | split: "|" %}
-    {% for page in include.nav-tree %}
-      {% capture nav-tree-page-name %}{{ page.file | split: "." | first }}{% endcapture %}
+    {% for page in site-pages-in-book %}
+      {% capture nav-tree-page-name %}{{ page.name | split: "." | first }}{% endcapture %}
       {% assign nav-tree-page-list = nav-tree-page-list | push: nav-tree-page-name %}
     {% endfor %}
 
-    <ol{% if nav-tree-page-list contains current-file %} class="active"{% endif %}>
+    <ol>
       {% for item in include.nav-tree | sort: "order" %}
         <li class="{% if item.file == current-file %}active{% endif %}
         {% unless nav-tree-page-list contains item.file %}no-file{% endunless %}
-        {% if item.link == "none" %}no-link{% endif %}
+        {% if item.link == 'none' %}no-link{% endif %}
         {% if item.children == nil %}no-children{% else %}has-children{% endif %}
         {% if item.class != nil %}{{ item.class }}{% endif %}">
             <a {% if item.file != nil and item.link != "none" %}href="{{ item.file }}.html{% if item.id != nil %}#{{ item.id }}{% endif %}"{% endif %}
@@ -69,7 +70,7 @@ defined in meta.yml. This is defined in _config.yml as nav-source.
                 {{ item.label | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}
             </a>
             {% if item.children != nil %}
-              {% include nav-list nav-tree=item.children has-active-child=has-active-child %}
+              {% include nav-list nav-tree=item.children %}
             {% endif %}
         </li>
       {% endfor %}

--- a/_includes/toc
+++ b/_includes/toc
@@ -8,73 +8,77 @@ Now check which output format we're creating, and capture its toc.
 Fall back to print-pdf toc, then web nav list.
 {% endcomment %}
 
-{% if site.output == "print-pdf" %}
-    {% if print-pdf-toc != nil %}
-        {% assign toc = print-pdf-toc %}
-    {% elsif web-nav-tree != nil %}
-        {% assign toc = web-nav-tree %}
+{% unless include.start %}
+
+    {% if site.output == "print-pdf" %}
+        {% if print-pdf-toc != nil %}
+            {% assign toc = print-pdf-toc %}
+        {% elsif web-nav-tree != nil %}
+            {% assign toc = web-nav-tree %}
+        {% else %}
+            Please define a TOC or web nav in meta.yml.
+        {% endif %}
+
+    {% elsif site.output == "screen-pdf" %}
+        {% if screen-pdf-toc != nil %}
+            {% assign toc = screen-pdf-toc %}
+        {% elsif print-pdf-toc != nil %}
+            {% assign toc = print-pdf-toc %}
+        {% elsif web-nav-tree != nil %}
+            {% assign toc = web-nav-tree %}
+        {% else %}
+            Please define a TOC or web nav in meta.yml.
+        {% endif %}
+
+    {% elsif site.output == "epub" %}
+        {% if epub-toc != nil %}
+            {% assign toc = epub-toc %}
+        {% elsif print-pdf-toc != nil %}
+            {% assign toc = print-pdf-toc %}
+        {% elsif web-nav-tree != nil %}
+            {% assign toc = web-nav-tree %}
+        {% else %}
+            Please define a TOC or web nav in meta.yml.
+        {% endif %}
+
+    {% elsif site.output == "web" %}
+        {% if web-toc != nil %}
+            {% assign toc = web-toc %}
+        {% elsif web-nav-tree != nil %}
+            {% assign toc = web-nav-tree %}
+        {% elsif print-pdf-toc != nil %}
+            {% assign toc = print-pdf-toc %}
+        {% else %}
+            Please define a TOC or web nav in meta.yml.
+        {% endif %}
+
+    {% elsif site.output == "app" %}
+        {% if app-toc != nil %}
+            {% assign toc = app-toc %}
+        {% elsif app-nav-tree != nil %}
+            {% assign toc = app-nav-tree %}
+        {% elsif web-toc != nil %}
+            {% assign toc = web-toc %}
+        {% elsif web-nav-tree != nil %}
+            {% assign toc = web-nav-tree %}
+        {% elsif print-pdf-toc != nil %}
+            {% assign toc = print-pdf-toc %}
+        {% else %}
+            Please define a TOC or web nav in meta.yml.
+        {% endif %}
+
     {% else %}
-        Please define a TOC or web nav in meta.yml.
+        {% if web-nav-tree != nil %}
+            {% assign toc = web-nav-tree %}
+        {% elsif print-pdf-toc != nil %}
+            {% assign toc = print-pdf-toc %}
+        {% else %}
+            Please define a TOC or web nav in meta.yml.
+        {% endif %}
+
     {% endif %}
 
-{% elsif site.output == "screen-pdf" %}
-    {% if screen-pdf-toc != nil %}
-        {% assign toc = screen-pdf-toc %}
-    {% elsif print-pdf-toc != nil %}
-        {% assign toc = print-pdf-toc %}
-    {% elsif web-nav-tree != nil %}
-        {% assign toc = web-nav-tree %}
-    {% else %}
-        Please define a TOC or web nav in meta.yml.
-    {% endif %}
-
-{% elsif site.output == "epub" %}
-    {% if epub-toc != nil %}
-        {% assign toc = epub-toc %}
-    {% elsif print-pdf-toc != nil %}
-        {% assign toc = print-pdf-toc %}
-    {% elsif web-nav-tree != nil %}
-        {% assign toc = web-nav-tree %}
-    {% else %}
-        Please define a TOC or web nav in meta.yml.
-    {% endif %}
-
-{% elsif site.output == "web" %}
-    {% if web-toc != nil %}
-        {% assign toc = web-toc %}
-    {% elsif web-nav-tree != nil %}
-        {% assign toc = web-nav-tree %}
-    {% elsif print-pdf-toc != nil %}
-        {% assign toc = print-pdf-toc %}
-    {% else %}
-        Please define a TOC or web nav in meta.yml.
-    {% endif %}
-
-{% elsif site.output == "app" %}
-    {% if app-toc != nil %}
-        {% assign toc = app-toc %}
-    {% elsif app-nav-tree != nil %}
-        {% assign toc = app-nav-tree %}
-    {% elsif web-toc != nil %}
-        {% assign toc = web-toc %}
-    {% elsif web-nav-tree != nil %}
-        {% assign toc = web-nav-tree %}
-    {% elsif print-pdf-toc != nil %}
-        {% assign toc = print-pdf-toc %}
-    {% else %}
-        Please define a TOC or web nav in meta.yml.
-    {% endif %}
-
-{% else %}
-    {% if web-nav-tree != nil %}
-        {% assign toc = web-nav-tree %}
-    {% elsif print-pdf-toc != nil %}
-        {% assign toc = print-pdf-toc %}
-    {% else %}
-        Please define a TOC or web nav in meta.yml.
-    {% endif %}
-
-{% endif %}
+{% endunless %}
 
 {% comment %}
 If the file that called this include didn't specify a start parameter, then

--- a/_includes/toc
+++ b/_includes/toc
@@ -93,6 +93,20 @@ Otherwise, the toc-branch should be the children called by this include recursiv
     {% assign toc-branch = toc %}
 {% endif %}
 
+{% comment %}If we're not inside a book, we need a path to each file.
+By default, assume we're linking to files in 'book',
+and allow setting a different book directory as a 'book' argument.{% endcomment %}
+{% if is-book-directory %}
+    {% capture toc-path-to-file %}{% endcapture %}
+{% else %}
+    {% if include.book %}
+        {% capture toc-path-to-file %}{{ include.book }}/text/{% endcapture %}
+    {% else %}
+        {% capture toc-path-to-file %}book/text/{% endcapture %}
+    {% endif %}
+{% endif %}
+
+
 {% comment %}
 Now we'll use all that to output the toc list.
 {% endcomment %}
@@ -130,7 +144,7 @@ at the top of the toc, put this in a nav element.{% endcomment %}
     {% if include-in-toc == true %}
 
         <li class="toc-entry-title{% if page.url contains item.file %} active{% endif %}{% if item.class != nil %} {{ item.class }}{% endif %}">
-            {% if item.file != nil %}<a href="{{ item.file }}.html{% if item.id and item.id != "" %}#{{ item.id }}{% endif %}"
+            {% if item.file != nil %}<a href="{{ toc-path-to-file }}{{ item.file }}.html{% if item.id and item.id != "" %}#{{ item.id }}{% endif %}"
                {% if page.url contains item.file %}class="active"{% endif %}>{% endif %}
                 <span class="toc-entry-text">{{ item.label | markdownify | remove: '<p>' | remove: '</p>' | strip_newlines }}</span>
             {% if item.file != nil %}</a>{% endif %}

--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -45,7 +45,9 @@ function ebNav() {
             var j, equallyActiveParent;
             for (j = 0; j < activeChildren.length; j += 1) {
                 equallyActiveParent = activeChildren[j].closest('li:not(.active)');
-                equallyActiveParent.classList.add('active');
+                if (equallyActiveParent && equallyActiveParent !== 'undefined') {
+                    equallyActiveParent.classList.add('active');
+                }
             }
 
             // show the menu when we click the link

--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -1,116 +1,115 @@
-"use strict";
+/*jslint browser */
+/*globals window */
 
 function ebNav() {
+    'use strict';
 
-  // let Opera Mini use the footer-anchor pattern
-  if (navigator.userAgent.indexOf('Opera Mini') === - 1) {
+    // let Opera Mini use the footer-anchor pattern
+    if (navigator.userAgent.indexOf('Opera Mini') === -1) {
 
-    // let newer browsers use js-powered menu
-    if('querySelector' in document &&
-       'addEventListener' in window) {
+        // let newer browsers use js-powered menu
+        if (document.querySelector !== "undefined" &&
+                window.addEventListener) {
 
-      // set js nav class
-      document.documentElement.classList.add('js-nav');
+            // set js nav class
+            document.documentElement.classList.add('js-nav');
 
-      // set up the variables
-      var menuLink = document.querySelector('[href="#nav"]');
-      var menu = document.querySelector('#nav');
+            // set up the variables
+            var menuLink = document.querySelector('[href="#nav"]');
+            var menu = document.querySelector('#nav');
 
-      // hide the menu until we click the link
-      menu.classList.add("visuallyhidden");
+            // hide the menu until we click the link
+            menu.classList.add("visuallyhidden");
 
-      // add a close button
-      var closeButton = '<button data-toggle data-nav-close>';
-          closeButton += '<span class="visuallyhidden">Close menu</span>';
-          closeButton += '</button>';
-      menu.insertAdjacentHTML('afterBegin', closeButton);
+            // add a close button
+            var closeButton = '<button data-toggle data-nav-close>';
+            closeButton += '<span class="visuallyhidden">Close menu</span>';
+            closeButton += '</button>';
+            menu.insertAdjacentHTML('afterBegin', closeButton);
 
-      // hide the children and add the button for toggling
-      var subMenus = document
-                    .querySelectorAll('#nav .has-children, #nav .has-children');
-      var showChildrenButton = '<button data-toggle data-toggle-nav>';
-          showChildrenButton += '<span class="visuallyhidden">Toggle</span>'
-          showChildrenButton += '</button>';
-      for (var i = 0; i < subMenus.length; i++) {
-        subMenus[i].querySelector('ol, ul').classList.add('visuallyhidden');
-        subMenus[i].querySelector('a, .docs-list-title')
-                   .insertAdjacentHTML('afterend', showChildrenButton);
-      };
+            // hide the children and add the button for toggling
+            var subMenus = document
+                .querySelectorAll('#nav .has-children, #nav .has-children');
+            var showChildrenButton = '<button data-toggle data-toggle-nav>';
+            showChildrenButton += '<span class="visuallyhidden">Toggle</span>';
+            showChildrenButton += '</button>';
+            var i;
+            for (i = 0; i < subMenus.length; i += 1) {
+                subMenus[i].querySelector('ol, ul').classList.add('visuallyhidden');
+                subMenus[i].querySelector('a, .docs-list-title')
+                    .insertAdjacentHTML('afterend', showChildrenButton);
+            }
 
-      // show the menu when we click the link
-      menuLink.addEventListener("click", function(ev) {
-        ev.preventDefault();
-        menu.classList.toggle("visuallyhidden");
-        document.documentElement.classList.toggle('js-nav-open');
-      }, true);
-
-      var ebHideMenu = function() {
-          menu.classList.add("visuallyhidden");
-          document.documentElement.classList.remove('js-nav-open');
-      };
-
-      // listen for clicks inside the menu
-      menu.addEventListener("click", function(ev) {
-        var clickedElement = ev.target || ev.srcElement;
-
-        // hide the menu when we click the button
-        if (clickedElement.hasAttribute("data-nav-close")) {
-            ev.preventDefault();
-            ebHideMenu();
-            return;
-        };
-
-        // show the children when we click a .has-children
-        if (clickedElement.hasAttribute("data-toggle-nav")) {
-            ev.preventDefault();
-            clickedElement.classList.toggle('show-children');
-            clickedElement.nextElementSibling.classList.toggle('visuallyhidden');
-            return;
-        };
-
-        // if it's an anchor with an href (an in-page link)
-        if (clickedElement.tagName === "A" && clickedElement.getAttribute('href')) {
-            ebHideMenu();
-            return;
-        };
-
-        // if it's an anchor without an href (a nav-only link)
-        if (clickedElement.tagName === "A") {
-            clickedElement.nextElementSibling.classList.toggle('show-children');
-            clickedElement.nextElementSibling.nextElementSibling.classList.toggle('visuallyhidden');
-            return;
-        };
-
-
-      });
-
-      // This enables a back button, e.g. for where we don't have a
-      // browser or hardware back button, and we have Jekyll add one.
-      // This button is hidden in scss with `$nav-bar-back-button-hide: true;`.
-      // If the user has navigated (i.e. there is a document referrer),
-      // listen for clicks on our back button and go back when clicked.
-      // We check history.length > 2 because new tab plus landing page
-      // can constitute 2 entries in the history (varies by browser).
-      if (document.referrer != "" || window.history.length > 2) {
-        var navBackButton = document.querySelector('a.nav-back-button');
-        if (navBackButton) {
-            navBackButton.addEventListener('click', function(ev) {
+            // show the menu when we click the link
+            menuLink.addEventListener("click", function (ev) {
                 ev.preventDefault();
-                console.log('Going back...');
-                window.history.back();
+                menu.classList.toggle("visuallyhidden");
+                document.documentElement.classList.toggle('js-nav-open');
+            }, true);
+
+            var ebHideMenu = function () {
+                menu.classList.add("visuallyhidden");
+                document.documentElement.classList.remove('js-nav-open');
+            };
+
+            // listen for clicks inside the menu
+            menu.addEventListener("click", function (ev) {
+                var clickedElement = ev.target || ev.srcElement;
+
+                // hide the menu when we click the button
+                if (clickedElement.hasAttribute("data-nav-close")) {
+                    ev.preventDefault();
+                    ebHideMenu();
+                    return;
+                }
+
+                // show the children when we click a .has-children
+                if (clickedElement.hasAttribute("data-toggle-nav")) {
+                    ev.preventDefault();
+                    clickedElement.classList.toggle('show-children');
+                    clickedElement.nextElementSibling.classList.toggle('visuallyhidden');
+                    return;
+                }
+
+                // if it's an anchor with an href (an in-page link)
+                if (clickedElement.tagName === "A" && clickedElement.getAttribute('href')) {
+                    ebHideMenu();
+                    return;
+                }
+
+                // if it's an anchor without an href (a nav-only link)
+                if (clickedElement.tagName === "A") {
+                    clickedElement.nextElementSibling.classList.toggle('show-children');
+                    clickedElement.nextElementSibling.nextElementSibling.classList.toggle('visuallyhidden');
+                    return;
+                }
             });
-        };
-      } else {
-          var navBackButton = document.querySelector('a.nav-back-button');
-          if (navBackButton) {
-            navBackButton.parentNode.removeChild(navBackButton);
-          };
-      };
 
-    };
-
-  };
-
-};
+            // This enables a back button, e.g. for where we don't have a
+            // browser or hardware back button, and we have Jekyll add one.
+            // This button is hidden in scss with `$nav-bar-back-button-hide: true;`.
+            // If the user has navigated (i.e. there is a document referrer),
+            // listen for clicks on our back button and go back when clicked.
+            // We check history.length > 2 because new tab plus landing page
+            // can constitute 2 entries in the history (varies by browser).
+            var navBackButton;
+            if (document.referrer !== "" || window.history.length > 2) {
+                navBackButton = document.querySelector('a.nav-back-button');
+                if (navBackButton) {
+                    navBackButton.addEventListener('click', function (ev) {
+                        ev.preventDefault();
+                        console.log('Going back...');
+                        window.history.back();
+                    });
+                }
+            } else {
+                navBackButton = document.querySelector('a.nav-back-button');
+                if (navBackButton) {
+                    navBackButton.parentNode.removeChild(navBackButton);
+                }
+            }
+        }
+    }
+}
 
 ebNav();

--- a/assets/js/nav.js
+++ b/assets/js/nav.js
@@ -40,6 +40,14 @@ function ebNav() {
                     .insertAdjacentHTML('afterend', showChildrenButton);
             }
 
+            // Mark parents of active children active too
+            var activeChildren = menu.querySelectorAll('li.active');
+            var j, equallyActiveParent;
+            for (j = 0; j < activeChildren.length; j += 1) {
+                equallyActiveParent = activeChildren[j].closest('li:not(.active)');
+                equallyActiveParent.classList.add('active');
+            }
+
             // show the menu when we click the link
             menuLink.addEventListener("click", function (ev) {
                 ev.preventDefault();

--- a/assets/js/polyfills.js
+++ b/assets/js/polyfills.js
@@ -122,3 +122,22 @@ if (!Array.prototype.find) {
     }
   });
 }
+
+// closest()
+// https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+if (!Element.prototype.matches) {
+  Element.prototype.matches = Element.prototype.msMatchesSelector ||
+                              Element.prototype.webkitMatchesSelector;
+}
+
+if (!Element.prototype.closest) {
+  Element.prototype.closest = function(s) {
+    var el = this;
+
+    do {
+      if (el.matches(s)) return el;
+      el = el.parentElement || el.parentNode;
+    } while (el !== null && el.nodeType === 1);
+    return null;
+  };
+}


### PR DESCRIPTION
- In the nav, this marks the parents of active children active too. Say you're on a chapter in Part 1 of a book: previously, the parent 'Part 1' menu item was not marked active (i.e. it was not highlighted in the nav bar). Since the nav bar always opens collapsed and not expanded, this meant that you couldn't see at first where you were in the book. With this fix, the parent file is marked active and highlighted accordingly. So if you're on a chapter page, its 'Part 1' parent nav item is highlighted.

   I haven't tested what happens when nav lists are three deep, as opposed to two-deep here, but we'll leave that for another time.

- I've fixed false negatives when checking if a file exists. We were getting an incorrect 'no-files' class on menu items on book pages, because we were only checking the file names of the item's children, and not the item itself.

- Small optimisation in the `toc` include: don't query `meta.yml` for a nav tree data object if a 'start' argument already exists, i.e. if the include has already been passed a data object.

- We can now create TOCs outside of book files (e.g. on landing pages) by passing a `book` argument to the `toc` include.

- I've documented the `toc` include's `book` and `start` arguments.