### PR TITLE
Image fixes

### DIFF
--- a/_data/images.yml
+++ b/_data/images.yml
@@ -1,0 +1,11 @@
+# Image settings
+# --------------
+# This file sets non-default settings for specific images.
+#
+# E.g.
+# - file: "duckrabbit.jpg"
+#   print-pdf:
+#     colorspace: "gray"
+#
+# Possible values
+# - print-PDF colorspace: cmyk | gray

--- a/_includes/image
+++ b/_includes/image
@@ -2,6 +2,11 @@
 
 {% include metadata %}
 
+{% comment %} Reset variables {% endcomment %}
+{% assign image = "" %}
+{% assign file-extension = "" %}
+{% assign image-alt = "" %}
+
 {% comment %} Get the image and its file extension.
 Let user use `file` or `src` for the image file,
 defaulting to src. {% endcomment %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,40 +23,44 @@ var gulp = require('gulp'),
     cheerio = require('gulp-cheerio');
 
 // Get arrays of possible book and language paths
-var metadata = yaml.load(fs.readFileSync('_data/meta.yml', 'utf8'));
-var works = metadata.works;
-function loadMetadata() {
-    'use strict';
-    var paths = [];
-    var filePaths = [];
-    var books = [];
-    var languages = [];
-    var i;
-    var j;
-    for (i = 0; i < works.length; i += 1) {
-        books.push(works[i].directory);
-        paths.push('_site/' + works[i].directory + '/text/');
-        filePaths.push('_site/' + works[i].directory + '/text/*.html');
-        if (works[i].translations) {
-            for (j = 0; j < works[i].translations.length; j += 1) {
-                languages.push(works[i].translations[j].directory);
-                paths.push('_site/' + works[i].directory + '/' + works[i].translations[j].directory + '/text/');
-                filePaths.push('_site/' + works[i].directory + '/' + works[i].translations[j].directory + '/text/*.html');
+if (fileExists.sync('_data/meta.yml')) {
+    var metadata = yaml.load(fs.readFileSync('_data/meta.yml', 'utf8'));
+    var works = metadata.works;
+    function loadMetadata() {
+        'use strict';
+        var paths = [];
+        var filePaths = [];
+        var books = [];
+        var languages = [];
+        var i;
+        var j;
+        for (i = 0; i < works.length; i += 1) {
+            books.push(works[i].directory);
+            paths.push('_site/' + works[i].directory + '/text/');
+            filePaths.push('_site/' + works[i].directory + '/text/*.html');
+            if (works[i].translations) {
+                for (j = 0; j < works[i].translations.length; j += 1) {
+                    languages.push(works[i].translations[j].directory);
+                    paths.push('_site/' + works[i].directory + '/' + works[i].translations[j].directory + '/text/');
+                    filePaths.push('_site/' + works[i].directory + '/' + works[i].translations[j].directory + '/text/*.html');
+                }
             }
         }
+        return {
+            books: books,
+            languages: languages,
+            paths: paths,
+            filePaths: filePaths
+        };
     }
-    return {
-        books: books,
-        languages: languages,
-        paths: paths,
-        filePaths: filePaths
-    };
+    loadMetadata();
+}
+
 // Load image settings if they exist
 var imageSettings = [];
 if (fs.existsSync('_data/images.yml')) {
     imageSettings = yaml.load(fs.readFileSync('_data/images.yml', 'utf8'));
 }
-loadMetadata();
 
 // Get the book we're processing
 var book = 'book';

--- a/samples/text/02-02-figures.md
+++ b/samples/text/02-02-figures.md
@@ -33,9 +33,13 @@ A program that employs the pre-cloak stage of superheroes has been active in Rwa
 
 [^3]: Rwandan Orphans Project (2016).  Available at: http://www.rwandanorphansproject.org/ (Accessed 14 May 2016).
 
-![Figure 1](../{{ site.image-set }}/fradkin-1.jpg){:.height-15}
-**Figure 1**{:.figure-reference} The Rwandan Orphans Project (near Kigali, Rwanda) uses comic superheroes to empower orphaned children. Capes from old t-shirts, masks from cereal boxes. Published with permission from The Rwandan Orphans Project. Photo © Lisa Meaney, MFT, [Rwandan Orphans Project](http://www.rwandanorphansproject.org), 2016 (Accessed 14 May 2016).
-{:.image-with-caption #figure-1}
+{% include figure
+    image="fradkin-1.jpg"
+    image-height="15"
+    reference="Figure 1"
+    caption="The Rwandan Orphans Project (near Kigali, Rwanda) uses comic superheroes to empower orphaned children. Capes from old t-shirts, masks from cereal boxes. Published with permission from The Rwandan Orphans Project. Photo © Lisa Meaney, MFT, [Rwandan Orphans Project](http://www.rwandanorphansproject.org), 2016 (Accessed 14 May 2016)."
+    description="Children stand in a line wearing super-hero capes and masks made from cereal boxes, making bold super-hero poses."
+%}
 
 5,000 miles WSW of Rwanda is a program in São Paulo, Brazil. The ‘Superformula’ program at the A.C. Camargo Cancer Center (2016[^4]), attempts to raise the spirits of its pediatric patients using special comics, videos, and superhero plastic covers for IV bags ([Figure 2](#figure-2)). The children are encouraged to do battle with their cancer, as the comic superheroes battle evil. Their chemo drip is ‘Superformula.’ While this approach may first seem novel, over time it may wear thin, as many patients on the ward will lose their battle. The Superformula program instills hope upon the ward, through the premise of ‘invincibility suggestion.’
 


### PR DESCRIPTION
Various fixes and refinements for image handling:

- enables setting colour profiles for specific images (e.g. when you want some images in a print PDF to be grayscale and others to be CMYK)
- fixes a bug that can allow an image without `alt` text to inherit the `alt` text of a preceding image
- updates the gulpfile so that it can be used as-is in remote-media repos with the electric-book-media repo (see https://github.com/electricbookworks/electric-book-media/pull/2)
- updates the `samples` book by removing a deprecated figure syntax.