### PR TITLE
Create fallbacks for OG page title

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -198,7 +198,8 @@
     <link rel="icon" type="image/png" href="{{ path-to-root-directory }}assets/images/web/favicon.png">
 
     {% comment %}OpenGraph metadata{% endcomment %}
-    <meta property="og:title" content="{{ page.title }}" />
+    <meta property="og:title"
+          content="{% if page.title and page.title != "" %}{{ page.title }}{% elsif title and title != "" %}{{ title }}{% else %}{{ project-name }}{% endif %}" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="{{ site.canonical-url}}{{ site.baseurl }}{{ page.url }}" />
 

--- a/book/text/0-0-cover.md
+++ b/book/text/0-0-cover.md
@@ -1,5 +1,4 @@
 ---
-title: Cover
 style: cover
 ---
 

--- a/book/text/index.md
+++ b/book/text/index.md
@@ -1,5 +1,4 @@
 ---
-title: Cover
 style: cover
 ---
 

--- a/samples/fr/text/index.md
+++ b/samples/fr/text/index.md
@@ -1,5 +1,4 @@
 ---
-title: Cover
 style: cover
 ---
 

--- a/samples/text/00-00-cover.md
+++ b/samples/text/00-00-cover.md
@@ -1,5 +1,4 @@
 ---
-title: Cover
 style: cover
 ---
 

--- a/samples/text/index.md
+++ b/samples/text/index.md
@@ -1,5 +1,4 @@
 ---
-title: Cover
 style: cover
 ---
 


### PR DESCRIPTION
Create fallbacks for OG page title and remove 'Cover' as a title for cover and book index pages. This title is not useful when cover pages are shared on social media.