### PR TITLE
Fix links to translated images in live builds

### DIFF
--- a/_includes/metadata
+++ b/_includes/metadata
@@ -767,9 +767,7 @@ the {{ images }} path should include the language subdirectory.{% endcomment %}
 
     {% comment %}If we are using external-media, we can't know
     if translated images exist, so let's assume that they do.{% endcomment %}
-    {% if site.data.settings.local-media.[build] and site.data.settings.local-media.[build] != "" %}
-        {% assign translated-images-exist = true %}
-    {% elsif site.data.settings.remote-media.[build] and site.data.settings.remote-media.[build] != "" %}
+    {% if site.data.settings.local-media or site.data.settings.remote-media %}
         {% assign translated-images-exist = true %}
     {% endif %}
 


### PR DESCRIPTION
This makes the check for whether we're using external media less strict. Previously, not having a `live` setting for external media, while actually using an external-media repo, led the `metadata` include to believe that the translation should use the parent language's images.

Now, if *any* external media setting is used, the metadata must assume that translated images could exist, and build the full path to them.

This is related to the changes in db222d0808cc8f9612543ce515fcefb820f00261.