### PR TITLE
Fix regression in #413

### DIFF
--- a/_includes/toc
+++ b/_includes/toc
@@ -96,7 +96,7 @@ Otherwise, the toc-branch should be the children called by this include recursiv
 {% comment %}If we're not inside a book, we need a path to each file.
 By default, assume we're linking to files in 'book',
 and allow setting a different book directory as a 'book' argument.{% endcomment %}
-{% if is-book-directory %}
+{% if is-book-subdirectory %}
     {% capture toc-path-to-file %}{% endcapture %}
 {% else %}
     {% if include.book %}


### PR DESCRIPTION
In #413, the wrong variable name broke the check for whether we are in a directory, sorry.