### PR TITLE
Use EBW fork of make-runnable

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "gulp-uglify": "^3.0.1",
     "js-yaml": "^3.13.1",
     "jszip": "^3.2.2",
-    "make-runnable": "^1.3.6",
+    "make-runnable": "github:electricbookworks/make-runnable",
     "path": "^0.12.7",
     "puppeteer": "^2.1.1",
     "yargs": "^9.0.1"


### PR DESCRIPTION
The original make-runnable uses a very outdated version of yargs which has security vulnerabilities. While those security vulnerabilities don't affect us (only using Node for dev), various security warning messages are distracting.