### PR TITLE
 Add ability to create a zip package of a project 

### DIFF
--- a/_docs/advanced/packaging-the-project.md
+++ b/_docs/advanced/packaging-the-project.md
@@ -1,0 +1,17 @@
+---
+title: Packaging the project
+categories: advanced
+---
+
+# Packaging the project
+{:.no_toc}
+
+You may need to package your project without its Git history and non-version-controlled (`.gitignore`d) files. For instance, we might include an `electric-book.zip` package, containing the Electric Book template, in a release. This zip file contains the entire template without its Git history, so that it's the blank slate you need to start a new project.
+
+To create a package, from the command line run this:
+
+``` sh
+npm run package
+```
+
+A zip file of your project will be saved to the `_output` folder.

--- a/_docs/setup/quick-start.md
+++ b/_docs/setup/quick-start.md
@@ -4,15 +4,28 @@ categories: setup
 order: 0
 ---
 
-# Quick new-book setup
+# Quick start
 
-This quick setup assumes you already have [Jekyll](http://jekyllrb.com/) and [Prince](http://www.princexml.com/) (if you want PDFs) installed and working on your computer. ([Detailed installation guidance here](setting-up-your-computer).)
+This quick setup assumes you already have [Jekyll](http://jekyllrb.com/), [Node](https://nodejs.org/) and [Prince](http://www.princexml.com/) (for PDF output) installed. If not, see [setup guidance here](setting-up-your-computer).
 
-1. Download the [Jekyll template](https://github.com/electricbookworks/electric-book).
+## Create a new project
+
+1. Download `electric-book.zip` from the [latest release](https://github.com/electricbookworks/electric-book/releases/latest) and extract it.
+2. In the extracted `electric-book` folder, run the `run-` script for your operating system.
+
+   (On OSX and Linux, you need to [give it permission first](http://stackoverflow.com/a/5126052/1781075).)
+
+3. Choose the 'Install or update dependencies' option first. You should only need to do this once.
+4. Run the `run-` script to generate a book.
+
+   The template includes two books:
+   - `book`: a bare-bones book to start working in; and
+   - `samples`: a long book containing loads of examples.
+
+## Edit your first book
+
 2. Open `_data/meta.yml` and replace the sample book information there with your project and book information.
-3. In the `book` folder edit the template files, and add your book's content.
-4. To modify the design, edit the `.scss` files for each output format in `book/styles`.
-5. Run the `run-` script for your operating system. (On OSX and Linux, you need to [give it permission](http://stackoverflow.com/a/5126052/1781075).)
-6. The first time you run it, start with the 'Install or update dependencies' option.
+3. In `book/text`, overwrite the template's markdown files with your own.
+4. To change the design, edit the `.scss` files for each output format: set project-wide styles in `_sass`, and book-specific styles in `book/styles`.
 
 There is much more detail in [the docs](../).

--- a/_docs/setup/setting-up-a-book.md
+++ b/_docs/setup/setting-up-a-book.md
@@ -19,7 +19,11 @@ The process of setting up a new book is covered very briefly in our [quick-start
 
 To create a new book in a new project:
 
-1. An Electric Book repo, or project folder, can hold one book or many, like a series of books that share similar metadata or features (e.g. they're all by the same author). Make a copy of the folder and, if you like, rename it for your project. E.g. `my-sci-fi`.
+1. Download `electric-book.zip` from the [latest release](https://github.com/electricbookworks/electric-book/releases/latest) and extract it. This is now your project folder. You can rename it for your project. (We recommend avoiding spaces in the folder name.) Let's call our example project `my-sci-fi`.
+
+   > Technical note: the latest release may not contain the most recent changes to the template. If you want those, make a copy of the [template repo's master branch](https://github.com/electricbookworks/electric-book), and discard its Git history (i.e. delete the `.git` folder in your copy).
+
+1. An Electric Book repo, or project folder, can hold one book or many, like a series of books that share similar metadata or features (e.g. they're all by the same author).
 1. Inside `my-sci-fi`, open and edit these three files:
     *   `_config.yml`: Edit the values there for your Jekyll setup. The comments will guide you.
     *   `index.md`: Replace our template text with your own. Usually, a link to each book is useful, e.g. `[Space Potatoes](space-potatoes)`.

--- a/_tools/package/package.js
+++ b/_tools/package/package.js
@@ -1,0 +1,132 @@
+/*jslint node */
+/*globals */
+
+var fs = require('fs');
+var path = require('path');
+var createReadStream = require('fs').createReadStream;
+var createInterface = require('readline').createInterface;
+var once = require('events').once;
+var JSZip = require('jszip');
+
+// Rudimentary way to get a files list synchronously
+var filesReady = false;
+
+// Thanks https://github.com/lostandfound/epub-zip
+// for the initial idea for this.
+// Note that we use path.posix (not just path)
+// to always get forward slashes in paths
+// generated on Windows machines.
+function getFiles(root, files, base) {
+    'use strict';
+
+    base = base || '';
+    files = files || [];
+    var directory = path.posix.join(root, base);
+
+    // Files and folders to skip in regex format.
+    // Start with commented lines, .git and any other paths to skip entirely...
+    var pathsToSkip = ['.git', '_output'];
+
+    // ... then add all paths from .gitignore
+    // (https://nodejs.org/api/readline.html#readline_example_read_file_stream_line_by_line)
+    (async function readGitignore() {
+        try {
+            const readlineInterface = createInterface({
+            input: createReadStream('.gitignore'),
+            crlfDelay: Infinity
+        });
+
+        readlineInterface.on('line', (line) => {
+            // Remove trailing wildcards and trailing slashes,
+            line = line.replace(/\*.*/, '');
+            line = line.replace(/\/$/, '');
+            // and skip blank lines and lines that start with #
+            if (line.length > 0 && !line.startsWith('#')) {
+                pathsToSkip.push(line);
+            }
+        });
+
+        await once(readlineInterface, 'close');
+
+        } catch (err) {
+            console.error(err);
+        }
+
+        if (fs.lstatSync(directory).isDirectory()) {
+            if (pathsToSkip.includes(directory)) {
+                // console.log('Skipping ' + directory);
+            } else {
+                fs.readdirSync(directory)
+                    .forEach(function (directoryEntry) {
+                        // console.log('Reading ' + directory + '...' + directoryEntry);
+                        getFiles(root, files, path.posix.join(base, directoryEntry));
+                    });
+            }
+        } else {
+            if (pathsToSkip.includes(base)) {
+                // console.log('Skipping ' + base);
+            } else {
+                files.push(base);
+            }
+        }
+        filesReady = true;
+    })();
+    return files;
+}
+
+module.exports = async function (repoDirectory) {
+    'use strict';
+
+    // Check if the directory exists
+    if (!repoDirectory) {
+        throw new Error('Sorry, could not find ' + repoDirectory + '.');
+    }
+
+    // Get the root directory's name for the zip filename
+    var zipFileName = process.cwd().replace(/^.*[\\\/]/, '');
+
+    // Feedback
+    console.log('Packaging ' + zipFileName + ' as ' + zipFileName + '.zip');
+
+    // Create a new instance of JSZip
+    var zip = new JSZip();
+
+    // Get the files to zip
+    var files = getFiles(repoDirectory);
+
+    var checkingForFilesReady = setInterval(function() {
+        if (filesReady === true) {
+            // Add all the files
+            files.forEach(function (file) {
+                // console.log('Adding ' + file + ' to zip.');
+                zip.file(file, fs.readFileSync(path.posix.join(repoDirectory, file)), {compression: "DEFLATE"});
+            });
+
+            // Create an _output folder. We ignored it earlier to avoid
+            // including its contents, but we do want one in the package.
+            // Include a .gitignore file as in the template.
+            zip.folder('_output')
+                    .file('.gitignore', '# Ignore everything in this directory\n*\n# Except this file\n!.gitignore\n');
+
+            // Write the zip file to disk
+            zip
+                .generateNodeStream({type: 'nodebuffer', streamFiles: true})
+                .pipe(fs.createWriteStream('_output/' + zipFileName + '.zip'))
+                .on('finish', function () {
+                    // JSZip generates a readable stream with a "end" event,
+                    // but is piped here in a writable stream which emits a "finish" event.
+                    console.log(zipFileName + '.zip saved to _output.');
+                });
+            clearInterval(checkingForFilesReady);
+        } else {
+            console.log('Waiting for file list...');
+        }
+    }, 3000);
+};
+
+// Make this runnable from the command line
+// https://www.npmjs.com/package/make-runnable
+// This must be at the end of the file.
+require('make-runnable/custom')({
+    printOutputFrame: false
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "cordova": "cordova"
+    "cordova": "cordova",
+    "package": "node _tools/package/package.js ./"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I want to include an `electric-book.zip` package, containing the Electric Book template, in each release. This zip file contains the entire template without its Git history, so that it's the blank slate you need to start a new project. This PR adds a quick way to create that package, and updates the docs accordingly.
