### PR TITLE
Fix PDF image after lazyloading regression

### DIFF
--- a/_includes/image
+++ b/_includes/image
@@ -34,7 +34,8 @@ full-width images everywhere. Here is a guide:
 https://builtvisible.com/responsive-images-for-busy-people-a-quick-primer/ {% endcomment %}
 
 {% comment %} Provide no-JS fallback when lazyloading JS
-is not available {% endcomment %}
+is not available in web output {% endcomment %}
+{% if site.output == "web" %}
 <noscript>
 
     <img
@@ -55,18 +56,21 @@ is not available {% endcomment %}
         {% if image-alt %} alt="{{ image-alt }}"{% endif %} />
 
 </noscript>
+{% endif %}
 
 <img
-    data-src="{{ images }}/{{ image }}.{{ file-extension }}"
 
     {% if site.output == "web" %}
-    {% unless file-extension == "svg" %}
-    sizes="auto"
-    data-srcset="{{ images }}/{{ image }}-320.{{ file-extension }} 320w,
-    {{ images }}/{{ image }}-640.{{ file-extension }} 640w,
-    {{ images }}/{{ image }}-1024.{{ file-extension }} 1024w,
-    {{ images }}/{{ image }}-2048.{{ file-extension }} 2048w"
-    {% endunless %}
+        data-src="{{ images }}/{{ image }}.{{ file-extension }}"
+        {% unless file-extension == "svg" %}
+            sizes="auto"
+            data-srcset="{{ images }}/{{ image }}-320.{{ file-extension }} 320w,
+            {{ images }}/{{ image }}-640.{{ file-extension }} 640w,
+            {{ images }}/{{ image }}-1024.{{ file-extension }} 1024w,
+            {{ images }}/{{ image }}-2048.{{ file-extension }} 2048w"
+            {% endunless %}
+    {% else %}
+        src="{{ images }}/{{ image }}.{{ file-extension }}"
     {% endif %}
 
     class="{% if include.class %}{{ include.class }}{% endif %}{% if file-extension == 'svg' %} inject-svg{% endif %}"

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -24,12 +24,14 @@ layout: null
     {% include_relative tables.js %}
     {% include_relative footnote-popups.js %}
     {% include_relative show-hide.js %}
-    {% include_relative lazyload.js %}
 
     {% if site.data.settings.web.svg.inject == true %}
         {% include_relative svg-inject.min.js %}
         {% include_relative svg-management.js %}
     {% endif %}
+
+    {% comment %} Load after SVG management {% endcomment %}
+    {% include_relative lazyload.js %}
 
 {% endif %}
 

--- a/assets/js/lazyload.js
+++ b/assets/js/lazyload.js
@@ -1,5 +1,5 @@
 /*jslint browser */
-/*globals window, IntersectionObserver, svgInject */
+/*globals window, IntersectionObserver, SVGInject */
 
 // Add observer
 var ebImageObserverConfig = {
@@ -11,8 +11,9 @@ var ebImageObserverConfig = {
 function ebInjectLazyLoadedSVG(image) {
     'use strict';
     if (image.classList.contains('inject-svg')
-            && !image.classList.contains('no-inject-svg')) {
-        svgInject(image);
+            && !image.classList.contains('no-inject-svg')
+            && typeof SVGInject === 'function') {
+        SVGInject(image);
     }
 }
 
@@ -41,6 +42,12 @@ function ebLazyLoadImages() {
                     }
                     if (lazyImage.dataset.srcset) {
                         lazyImage.srcset = lazyImage.dataset.srcset;
+                    }
+
+                    // If the image is an SVG, inject it if necessary
+                    var fileExtension = lazyImage.src.split('.').pop();
+                    if (fileExtension === 'svg' || fileExtension === 'SVG') {
+                        ebInjectLazyLoadedSVG(lazyImage);
                     }
 
                     // Stop observing the image once loaded


### PR DESCRIPTION
This should fix a regression (aka silly mistake) I made in #419: when adding lazy-loading of images, I didn't ensure that SVGs were properly loaded in all formats.

This should fix #421. (Thanks, @jaycolmvar.)

@LouiseSteward Can you look over these fixes before I merge, please?