### PR TITLE
SVG improvements

### DIFF
--- a/_includes/figure
+++ b/_includes/figure
@@ -29,10 +29,14 @@ because https://github.com/jekyll/jekyll/issues/2248.
 {% if include.image or include.images %}
 <div class="figure-images contains-{{ number-of-images }}">
 
-    {%for image in figure-images %}
+    {% for image in figure-images %}
 
-        {% assign image-filetype = image | split: "." %}
-        {% assign image-without-filetype = image | replace: image-filetype[1], "" | replace: ".", "" %}
+        {% comment %} Get the file extension and the filename without it,
+        in a way that allows for full stops in filenames. {% endcomment %}
+        {% assign image-name-array = image | split: "." %}
+        {% assign image-file-extension = image-name-array | last %}
+        {% capture image-extension-with-full-stop %}.{{ image-file-extension }}{% endcapture %}
+        {% assign image-without-file-extension = image | replace: image-extension-with-full-stop, "" %}
 
         {% if include.link %}<a href="{{ include.link }}">{% elsif site.output == "web" %}<a href="{{ images }}/{{ image }}">{% endif %}
 
@@ -40,22 +44,30 @@ because https://github.com/jekyll/jekyll/issues/2248.
 
                 <noscript>
                     <img src="{{ images }}/{{ image }}"
-                        srcset="{{ images }}/{{ image-without-filetype }}-320.{{ image-filetype[1] }} 320w,
-                                {{ images }}/{{ image-without-filetype }}-640.{{ image-filetype[1] }} 640w,
-                                {{ images }}/{{ image-without-filetype }}-1024.{{ image-filetype[1] }} 1024w,
-                                {{ images }}/{{ image-without-filetype }}.{{ image-filetype[1] }} 1280w"
-                        sizes="(min-width: 600px) 1300px, 100vw"
+
+                        {% unless image-file-extension == 'svg' %}
+                            srcset="{{ images }}/{{ image-without-file-extension }}-320.{{ image-file-extension }} 320w,
+                                    {{ images }}/{{ image-without-file-extension }}-640.{{ image-file-extension }} 640w,
+                                    {{ images }}/{{ image-without-file-extension }}-1024.{{ image-file-extension }} 1024w,
+                                    {{ images }}/{{ image-without-file-extension }}.{{ image-file-extension }} 1280w"
+                            sizes="(min-width: 600px) 1300px, 100vw"
+                        {% endunless %}
+
                         alt="{% if include.title %}{{ include.title | markdownify | strip_html }}: {% endif %}{% if include.description %}{{ include.description | markdownify | strip_html }}{% else %}{{ include.caption | markdownify | strip_html }}{% endif %}"
                         {% if include.image-height != nil %} class="height-{{ include.image-height }}"{% endif %} 
                     />
                 </noscript>
 
                 <img data-src="{{ images }}/{{ image }}"
-                    data-srcset="{{ images }}/{{ image-without-filetype }}-320.{{ image-filetype[1] }} 320w,
-                                {{ images }}/{{ image-without-filetype }}-640.{{ image-filetype[1] }} 640w,
-                                {{ images }}/{{ image-without-filetype }}-1024.{{ image-filetype[1] }} 1024w,
-                                {{ images }}/{{ image-without-filetype }}.{{ image-filetype[1] }} 1280w"
-                    sizes="(min-width: 600px) 1300px, 100vw"
+
+                    {% unless image-file-extension == 'svg' %}
+                        data-srcset="{{ images }}/{{ image-without-file-extension }}-320.{{ image-file-extension }} 320w,
+                                    {{ images }}/{{ image-without-file-extension }}-640.{{ image-file-extension }} 640w,
+                                    {{ images }}/{{ image-without-file-extension }}-1024.{{ image-file-extension }} 1024w,
+                                    {{ images }}/{{ image-without-file-extension }}.{{ image-file-extension }} 1280w"
+                        sizes="(min-width: 600px) 1300px, 100vw"
+                    {% endunless %}
+
                     alt="{% if include.title %}{{ include.title | markdownify | strip_html }}: {% endif %}{% if include.description %}{{ include.description | markdownify | strip_html }}{% else %}{{ include.caption | markdownify | strip_html }}{% endif %}"
                     class="{% if image contains '.svg' %}inject-svg{% endif %}{% if include.image-height != nil %} height-{{ include.image-height }}{% endif %}"
                 />

--- a/_includes/image
+++ b/_includes/image
@@ -4,19 +4,24 @@
 
 {% comment %} Reset variables {% endcomment %}
 {% assign image = "" %}
-{% assign file-extension = "" %}
+{% assign image-file-extension = "" %}
 {% assign image-alt = "" %}
 
 {% comment %} Get the image and its file extension.
 Let user use `file` or `src` for the image file,
 defaulting to src. {% endcomment %}
 {% if include.file %}
-    {% assign image = include.file | split: "." | first %}
-    {% assign file-extension = include.file | split: "." | last %}
-{% elsif include.src %}
-    {% assign image = include.src | split: "." | first %}
-    {% assign file-extension = include.src | split: "." | last %}
+    {% assign image = include.file %}
+{% else %}
+    {% assign image = include.src %}
 {% endif %}
+
+{% comment %} Get the file extension and the filename without it,
+in a way that allows for full stops in filenames. {% endcomment %}
+{% assign image-name-array = image | split: "." %}
+{% assign image-file-extension = image-name-array | last %}
+{% capture image-extension-with-full-stop %}.{{ image-file-extension }}{% endcapture %}
+{% assign image-without-file-extension = image | replace: image-extension-with-full-stop, "" %}
 
 {% comment %} Capture and clean any alt text. {% endcomment %}
 {% if include.alt %}
@@ -44,19 +49,19 @@ is not available in web output {% endcomment %}
 <noscript>
 
     <img
-        src="{{ images }}/{{ image }}.{{ file-extension }}"
+        src="{{ images }}/{{ image }}"
 
         {% if site.output == "web" %}
-        {% unless file-extension == "svg" %}
-        sizes="auto"
-        srcset="{{ images }}/{{ image }}-320.{{ file-extension }} 320w,
-        {{ images }}/{{ image }}-640.{{ file-extension }} 640w,
-        {{ images }}/{{ image }}-1024.{{ file-extension }} 1024w,
-        {{ images }}/{{ image }}-2048.{{ file-extension }} 2048w"
-        {% endunless %}
+            {% unless image-file-extension == "svg" %}
+            sizes="auto"
+            srcset="{{ images }}/{{ image-without-file-extension }}-320.{{ image-file-extension }} 320w,
+            {{ images }}/{{ image-without-file-extension }}-640.{{ image-file-extension }} 640w,
+            {{ images }}/{{ image-without-file-extension }}-1024.{{ image-file-extension }} 1024w,
+            {{ images }}/{{ image-without-file-extension }}-2048.{{ image-file-extension }} 2048w"
+            {% endunless %}
         {% endif %}
 
-        class="{% if include.class %}{{ include.class }}{% endif %}{% if file-extension == 'svg' %} inject-svg{% endif %}"
+        class="{% if include.class %}{{ include.class }}{% endif %}{% if image-file-extension == 'svg' %} inject-svg{% endif %}"
         {% if include.id %} id="{{ include.id }}"{% endif %}
         {% if image-alt %} alt="{{ image-alt }}"{% endif %} />
 
@@ -66,19 +71,19 @@ is not available in web output {% endcomment %}
 <img
 
     {% if site.output == "web" %}
-        data-src="{{ images }}/{{ image }}.{{ file-extension }}"
-        {% unless file-extension == "svg" %}
+        data-src="{{ images }}/{{ image }}"
+        {% unless image-file-extension == "svg" %}
             sizes="auto"
-            data-srcset="{{ images }}/{{ image }}-320.{{ file-extension }} 320w,
-            {{ images }}/{{ image }}-640.{{ file-extension }} 640w,
-            {{ images }}/{{ image }}-1024.{{ file-extension }} 1024w,
-            {{ images }}/{{ image }}-2048.{{ file-extension }} 2048w"
-            {% endunless %}
+            data-srcset="{{ images }}/{{ image-without-file-extension }}-320.{{ image-file-extension }} 320w,
+            {{ images }}/{{ image-without-file-extension }}-640.{{ image-file-extension }} 640w,
+            {{ images }}/{{ image-without-file-extension }}-1024.{{ image-file-extension }} 1024w,
+            {{ images }}/{{ image-without-file-extension }}-2048.{{ image-file-extension }} 2048w"
+        {% endunless %}
     {% else %}
-        src="{{ images }}/{{ image }}.{{ file-extension }}"
+        src="{{ images }}/{{ image }}"
     {% endif %}
 
-    class="{% if include.class %}{{ include.class }}{% endif %}{% if file-extension == 'svg' %} inject-svg{% endif %}"
+    class="{% if include.class %}{{ include.class }}{% endif %}{% if image-file-extension == 'svg' %} inject-svg{% endif %}"
     {% if include.id %} id="{{ include.id }}"{% endif %}
     {% if image-alt %} alt="{{ image-alt }}"{% endif %} />
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,8 @@ var gulp = require('gulp'),
     yaml = require('js-yaml'),
     debug = require('gulp-debug'),
     del = require('del'),
-    cheerio = require('gulp-cheerio');
+    cheerio = require('gulp-cheerio'),
+    tap = require('gulp-tap');
 
 // A function for loading book metadata as an object
 function loadMetadata() {
@@ -133,24 +134,220 @@ var filetypes = 'jpg,jpeg,gif,png';
 gulp.task('images:svg', function (done) {
     'use strict';
     console.log('Processing SVG images from ' + paths.img.source);
+    var prefix = '';
     gulp.src(paths.img.source + '*.svg')
         .pipe(debug({title: 'Processing SVG '}))
-        .pipe(svgmin({
-            plugins: [
-                {
-                    removeViewBox: false
-                },
-                {
-                    removeDimensions: true
-                },
-                {
-                    removeAttrs: {attrs: 'data.*'}
-                }, {
-                    removeUnknownsAndDefaults: {
-                        defaultAttrs: false
+        .pipe(tap(function (file) {
+            prefix = file.basename.replace('.', '').replace(' ', '');
+        }))
+        .pipe(svgmin(function getOptions() {
+            return {
+                plugins: [
+                    {
+                        // We definitely want a viewBox
+                        removeViewBox: false
+                    },
+                    {
+                        // With a viewBox, we can remove these
+                        removeDimensions: true
+                    },
+                    {
+                        // We can remove data- attributes
+                        removeAttrs: {
+                            attrs: 'data.*'
+                        }
+                    },
+                    {
+                        // Remove unknown elements, but not default values
+                        removeUnknownsAndDefaults: {
+                            defaultAttrs: false
+                        }
+                    },
+                    {
+                        // We want titles for accessibility
+                        removeTitle: false
+                    },
+                    {
+                        // We want descriptions for accessibility
+                        removeDesc: false
+                    },
+                    {
+                        // Default
+                        convertStyleToAttrs: true
+                    },
+                    {
+                        // Default
+                        removeUselessStrokeAndFill: true
+                    },
+                    {
+                        // Default
+                        inlineStyles: true
+                    },
+                    {
+                        // Default
+                        cleanupAttrs: true
+                    },
+                    {
+                        // Default
+                        removeDoctype: true
+                    },
+                    {
+                        // Default
+                        removeXMLProcInst: true
+                    },
+                    {
+                        // Default
+                        removeComments: true
+                    },
+                    {
+                        // Default
+                        removeMetadata: true
+                    },
+                    {
+                        // Default
+                        removeUselessDefs: true
+                    },
+                    {
+                        // Default
+                        removeXMLNS: false
+                    },
+                    {
+                        // Default
+                        removeEditorsNSData: true
+                    },
+                    {
+                        // Default
+                        removeEmptyAttrs: true
+                    },
+                    {
+                        // Default
+                        removeHiddenElems: true
+                    },
+                    {
+                        // Default
+                        removeEmptyText: true
+                    },
+                    {
+                        // Default
+                        removeEmptyContainers: true
+                    },
+                    {
+                        // Default
+                        cleanupEnableBackground: true
+                    },
+                    {
+                        // Default
+                        minifyStyles: true
+                    },
+                    {
+                        // Default
+                        convertColors: true
+                    },
+                    {
+                        // Default
+                        convertPathData: true
+                    },
+                    {
+                        // Default
+                        convertTransform: true
+                    },
+                    {
+                        // Default
+                        removeNonInheritableGroupAttrs: true
+                    },
+                    {
+                        // Default
+                        removeUselessStrokeAndFill: true
+                    },
+                    {
+                        // Default
+                        removeUnusedNS: true
+                    },
+                    {
+                        // Default
+                        prefixIds: false
+                    },
+                    {
+                        // Prefix and minify IDs
+                        cleanupIDs: {
+                            prefix: prefix + '-',
+                            minify: true
+                        }
+                    },
+                    {
+                        // Default
+                        cleanupNumericValues: true
+                    },
+                    {
+                        // Default
+                        cleanupListOfValues: true
+                    },
+                    {
+                        // Default
+                        moveElemsAttrsToGroup: true
+                    },
+                    {
+                        // Default
+                        collapseGroups: true
+                    },
+                    {
+                        // Default
+                        removeRasterImages: false
+                    },
+                    {
+                        // Default
+                        mergePaths: true
+                    },
+                    {
+                        // Default
+                        convertShapeToPath: false
+                    },
+                    {
+                        // Default
+                        convertEllipseToCircle: true
+                    },
+                    {
+                        // Default
+                        sortAttrs: false
+                    },
+                    {
+                        // Default
+                        sortDefsChildren: true
+                    },
+                    {
+                        // Default
+                        removeAttributesBySelector: false
+                    },
+                    {
+                        // Default
+                        removeElementsByAttr: false
+                    },
+                    {
+                        // Default
+                        addClassesToSVGElement: false
+                    },
+                    {
+                        // Default
+                        addAttributesToSVGElement: false
+                    },
+                    {
+                        // Default
+                        removeOffCanvasPaths: false
+                    },
+                    {
+                        // Default
+                        removeStyleElement: false
+                    },
+                    {
+                        // Default
+                        removeScriptElement: false
+                    },
+                    {
+                        // Default
+                        reusePaths: false
                     }
-                }
-            ]
+                ]
+            };
         }).on('error', function (e) {
             console.log(e);
         }))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+/*jslint for, this */
+
 // This gulpfile processes:
 // - images, optimising them for output formats
 // - Javascript, optionally, minifying scripts for performance
@@ -22,16 +24,20 @@ var gulp = require('gulp'),
     del = require('del'),
     cheerio = require('gulp-cheerio');
 
-// Get arrays of possible book and language paths
-if (fileExists.sync('_data/meta.yml')) {
-    var metadata = yaml.load(fs.readFileSync('_data/meta.yml', 'utf8'));
-    var works = metadata.works;
-    function loadMetadata() {
-        'use strict';
-        var paths = [];
-        var filePaths = [];
-        var books = [];
-        var languages = [];
+// A function for loading book metadata as an object
+function loadMetadata() {
+    'use strict';
+
+    var paths = [];
+    var filePaths = [];
+    var books = [];
+    var languages = [];
+
+    if (fileExists.sync('_data/meta.yml')) {
+
+        var metadata = yaml.load(fs.readFileSync('_data/meta.yml', 'utf8'));
+        var works = metadata.works;
+
         var i;
         var j;
         for (i = 0; i < works.length; i += 1) {
@@ -46,14 +52,14 @@ if (fileExists.sync('_data/meta.yml')) {
                 }
             }
         }
-        return {
-            books: books,
-            languages: languages,
-            paths: paths,
-            filePaths: filePaths
-        };
     }
-    loadMetadata();
+
+    return {
+        books: books,
+        languages: languages,
+        paths: paths,
+        filePaths: filePaths
+    };
 }
 
 // Load image settings if they exist

--- a/package-lock.json
+++ b/package-lock.json
@@ -3315,6 +3315,26 @@
         }
       }
     },
+    "gulp-tap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-tap/-/gulp-tap-2.0.0.tgz",
+      "integrity": "sha512-U5/v1bTozx672QHzrvzPe6fPl2io7Wqyrx2y30AG53eMU/idH4BrY/b2yikOkdyhjDqGgPoMUMnpBg9e9LK8Nw==",
+      "dev": true,
+      "requires": {
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
     "gulp-uglify": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-rename": "^1.4.0",
     "gulp-responsive-images": "github:electricbookworks/gulp-responsive-images",
     "gulp-svgmin": "^2.2.0",
+    "gulp-tap": "^2.0.0",
     "gulp-uglify": "^3.0.1",
     "js-yaml": "^3.13.1",
     "yargs": "^9.0.1"

--- a/samples/text/02-02-figures.md
+++ b/samples/text/02-02-figures.md
@@ -13,6 +13,14 @@ To ensure EPUB2 compatibility (which requires valid XHTML 1.1), we don't use the
 * for very simple figures, a paragraph with an `image-with-caption` class that starts with an inline image followed by text; or
 * a div with a `figure` class containing both an image and its caption, created with our `figure` include.
 
+{% include figure
+   image="naples.svg"
+   caption="A map of Naples"
+   link="https://en.wikipedia.org/wiki/Naples"
+   description="A map showing the location of Naples."
+   reference="Figure 1"
+%}
+
 Old versions of the Electric Book template used a `blockquote` instead of a `div` for the figure, since a blockquote can be created with markdown `>` syntax.
 
 To show figures in context, here is an article from *The Comics Grid: Journal of comics scholarship* by [Chris Fradkin](10-02-dynamic-index.html#fradkin-1){:.indexed #fradkin-1}. The abstract, if you're curious:
@@ -36,7 +44,7 @@ A program that employs the pre-cloak stage of superheroes has been active in Rwa
 {% include figure
     image="fradkin-1.jpg"
     image-height="15"
-    reference="Figure 1"
+    reference="Figure 2"
     caption="The Rwandan Orphans Project (near Kigali, Rwanda) uses comic superheroes to empower orphaned children. Capes from old t-shirts, masks from cereal boxes. Published with permission from The Rwandan Orphans Project. Photo © Lisa Meaney, MFT, [Rwandan Orphans Project](http://www.rwandanorphansproject.org), 2016 (Accessed 14 May 2016)."
     description="Children stand in a line wearing super-hero capes and masks made from cereal boxes, making bold super-hero poses."
 %}
@@ -48,7 +56,7 @@ A program that employs the pre-cloak stage of superheroes has been active in Rwa
 {% include figure
     image="fradkin-2.jpg"
     image-height="15"
-    reference="Figure 2"
+    reference="Figure 3"
     caption="On the pediatric ward of the A.C. Camargo Cancer Center, superhero IV covers transform children’s chemo drip into _Superformula_. Design & Branding © J. Walter Thompson, Brazil, 2016 (Accessed 15&nbsp;May 2016)."
     description="A poster that describes _Superformula to fight cancer_ covers, which have superhero logos on the covers of chemo drips. There is a batman logo on the cover in the foreground. Photos and text explain how the cover is attached."
 %}


### PR DESCRIPTION
This improves SVG processing and their inclusion in figures:

- the `figure` include no longer includes redundant `srcset` attributes for SVG images
- logic fixed for file extensions in `figure` and `image` includes
- include a thorough template of options for SVG optimisation options in `gulpfile.js`...
- as well as creating uniquely prefixed IDs in SVG elements during gulp processing
- add an example of an SVG in a figure in Samples
- improvements to readability of code in `image` and `figure` includes.
