### PR TITLE
Workaround para indent issue introduced in #416

### DIFF
--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -49,7 +49,7 @@ $font-size-bigger: 2 !default; // How many times bigger than font-size-default f
 // Do you want space between paragraphs, rather than a text-indent? true or false
 $spaced-paras: true !default;
 // If not spacing paras, how large is the first-line indent on paragraphs?
-$paragraph-indent: $font-size-default !default;
+$paragraph-indent: $line-height-default !default;
 
 // Rounded corners
 $button-border-radius: 0.1em !default; // Roundness of button corners

--- a/_sass/epub.scss
+++ b/_sass/epub.scss
@@ -46,7 +46,7 @@ $font-size-bigger: 2 !default; // How many times bigger than font-size-default f
 // Do you want space between paragraphs, rather than a text-indent? true or false
 $spaced-paras: false !default;
 // If not spacing paras, how large is the first-line indent on paragraphs?
-$paragraph-indent: $font-size-default !default;
+$paragraph-indent: $line-height-default !default;
 
 // Extra margin
 // Some epub readers don't add any margin to their viewport.

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -106,7 +106,7 @@ $math-size-percent: 85%; // Adjust this to make math character size match your b
 // Do you want space between paragraphs, rather than a text-indent? true or false
 $spaced-paras: false !default;
 // If not spacing paras, how large is the first-line indent on paragraphs?
-$paragraph-indent: $font-size-default !default;
+$paragraph-indent: $line-height-default !default;
 
 // Rounded corners
 $button-border-radius: 0.1em !default; // Roundness of button corners

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -106,7 +106,7 @@ $math-size-percent: 85%; // Adjust this to make math character size match your b
 // Do you want space between paragraphs, rather than a text-indent? true or false
 $spaced-paras: false !default;
 // If not spacing paras, how large is the first-line indent on paragraphs?
-$paragraph-indent: $font-size-default !default;
+$paragraph-indent: $line-height-default !default;
 
 // Rounded corners
 $button-border-radius: 0.1em !default; // Roundness of button corners

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -49,7 +49,7 @@ $font-size-bigger: 2 !default; // How many times bigger than font-size-default f
 // Do you want space between paragraphs, rather than a text-indent? true or false
 $spaced-paras: true !default;
 // If not spacing paras, how large is the first-line indent on paragraphs?
-$paragraph-indent: $font-size-default !default;
+$paragraph-indent: $line-height-default !default;
 
 // Rounded corners
 $button-border-radius: 0.1em !default; // Roundness of button corners


### PR DESCRIPTION
In #416 I created a dedicated `$paragraph-indent` variable, which seems a better way to control paragraph indentation than just using `$line-height-default` (which tends to be too great an indent visually). However, there are far more places in the CSS that use `$line-height-default` for indentation (e.g. subsequent paras and list indentation) that also need updating. So, for now, setting `$paragraph-indent` to `$line-height-default` keeps the old behaviour while I work on a deeper refactoring in the many partials that handle indentation.