### PR TITLE
Remove unnecessary links in epub template

### DIFF
--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -140,14 +140,8 @@ works:
             file: "0-3-contents"
           - label: "Chapter One"
             file: "01"
-            id: "1-hello-world"
           - label: "Chapter Two"
             file: "02"
-            id: "2-goodbye-world"
-            children:
-              - label: "Subsection"
-                file: "02"
-                id: "example-id"
       screen-pdf:
         date: "2016-05-07" # YYYY-MM-DD e.g. publication date or last revision
         format: "Digital download" # e.g. Paperback, Digital download, Digital online


### PR DESCRIPTION
Discovered when demoing recently, meta.yml includes some values in the epub toc that are very specific to the dummy text in the template. The slightest change to the dummy text headings will cause invalid epub output, which will frustrate and confuse new users, who can't be expected to know to fix meta.yml. This removes that unnecessary little complexity.