### PR TITLE
Use JS to make tables scroll on mobile

### DIFF
--- a/_sass/partials/_web-tables.scss
+++ b/_sass/partials/_web-tables.scss
@@ -13,6 +13,11 @@ $web-tables: true !default;
 			display: block; // required for overflow-x: auto to work
 			overflow-x: auto;
 		}
+		// Do the same if JS has added a responsive-table class
+		&.scrolling-table {
+			display: block; // required for overflow-x: auto to work
+			overflow-x: auto;
+		}
 	}
 	thead, th, .table-subhead {
 		page-break-after: avoid;

--- a/assets/js/tables.js
+++ b/assets/js/tables.js
@@ -1,3 +1,57 @@
+/*jslint browser */
+/*globals window */
+
+function ebPositionTable(tableWrapper) {
+    'use strict';
+
+    // Get the table
+    var table = tableWrapper.querySelector('table');
+
+    // Reset table positioning
+    table.style.transform = 'none';
+    table.classList.remove('scrolling-table');
+
+    // Get widths for responsiveness calculations
+    var tableWrapperWidth = tableWrapper.getBoundingClientRect().width;
+    var tableWidth = table.getBoundingClientRect().width;
+    var bodyWidth = document.body.getBoundingClientRect().width;
+    var remainingWidth = bodyWidth - tableWidth;
+    var shiftLeftToCenter = (tableWidth - tableWrapperWidth) / 2;
+
+    // Center the table in the screen area
+    // if it's wider than the text area, and
+    // there is space left and right to shift into.
+    if (tableWidth > tableWrapperWidth
+            && remainingWidth > 0) {
+        table.style.transform = 'translateX(-' + shiftLeftToCenter + 'px)';
+    }
+
+    // If the table is wider than the viewport,
+    // add class `responsive-table` so we can scroll with CSS.
+    if (remainingWidth < 0) {
+        table.classList.add('scrolling-table');
+    }
+}
+
+function ebPositionAllTables() {
+    'use strict';
+
+    var tableWrappers = document.querySelectorAll('.table-wrapper');
+
+    var i;
+    for (i = 0; i < tableWrappers.length; i += 1) {
+        ebPositionTable(tableWrappers[i]);
+    }
+}
+
+// Only resize tables when resizing has stopped for 1s
+function ebPositionTablesWhenResizingCompletes() {
+    'use strict';
+    var resizeTimeout;
+    clearInterval(resizeTimeout);
+    resizeTimeout = setTimeout(ebPositionAllTables, 1000);
+}
+
 function ebTables() {
     'use strict';
 
@@ -9,7 +63,7 @@ function ebTables() {
         return;
     }
 
-    var tables = document.querySelectorAll('table');
+    var tables = document.querySelectorAll('.figure table');
 
     tables.forEach(function (table) {
         // make the wrapper and add a class
@@ -21,7 +75,14 @@ function ebTables() {
 
         // move the table inside the wrapper
         tableWrapper.appendChild(table);
+
+        // Position the table
+        ebPositionTable(tableWrapper);
     });
+
+    // Listen for changes to screen size. If sizes changes,
+    // reposition the tables.
+    window.addEventListener('resize', ebPositionTablesWhenResizingCompletes);
 }
 
 ebTables();


### PR DESCRIPTION
This makes horizontal table scrolling smarter, by better detecting when a table needs to scroll horizontally on narrow screens.