### PR TITLE
Enable turning lazyloading on/off in settings.yml

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -103,6 +103,11 @@ web:
   # Set 'inject' to false to disable SVG injection.
   svg:
     inject: true
+  # -----------------
+  # Images management
+  # -----------------
+  images:
+    lazyload: true
 
 # ----------------------------------------------------------
 # Epub settings

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -5,6 +5,7 @@ layout: null
 ---
 
 {% include_relative polyfills.js %}
+{% include_relative settings.js %}
 {% include_relative locales.js %}
 {% include_relative mark-parents.js %}
 

--- a/assets/js/lazyload.js
+++ b/assets/js/lazyload.js
@@ -1,5 +1,5 @@
 /*jslint browser */
-/*globals window, IntersectionObserver, SVGInject */
+/*globals window, IntersectionObserver, SVGInject, settings */
 
 // Add observer
 var ebImageObserverConfig = {
@@ -26,8 +26,10 @@ function ebLazyLoadImages() {
         .call(document.querySelectorAll('[data-src], [data-srcset]'));
 
     // If IntersectionObserver is supported,
+    // and lazyloading is on in settings.yml (loaded in settings.js),
     // create a new one that will use it on all the lazyImages.
-    if (window.hasOwnProperty('IntersectionObserver')) {
+    if (window.hasOwnProperty('IntersectionObserver')
+            && settings.web.images.lazyload === true) {
         var lazyImageObserver = new IntersectionObserver(function
                 (entries, lazyImageObserver) {
             entries.forEach(function (entry) {

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,0 +1,21 @@
+// Load settings.yml into a settings array.
+
+// Fetch specific values from settings.yml and
+// convert them into a Javascript object called settings.
+// Note that some YAML keys use hyphens, which are invalid JS. 
+// So to use them as variables, use square brackets and quotes,
+// e.g. search['search-placeholder'].
+// NB: The generated settings load in client-side Javascript, so
+// do not include any settings that should not be publicly available.
+
+// Create default settings object
+var settings = {
+    web: {
+        images: {
+            lazyload: true
+        }
+    }
+};
+
+// Override default settings from settings.yml
+settings.web.images.lazyload = {{ site.data.settings.web.images.lazyload }};


### PR DESCRIPTION
Some projects don't need (or shouldn't have) lazyloaded images. This change lets us toggle lazyloading on or off from `settings.yml`.

How this works:

- in `bundle.js`, we include a `settings.js`, which Jekyll populates with the lazyloading value from `settings.yml`.
- `settings.js` creates a `settings` object which is then available for all subsequent JS. (In future, we could add other settings to this object if we need them for JS. We do something similar with `locales.js`, except there we can safely include all of `locales.yml`, whereas `settings.yml` may include values that are only for site generation, and should not be exposed in client-side JS. So we are selective about which settings to include in the `settings` object.)
- `lazyload.js`, which is also included in `bundle.js`, checks whether lazyloading is activated (i.e. `settings.web.images.lazyload === true`). If it isn't, `lazyload.js` immediately lets all the images on the page load, without waiting for the image to scroll nearby (i.e. is skips the `intersectionObserver` and changes `data-src` attributes to `src`).
