### PR TITLE
Exit the output script if Jekyll builds fail

### DIFF
--- a/run-linux.sh
+++ b/run-linux.sh
@@ -77,11 +77,19 @@ Enter a number and hit enter. "
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML
 			# with MathJax enabled if necessary
+
+			# Exit if the Jekyll build fails
+			set -e
+
 			if [ "$printpdfmathjax" = "" ]; then
 				bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,$config"
 			else
 				bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,_configs/_config.mathjax-enabled.yml,$config"
 			fi
+
+			# Return to default error handling
+			set +e
+
 			# If using, MathJax, preprocess the HTML
 			if [ "$printpdfmathjax" = "" ]; then
 				echo "No MathJax required."
@@ -167,11 +175,19 @@ Enter a number and hit enter. "
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML
 			# with MathJax enabled if necessary
+
+			# Exit if the Jekyll build fails
+			set -e
+
 			if [ "$screenpdfmathjax" = "" ]; then
 				bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,$config"
 			else
 				bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,_configs/_config.mathjax-enabled.yml,$config"
 			fi
+
+			# Return to default error handling
+			set +e
+
 			# If using MathJax, process the HTML
 			if [ "$screenpdfmathjax" = "" ]; then
 				echo "No MathJax required."
@@ -302,11 +318,19 @@ You may need to reload the web page once this server is running."
 			# let the user know we're on it!
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML
+
+			# Exit if the Jekyll build fails
+			set -e
+
 			if [ "$epubmathjax" = "y" ]; then
 				bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.mathjax-enabled.yml,$config"
 			else
 				bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,$config"
 			fi
+
+			# Return to default error handling
+			set +e
+
 			# Now to assemble the epub
 			echo "Assembling epub..."
 			# Check if there are fonts to include
@@ -665,12 +689,20 @@ You may need to reload the web page once this server is running."
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML
 			# with MathJax enabled if necessary
+
+			# Exit if the Jekyll build fails
+			set -e
+
 			if [ "$appmathjax" = "" ]
 				then
 				bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,$config"
 			else
 				bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,_configs/_config.mathjax-enabled.yml,$config"
 			fi
+
+			# Return to default error handling
+			set +e
+
 			# Put HTML into _site/app/www by moving everything in _site
 			# excluding the _site/app folder itself, into _site/app/www.
 			# (rsync lets us exclude, where cp does not)
@@ -840,9 +872,17 @@ You may need to reload the web page once this server is running."
 			# let the user know we're on it!
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML.
+
+			# Exit if the Jekyll build fails
+			set -e
+
 			# We turn off the math engine so that we get raw TeX output,
 			# and because Pandoc does not support SVG output anyway.
 			bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,_configs/_config.math-disabled.yml,$config"
+
+			# Return to default error handling
+			set +e
+
 			# Navigate into the book's text folder in _site
 			if [ "$wordsubdirectory" = "" ]; then
 				cd _site/$bookfolder/text
@@ -960,12 +1000,19 @@ You may need to reload the web page once this server is running."
 
 		# Generate HTML with Jekyll
 		echo "Generating HTML with Jekyll..."
+
+		# Exit if the Jekyll build fails
+		set -e
+
 		if [ "$searchIndexToRefresh" = "a" ]
 			then
 			bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,$searchIndexConfig"
 		else
 			bundle exec jekyll build --config="_config.yml,_configs/_config.web.yml,$searchIndexConfig"
 		fi
+
+		# Return to default error handling
+		set +e
 
 		# Generate index
 		echo "Generating index ..."

--- a/run-mac.command
+++ b/run-mac.command
@@ -75,15 +75,24 @@ Enter a number and hit enter. "
 		repeat=""
 		while [ "$repeat" = "" ]
 		do
+
 			# let the user know we're on it!
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML
 			# with MathJax enabled if necessary
+
+			# Exit if the Jekyll build fails
+			set -e
+
 			if [ "$printpdfmathjax" = "" ]; then
 				bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,$config"
 			else
 				bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,_configs/_config.mathjax-enabled.yml,$config"
 			fi
+
+			# Return to default error handling
+			set +e
+
 			# If using, MathJax, preprocess the HTML
 			if [ "$printpdfmathjax" = "" ]; then
 				echo "No MathJax required."
@@ -169,11 +178,19 @@ Enter a number and hit enter. "
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML
 			# with MathJax enabled if necessary
+
+			# Exit if the Jekyll build fails
+			set -e
+
 			if [ "$screenpdfmathjax" = "" ]; then
 				bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,$config"
 			else
 				bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,_configs/_config.mathjax-enabled.yml,$config"
 			fi
+
+			# Return to default error handling
+			set +e
+
 			# If using MathJax, process the HTML
 			if [ "$screenpdfmathjax" = "" ]; then
 				echo "No MathJax required."
@@ -304,11 +321,19 @@ You may need to reload the web page once this server is running."
 			# let the user know we're on it!
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML
+
+			# Exit if the Jekyll build fails
+			set -e
+
 			if [ "$epubmathjax" = "y" ]; then
 				bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.mathjax-enabled.yml,$config"
 			else
 				bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,$config"
 			fi
+
+			# Return to default error handling
+			set +e
+
 			# Now to assemble the epub
 			echo "Assembling epub..."
 			# Check if there are fonts to include
@@ -667,12 +692,20 @@ You may need to reload the web page once this server is running."
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML
 			# with MathJax enabled if necessary
+
+			# Exit if the Jekyll build fails
+			set -e
+
 			if [ "$appmathjax" = "" ]
 				then
 				bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,$config"
 			else
 				bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,_configs/_config.mathjax-enabled.yml,$config"
 			fi
+
+			# Return to default error handling
+			set +e
+
 			# Put HTML into _site/app/www by moving everything in _site
 			# excluding the _site/app folder itself, into _site/app/www.
 			# (rsync lets us exclude, where cp does not)
@@ -840,9 +873,17 @@ You may need to reload the web page once this server is running."
 			# let the user know we're on it!
 			echo "Generating HTML..."
 			# ...and run Jekyll to build new HTML.
+
+			# Exit if the Jekyll build fails
+			set -e
+
 			# We turn off the math engine so that we get raw TeX output,
 			# and because Pandoc does not support SVG output anyway.
 			bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,_configs/_config.math-disabled.yml,$config"
+
+			# Return to default error handling
+			set +e
+
 			# Navigate into the book's text folder in _site
 			if [ "$wordsubdirectory" = "" ]; then
 				cd _site/$bookfolder/text
@@ -960,12 +1001,19 @@ You may need to reload the web page once this server is running."
 
 		# Generate HTML with Jekyll
 		echo "Generating HTML with Jekyll..."
+
+		# Exit if the Jekyll build fails
+		set -e
+
 		if [ "$searchIndexToRefresh" = "a" ]
 			then
 			bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,$searchIndexConfig"
 		else
 			bundle exec jekyll build --config="_config.yml,_configs/_config.web.yml,$searchIndexConfig"
 		fi
+
+		# Return to default error handling
+		set +e
 
 		# Generate index
 		echo "Generating index ..."

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -103,12 +103,12 @@ set /p process=Enter a number and hit return.
             :: ...and run Jekyll to build new HTML
             :: with MathJax enabled if necessary
             if not "%print-pdf-mathjax%"=="y" goto printpdfnomathjax
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,_configs/_config.mathjax-enabled.yml,%config%"
+            call bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,_configs/_config.mathjax-enabled.yml,%config%" || exit /b
             goto printpdfjekylldone
 
             :: Build Jekyll without MathJax
             :printpdfnomathjax
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,%config%"
+            call bundle exec jekyll build --config="_config.yml,_configs/_config.print-pdf.yml,%config%" || exit /b
 
             :printpdfjekylldone
 
@@ -215,10 +215,10 @@ set /p process=Enter a number and hit return.
             :: ...and run Jekyll to build new HTML
             :: with MathJax enabled if necessary
             if not "%screen-pdf-mathjax%"=="y" goto screenpdfnomathjax
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,_configs/_config.mathjax-enabled.yml,%config%"
+            call bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,_configs/_config.mathjax-enabled.yml,%config%" || exit /b
             goto screenpdfjekylldone
             :screenpdfnomathjax
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,%config%"
+            call bundle exec jekyll build --config="_config.yml,_configs/_config.screen-pdf.yml,%config%" || exit /b
             :screenpdfjekylldone
 
             :: Skip the next step if we're not using MathJax.
@@ -416,8 +416,8 @@ set /p process=Enter a number and hit return.
 
         :: ...and run Jekyll to build new HTML
         :epubJekyllBuild
-            if "%epubIncludeMathJax%"=="y" call bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.mathjax-enabled.yml,%config%"
-            if not "%epubIncludeMathJax%"=="y" call bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,%config%"
+            if "%epubIncludeMathJax%"=="y" call bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,_configs/_config.mathjax-enabled.yml,%config%" || exit /b
+            if not "%epubIncludeMathJax%"=="y" call bundle exec jekyll build --config="_config.yml,_configs/_config.epub.yml,%config%" || exit /b
             echo HTML generated.
             :epubJekyllDone
 
@@ -755,10 +755,10 @@ set /p process=Enter a number and hit return.
         :appbuildrepeat
             echo Building your HTML...
             if not "%appmathjax%"=="y" goto appbuildnomathjax
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,_configs/_config.mathjax-enabled.yml,%config%"
+            call bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,_configs/_config.mathjax-enabled.yml,%config%" || exit /b
             goto apphtmlbuilt
             :appbuildnomathjax
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,%config%"
+            call bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,%config%" || exit /b
             :apphtmlbuilt
 
             :: Put HTML into app/www by moving everything (/E) in _site
@@ -868,7 +868,7 @@ set /p process=Enter a number and hit return.
             :: ...and run Jekyll to build new HTML.
             :: We turn off the math engine so that we get raw TeX output,
             :: and because Pandoc does not support SVG output anyway.
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.%fromformat%.yml,_configs/_config.math-disabled.yml,%config%"
+            call bundle exec jekyll build --config="_config.yml,_configs/_config.%fromformat%.yml,_configs/_config.math-disabled.yml,%config%" || exit /b
 
             :: Navigate to the HTML we just generated
             if "%subdirectory%"=="" cd _site\%bookfolder%\text
@@ -1006,12 +1006,12 @@ set /p process=Enter a number and hit return.
 
         :buildForWebSearchIndex
 
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.web.yml,%searchIndexConfig%"
+            call bundle exec jekyll build --config="_config.yml,_configs/_config.web.yml,%searchIndexConfig%" || exit /b
             goto refreshSearchIndexRendering
 
         :buildForAppSearchIndex
 
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,%searchIndexConfig%"
+            call bundle exec jekyll build --config="_config.yml,_configs/_config.app.yml,%searchIndexConfig%" || exit /b
             goto refreshSearchIndexRendering
 
         :: Run script from scripts directory


### PR DESCRIPTION
Till now, if there is an error in a Jekyll build (e.g. if Sass or YAML are invalid), the output script will just skip that error and generate a book/site from the HTML in the _site folder from a previous build. If you don't spot that the Jekyll build failed, you can end up looking at the wrong output with awkward consequences.

This change forces the output script to exit completely if a Jekyll build fails. Note that it does not exit if a Jekyll *serve* fails, since those errors are easier to spot at the command line, and can be fixed live.