### PR TITLE
Don't expand books in home nav by default

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -108,6 +108,15 @@ web:
   # -----------------
   images:
     lazyload: true
+  # --------------
+  # Navigation
+  # --------------
+  # On your landing page, should books in the nav expand
+  # to include chapters? Expanding many chapters can
+  # make your pages much bigger and slower. true/false
+  nav:
+    home:
+      expand-books: false
 
 # ----------------------------------------------------------
 # Epub settings
@@ -175,6 +184,15 @@ app:
   # in an expansion file, edit these settings.
   google-play-expansion-file-enabled: false
   google-play-public-api-key: ""
+  # --------------
+  # Navigation
+  # --------------
+  # On your landing page, should books in the nav expand
+  # to include chapters? Expanding many chapters can
+  # make your pages much bigger and slower. true/false
+  nav:
+    home:
+      expand-books: false
 
 # ----------------------------------------------------------
 # External media settings

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -63,20 +63,32 @@
 
                     <ol class="nav-book-list">
                     {% for work in site.data.meta.works | sort: "order" %}
-                    {% assign home-nav-work-directory = work.directory %}
+                        {% assign home-nav-work-directory = work.directory %}
 
-                    {% comment %}Use the relevant output's nav, all fallback to web nav.{% endcomment %}
-                    {% if work.products[site.output].nav and work.products[site.output].nav != "" %}
-                        {% assign home-nav-work-tree = work.products[site.output].nav %}
-                    {% else %}
-                        {% assign home-nav-work-tree = work.products.web.nav %}
-                    {% endif %}
+                        {% comment %}Use the relevant output's nav, all fallback to web nav.{% endcomment %}
+                        {% if work.products[site.output].nav and work.products[site.output].nav != "" %}
+                            {% assign home-nav-work-tree = work.products[site.output].nav %}
+                        {% else %}
+                            {% assign home-nav-work-tree = work.products.web.nav %}
+                        {% endif %}
 
-                        <li class="has-children">
+                        {% comment %} Get book start page, fallback to web {% endcomment %}
+                        {% if work.products[site.output].start-page and work.products[site.output].start-page != "" %}
+                            {% assign this-book-start-page = work.products[site.output].start-page %}
+                        {% else %}
+                            {% assign this-book-start-page = work.products.web.start-page %}
+                        {% endif %}
+
+                        <li
+                            {% if site.data.settings[site.output].nav.home.expand-books == true %}class="has-children"{% endif %}>
+
                             <a href="{{ path-to-root-directory }}{{ work.directory }}/text/{{ work.products[site.output].start-page }}.html">
                                 {{ work.title }}
                             </a>
-                            {% include nav-list nav-tree=home-nav-work-tree directory=home-nav-work-directory %}
+
+                            {% if site.data.settings[site.output].nav.home.expand-books == true %}
+                                {% include nav-list nav-tree=home-nav-work-tree directory=home-nav-work-directory %}
+                            {% endif %}
                         </li>
                     {% endfor %}
                     </ol>


### PR DESCRIPTION
In projects with more than one book, including each book's chapters, as expandable dropdowns, in the home-page nav (and other non-book pages like search and contact pages) can make those pages unnecessarily large. In one project with about 25 books, the home page was over 500KB!

This change lets you choose whether to expand the nav to include book chapters in `settings.yml`. By default, we do not expand books in the home-page nav.