### PR TITLE
Translated landing-page OG images

### DIFF
--- a/_docs/setup/translations.md
+++ b/_docs/setup/translations.md
@@ -146,6 +146,13 @@ Here is an example of the translation section of the `meta.yml` file that includ
         title: Title in French
 ```
 
+### The language selector
+
+When a translation includes the same file names as the parent language, translated web and app pages will include a language-selector icon, to allow users to switch between languages. For this to work:
+
+- The parent-language and translated files must have the same filenames.
+- The files must be listed in the parent and translation `files` lists in `_data/meta.yml`.
+
 ### Epub-specific languages
 
 In some situations, you might want the language set in your epub's Dublin Core OPF metadata (`dc:language`) to be different to the language of the translation. For instance, Kindlegen will not convert epubs in languages it does not recognise. In this situation, you might need to set the epub's Dublin Core language tag to, say, English, even though your epub's content files are still in, say, Asanti Twi.

--- a/_docs/setup/translations.md
+++ b/_docs/setup/translations.md
@@ -172,11 +172,17 @@ The translate things like the navigation button and contact form, edit `_data/lo
 
 If your project is translated, it is best to create a landing page for each language. Create a folder in the root directory named after the relevant language code, e.g. `fr`. In that folder, create an `index.md` file. This is the landing page for that language. It's best to copy and then translate the existing `index.md` file in the root directory.
 
+Translated landing pages need their own translated image for open-graph metadata (i.e. social-media cards). The filename of this image is defined globally for all languages in `_data/meta.yml` as the `project` `image`. A file with that name must then be available for each language that has its own translated landing page.
+
+The parent language will use the project image in `assets/images/web`. A French landing page, for instance, will take its project image from `assets/fr/images/web`.
+
+So, for each translation, you need to create a folder in `assets` named for the language code, e.g. `fr`. In there, create an `images` folder, and in there a `web` folder. If you are using the output script (or `gulp`) to process images from `_source` folders into `web` and other image formats, then rather create a `_source` folder in `images`. The automated image-processing script will create the `web` folder and copy your image there from, say, `assets/fr/images/_source` to `assets/fr/images/web`.
+
 > ### Technical details
 >
 > By default, the home page (aka the landing page) is in the project's parent language. If the landing-page URL contains a query string defining a language (e.g `?lang=fr`), by default the `<title>` element and masthead will be translated by Javascript, using phrases set in `locales.yml`. However, the social-sharing (open graph) data will remain in the parent language, e.g. English.
 >
-> It is better to provide fully translated landing pages in each language. To do this, create a folder in the root directory named after the relevant language code. In that folder, create an `index.md` file. This is the landing page for that language. It's best to copy and then translate the existing `index.md` file in the root directory.
+> So for social-sharing purposes especially, it is better to provide fully translated landing pages in each language. To do this, create a folder in the root directory named after the relevant language code. In that folder, create an `index.md` file. This is the landing page for that language. It's best to copy and then translate the existing `index.md` file in the root directory.
 >
 > If that page exists, and a user navigates to a landing page containing a query string defining the language, they will be redirected to the actual, fully translated landing page for that language.
 {:.box}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -217,22 +217,53 @@
 
     <meta property="og:description" content="{{ og-description }}" />
 
-    {% if page.image %}
-        {% if is-homepage == true or is-project-search == true or is-translation-homepage == true %}
-            {% comment %}If a page.image is specified on the home page, we still use the project image{% endcomment %}
-            <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/assets/images/web/{{ project-image }}" />
+    {% comment %} Work out which image to use {% endcomment %}
+    {% capture og-image-relative %}
+
+        {% comment %} If the page has an image defined for it, use that... {% endcomment %}
+        {% if page.image %}
+
+            {% if is-homepage == true or is-project-search == true or is-translation-homepage == true %}
+                assets/images/web/{{ page.image }}
+            {% else %}
+                {{ book-directory }}/{{ site.image-set }}/{{ page.image }}
+            {% endif %}
+
+        {% comment %} If no page image is defined...
+
+        on non-book pages use the project image,
+        and the translated version for translated home pages.
+        We don't check for the existence of the translated image file,
+        to save build time. Onus on user to add it to assets/[language]. {% endcomment %}
+        {% elsif is-homepage == true or is-project-search == true or is-translation-homepage == true %}
+            {% if is-translation-homepage == true %}
+                assets/{{ language }}/images/web/{{ project-image }}
+            {% else %}
+                assets/images/web/{{ project-image }}
+            {% endif %}
+
+        {% comment %} Otherwise, if there is a web image, use that {% endcomment %}
+        {% elsif web-image != "" %}
+            {{ book-directory }}/{{ site.image-set }}/{{ web-image }}
+
+        {% comment %} Otherwise, if no web-image but there is an image defined
+        for the work or product, use that {% endcomment %}
+        {% elsif image != "" %}
+            {{ book-directory }}/{{ site.image-set }}/{{ image }}
+
+        {% comment %} Or fall back to the project image {% endcomment %}
         {% else %}
-            <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/{{ book-directory }}/{{ site.image-set }}/{{ page.image }}" />
+            assets/images/web/{{ project-image }}
         {% endif %}
-    {% elsif is-homepage == true or is-project-search == true or is-translation-homepage == true %}
-        <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/assets/images/web/{{ project-image }}" />
-    {% elsif web-image != "" %}
-        <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/{{ book-directory }}/{{ site.image-set }}/{{ web-image }}" />
-    {% elsif image != "" %}
-        <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/{{ book-directory }}/{{ site.image-set }}/{{ image }}" />
-    {% else %}
-        <meta property="og:image" content="{{ site.canonical-url }}{{ site.baseurl }}/assets/images/web/{{ project-image }}" />
-    {% endif %}
+    {% endcapture %}
+
+    {% comment %} Add absolute-link prefix to the relative path {% endcomment %}
+    {% capture og-image %}
+        {{ site.canonical-url }}{{ site.baseurl }}/{{ og-image-relative | strip_newlines | strip }}
+    {% endcapture %}
+
+    <meta property="og:image" content="{{ og-image | strip_newlines | strip }}" />
+
 
     {% comment %}If we're not in a book subdirectory, load the project stylesheet.
     Otherwise, load the styles for this book. {% endcomment %}


### PR DESCRIPTION
Since #423 we've been able to create fully translated landing pages. Those pages all still used the same project image for open-graph metadata. If that global project image was, say, English, then translated landing pages used that English image. No great.

This fixes that, by using a language-specific image for translated landing pages.

This does mean more work for users, because translated landing pages must have their own project image. To save build time, I've not included a test for whether a translated image exists and fallback to the parent-language's image. If the translated image isn't available, the translated landing page will have no OG image.