### PR TITLE
Fix faulty check for whether we're running Prince

### DIFF
--- a/assets/js/page-reference.js
+++ b/assets/js/page-reference.js
@@ -1,3 +1,4 @@
+/*jslint */
 /*globals window, Prince, pageLanguage, locales */
 
 // Page cross-reference in print
@@ -17,12 +18,7 @@ var postPageNumberPhrase = locales[pageLanguage]['cross-references']['post-page-
 function addPageReferenceFunc() {
     'use strict';
 
-    // exit if we're in phantom; we only want Prince to do this
-    if (typeof window.callPhantom === 'function') {
-        return;
-    }
-
-    if (Prince) {
+    if (typeof Prince === 'object') {
         console.log('Adding page references in Prince.');
         Prince.addScriptFunc("pagereference", function (currentPage, targetPage) {
 


### PR DESCRIPTION
The page-reference script uses `Prince.addScriptFunc()`, which is only available in Prince, and should only run there. So before using it we need to be sure we're in Prince.

While our previous check did work in Prince, it threw an error if we opened the page in, say, a browser where the Prince object does not exist. This made it difficult to debug PDF output in a browser. This means we can also remove the check for Phantom, since the Prince object would not exist there, either.