### PR TITLE
Add JS-driven lazyloading for images

### DIFF
--- a/_includes/figure
+++ b/_includes/figure
@@ -50,8 +50,8 @@ because https://github.com/jekyll/jekyll/issues/2248.
                     />
                 </noscript>
 
-                <img src="{{ images }}/{{ image }}"
-                    srcset="{{ images }}/{{ image-without-filetype }}-320.{{ image-filetype[1] }} 320w,
+                <img data-src="{{ images }}/{{ image }}"
+                    data-srcset="{{ images }}/{{ image-without-filetype }}-320.{{ image-filetype[1] }} 320w,
                                 {{ images }}/{{ image-without-filetype }}-640.{{ image-filetype[1] }} 640w,
                                 {{ images }}/{{ image-without-filetype }}-1024.{{ image-filetype[1] }} 1024w,
                                 {{ images }}/{{ image-without-filetype }}.{{ image-filetype[1] }} 1280w"

--- a/_includes/image
+++ b/_includes/image
@@ -32,13 +32,37 @@ root directory. {% endcomment %}
 {% comment %} Adjust the value of `sizes` if your site design does not need
 full-width images everywhere. Here is a guide:
 https://builtvisible.com/responsive-images-for-busy-people-a-quick-primer/ {% endcomment %}
+
+{% comment %} Provide no-JS fallback when lazyloading JS
+is not available {% endcomment %}
+<noscript>
+
+    <img
+        src="{{ images }}/{{ image }}.{{ file-extension }}"
+
+        {% if site.output == "web" %}
+        {% unless file-extension == "svg" %}
+        sizes="auto"
+        srcset="{{ images }}/{{ image }}-320.{{ file-extension }} 320w,
+        {{ images }}/{{ image }}-640.{{ file-extension }} 640w,
+        {{ images }}/{{ image }}-1024.{{ file-extension }} 1024w,
+        {{ images }}/{{ image }}-2048.{{ file-extension }} 2048w"
+        {% endunless %}
+        {% endif %}
+
+        class="{% if include.class %}{{ include.class }}{% endif %}{% if file-extension == 'svg' %} inject-svg{% endif %}"
+        {% if include.id %} id="{{ include.id }}"{% endif %}
+        {% if image-alt %} alt="{{ image-alt }}"{% endif %} />
+
+</noscript>
+
 <img
-    src="{{ images }}/{{ image }}.{{ file-extension }}"
+    data-src="{{ images }}/{{ image }}.{{ file-extension }}"
 
     {% if site.output == "web" %}
     {% unless file-extension == "svg" %}
     sizes="auto"
-    srcset="{{ images }}/{{ image }}-320.{{ file-extension }} 320w,
+    data-srcset="{{ images }}/{{ image }}-320.{{ file-extension }} 320w,
     {{ images }}/{{ image }}-640.{{ file-extension }} 640w,
     {{ images }}/{{ image }}-1024.{{ file-extension }} 1024w,
     {{ images }}/{{ image }}-2048.{{ file-extension }} 2048w"

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -24,6 +24,7 @@ layout: null
     {% include_relative tables.js %}
     {% include_relative footnote-popups.js %}
     {% include_relative show-hide.js %}
+    {% include_relative lazyload.js %}
 
     {% if site.data.settings.web.svg.inject == true %}
         {% include_relative svg-inject.min.js %}

--- a/assets/js/lazyload.js
+++ b/assets/js/lazyload.js
@@ -49,8 +49,7 @@ function ebLazyLoadImages() {
             });
         }, ebImageObserverConfig);
 
-        // For each image, give it a min-height
-        // and then observe it.
+        // Observe each image
         lazyImages.forEach(function (lazyImage) {
             lazyImageObserver.observe(lazyImage);
         });

--- a/assets/js/lazyload.js
+++ b/assets/js/lazyload.js
@@ -1,0 +1,72 @@
+/*jslint browser */
+/*globals window, IntersectionObserver, svgInject */
+
+// Add observer
+var ebImageObserverConfig = {
+    rootMargin: '200px' // load image when it's 200px from the viewport
+};
+
+// Re-run SVGInject() after lazyloading SVGs
+// (Assumes SVGInject() has been bundled already.)
+function ebInjectLazyLoadedSVG(image) {
+    'use strict';
+    if (image.classList.contains('inject-svg')
+            && !image.classList.contains('no-inject-svg')) {
+        svgInject(image);
+    }
+}
+
+function ebLazyLoadImages() {
+    'use strict';
+
+    // Create an array and then populate it with images.
+    var lazyImages = [];
+    lazyImages = lazyImages.slice
+        .call(document.querySelectorAll('[data-src], [data-srcset]'));
+
+    // If IntersectionObserver is supported,
+    // create a new one that will use it on all the lazyImages.
+    if (window.hasOwnProperty('IntersectionObserver')) {
+        var lazyImageObserver = new IntersectionObserver(function
+                (entries, lazyImageObserver) {
+            entries.forEach(function (entry) {
+                if (entry.isIntersecting) {
+
+                    var lazyImage = entry.target;
+
+                    // Set the src as the data-src,
+                    // and the src-set as the data-srcset.
+                    if (lazyImage.dataset.src) {
+                        lazyImage.src = lazyImage.dataset.src;
+                    }
+                    if (lazyImage.dataset.srcset) {
+                        lazyImage.srcset = lazyImage.dataset.srcset;
+                    }
+
+                    // Stop observing the image once loaded
+                    lazyImageObserver.unobserve(lazyImage);
+                }
+            });
+        }, ebImageObserverConfig);
+
+        // For each image, give it a min-height
+        // and then observe it.
+        lazyImages.forEach(function (lazyImage) {
+            lazyImageObserver.observe(lazyImage);
+        });
+    } else {
+        // If the browser doesn't support IntersectionObserver,
+        // just change all data-src to src and data-srcset to srcset.
+        lazyImages.forEach(function (lazyImage) {
+            if (lazyImage.dataset.src) {
+                lazyImage.src = lazyImage.dataset.src;
+            }
+            if (lazyImage.dataset.srcset) {
+                lazyImage.srcset = lazyImage.dataset.srcset;
+            }
+        });
+    }
+}
+
+// Go when the document is loaded
+document.addEventListener('DOMContentLoaded', ebLazyLoadImages());


### PR DESCRIPTION
This adds JS-driven lazy-loading for images included with our `image` and `figure` include tags. 

This does not yet use the `loading` attribute as discussed in https://github.com/electricbookworks/electric-book/issues/399.

@LouiseSteward Can you look this over when you get a chance, please?