### PR TITLE
Add expand- and close-all buttons, allow leaving sections open

### DIFF
--- a/_data/locales.yml
+++ b/_data/locales.yml
@@ -184,6 +184,9 @@ en:
     show-sidebar-tooltip-description: "Tap here to show the annotations sidebar. Select text to highlight and create notes on this page."
     show-annotated-text-tooltip-title: "Highlight annotations"
     show-annotated-text-tooltip-description: "Tap here to show or hide the annotation highlights on this page."
+  accordion:
+    show-all: "Expand all"
+    close-all: "Close all"
 # eo:
 #   iso-name: "Esperanto"
 #   local-name: ""
@@ -260,6 +263,9 @@ fr:
     show-sidebar-tooltip-description: "Cliquer ici pour afficher la barre latérale des annotations. Vous pouvez sélectionner le texte à surligner et à annoter sur cette page."
     show-annotated-text-tooltip-title: "Surligner les annotations"
     show-annotated-text-tooltip-description: "Cliquer ici pour afficher ou masquer les annotations surlignées sur cette page."
+  accordion:
+    show-all: "Montre tout"
+    close-all: "Ferme tout"
 # ff:
 #   iso-name: "Fula, Fulah, Pulaar, Pular"
 #   local-name: ""

--- a/_docs/layout/content-accordion.md
+++ b/_docs/layout/content-accordion.md
@@ -14,9 +14,10 @@ A book chapter can be much too long for reasonable reading on screen. Also, a ch
 
 The content accordion breaks up your page into sections, and collapses them, showing only each section's heading. To open or close a section, a user just clicks on the heading (or the toggle icon beside it).
 
-In addition, images in [figures](../editing/figures.html) will only load when a section is opened. This way, if a user doesn't open a given section, their device won't download it, saving them data.
-
 The content accordion only works in chapter files (i.e. markdown files that do not have a `style` set in their YAML frontmatter, or have it set to something other than `chapter`, such as frontmatter).
+
+Technical note: By default, when you open an accordion section, other open sections stay open. If you would like only one accordion section to open at a time, so that opening a section closes the others, set `autoCloseAccordionSections` to `true` in `assets/js/accordion.js`.
+{:.box}
 
 ## Activating the content accordion
 

--- a/_sass/partials/_web-accordion.scss
+++ b/_sass/partials/_web-accordion.scss
@@ -45,4 +45,33 @@ $web-accordion: true !default;
         display: none;
     }
 
+    .accordion-show-all-button-wrapper {
+        margin-top: $line-height-default;
+        text-align: right;
+    }
+
+    a.accordion-show-all-button {
+        border-radius: $button-border-radius;
+        border: 1px solid $color-mid;
+        color: $color-mid;
+        cursor: pointer;
+        display: inline-block;
+        font-family: $font-text-secondary;
+        font-size: $font-size-default / 2;
+        letter-spacing: 0.05em;
+        line-height: 1;
+        padding: 0.2em 0.3em;
+        text-transform: uppercase;
+
+        // Shift closer to section header
+        // transform: translateY($line-height-default);
+        & + * {
+            clear: both;
+        }
+    }
+
+    // Don't show the button if the page accordion setting is 'none'
+    [data-accordion-page='none'] .accordion-show-all-button-wrapper {
+        display: none;
+    }
 }


### PR DESCRIPTION
This adds small buttons for expanding or closing all accordion sections (if accordions are on in `settings.yml`, which they are not by default).

It also leaves open accordion sections open when a new section is opened, unless you set `autoCloseAccordionSections` to `true` in `assets/js/accordion.js`.