### PR TITLE
Fix gulp images by checking for no-image-settings properly

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,6 +68,12 @@ function loadMetadata() {
 var imageSettings = [];
 if (fs.existsSync('_data/images.yml')) {
     imageSettings = yaml.load(fs.readFileSync('_data/images.yml', 'utf8'));
+
+    // If the file is empty, imageSettings will be null.
+    // So we check for that and, if null, we create an array.
+    if (!imageSettings) {
+        imageSettings = [];
+    }
 }
 
 // Get the book we're processing


### PR DESCRIPTION
Thanks to @jaycolmvar for reporting a bug introduced in cb481cae614b859ad046f44f642620413cc542fc.

I'd added the ability to specify that particular images should be grayscale in print-PDF output, by adding them to an `_data/images.yml` file. We'd created an tested this code in a file that did have that requirement.

I didn't realise (and should have spotted in testing) that, when our gulp script reads a blank `images.yml` file (i.e. a file with no YAML data, excluding YAML comments) to the `imageSettings` variable, it doesn't result in an empty array but in a null value. That null causes an error when the script tries to loop through `imagesettings`.

I've added a check that makes `imageSettings` an empty array when `images.yml` is blank. This fixes #445.