### PR TITLE
Better <title> logic

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,16 +1,49 @@
 {% include metadata %}
 
+{% comment %} Determine the HTML <title>. Default is project title in meta.yml.
+If we're in a book, the metadata include sets the book title as 'title'.
+If the page has a title in its YAML frontmatter, append it after a colon,
+unless (a) this is the home page, in which case only use the page title, or
+(b) it's the same as the project/book title, in which case don't duplicate.
+
+If we're generating a PDF, the first HTML doc in the file list will set
+the entire PDF document title. So if we are outputting more than one file,
+we want the doc name to be the book title, not only the first doc's title.
+{% endcomment %}
+{% capture html-title %}{{ project-name }}{% endcapture %}
+{% if title and title != "" %}
+    {% capture html-title %}{{ title }}{% endcapture %}
+{% endif %}
+{% if page.title and page.title != "" %}
+    {% if html-title != page.title %}
+        {% if is-homepage %}
+            {% capture html-title %}{{ page.title }}{% endcapture %}
+        {% else %}
+            {% capture html-title %}{{ html-title }}: {{ page.title }}{% endcapture %}
+        {% endif %}
+    {% endif %}
+{% endif %}
+
+{% if site.output == "print-pdf" %}
+    {% if print-pdf-file-list.size > 1 %}
+        {% capture html-title %}{{ title }}{% endcapture %}
+    {% endif %}
+{% endif %}
+
+{% if site.output == "screen-pdf" %}
+    {% if screen-pdf-file-list.size > 1 %}
+        {% capture html-title %}{{ title }}{% endcapture %}
+    {% endif %}
+{% endif %}
+
+
 {% if site.output == "print-pdf" %}
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="{{ language }}" xml:lang="{{ language }}"{% if site.data.locales[language].direction %} dir="{{ site.data.locales[language].direction }}"{% endif %}>
 <head>
-    <title>
-    {% if title %}
-    {{ title }}{% if page.title %}: {{ page.title }}{% endif %}
-    {% else %}
-    {{ project-name }}{% if page.title %}: {{ page.title }}{% endif %}
-    {% endif %}
-    </title>
+
+    <title>{{ html-title }}</title>
+
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -36,13 +69,9 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="{{ language }}" xml:lang="{{ language }}"{% if site.data.locales[language].direction %} dir="{{ site.data.locales[language].direction }}"{% endif %}>
 <head>
-    <title>
-    {% if title %}
-    {{ title }}{% if page.title %}: {{ page.title }}{% endif %}
-    {% else %}
-    {{ project-name }}{% if page.title %}: {{ page.title }}{% endif %}
-    {% endif %}
-    </title>
+
+    <title>{{ html-title }}</title>
+
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
@@ -68,13 +97,8 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="{{ language }}"{% if site.data.locales[language].direction %} dir="{{ site.data.locales[language].direction }}"{% endif %}>
 <head>
-    <title>
-    {% if title %}
-    {{ title }}{% if page.title %}: {{ page.title }}{% endif %}
-    {% else %}
-    {{ project-name }}{% if page.title %}: {{ page.title }}{% endif %}
-    {% endif %}
-    </title>
+
+    <title>{{ html-title }}</title>
 
     {% comment %}This full meta tag is necessary for Kindle's character encoding to work.{% endcomment %}
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
@@ -123,13 +147,7 @@
 <html lang="{{ language }}"{% if site.data.locales[language].direction %} dir="{{ site.data.locales[language].direction }}"{% endif %}>
     <head>
 
-    <title>
-    {% if title %}
-    {{ title }}{% if page.title %}: {{ page.title }}{% endif %}
-    {% else %}
-    {{ project-name }}{% if page.title %}: {{ page.title }}{% endif %}
-    {% endif %}
-    </title>
+    <title>{{ html-title }}</title>
 
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="format-detection" content="telephone=no">
@@ -180,13 +198,9 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="{{ language }}" xml:lang="{{ language }}"{% if site.data.locales[language].direction %} dir="{{ site.data.locales[language].direction }}"{% endif %}>
 <head>
-    <title>
-    {% if title %}
-    {{ title }}{% if page.title %}: {{ page.title }}{% endif %}
-    {% else %}
-    {{ project-name }}{% if page.title %}: {{ page.title }}{% endif %}
-    {% endif %}
-    </title>
+
+    <title>{{ html-title }}</title>
+
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/_includes/metadata
+++ b/_includes/metadata
@@ -1,4 +1,4 @@
- {% comment %}
+{% comment %}
 Loop through meta.yml and return this book's metadata
 as a set of Liquid variables that we can use on pages
 as output tags, e.g. {{ title }} for the current

--- a/_sass/partials/_print-pdf-view.scss
+++ b/_sass/partials/_print-pdf-view.scss
@@ -9,8 +9,9 @@ $print-pdf-view: true !default;
     	prince-pdf-paper-tray: auto; // auto | pick-tray-by-pdf-size
     	prince-pdf-print-scaling: auto; // auto | none
     	prince-pdf-script: ""; // Insert Javascript between the quotes if needed: http://www.princexml.com/doc/properties/prince-pdf-script/
-        prince-pdf-color-options: use-#{$black-ink}-black; //  takes two values, use-true-black (/DeviceGray black in the PDF) and use-rich-black (/DeviceRGB black in PDF)
+        prince-pdf-color-options: use-#{$black-ink}-black; // takes two values, use-true-black (/DeviceGray black in the PDF) and use-rich-black (/DeviceRGB black in PDF)
         prince-pdf-profile: $pdf-profile;
+        prince-pdf-display-doc-title: true; // only supported from Prince 13
         // Note colour profiles are stored in the non-generated Jekyll root, not in _site
         prince-pdf-output-intent: url("../../../_tools/profiles/#{$color-profile}");
         @if $output-format == "print-pdf" {


### PR DESCRIPTION
This improves the logic for setting the <title> element depending on pages and formats.

The default `<title>` is the project name set in `meta.yml`.

Then, if we're in a book, the `metadata` include sets the book title as the `title` variable.

If the page being generated has a `title:` set in its YAML frontmatter, we add that appended after a colon, unless:

- we're generating the home page, in which case only use the page's `title:`, or
- the page's `title:` is the same as the project/book title, in which case don't duplicate it.

PDFs have extra logic.

If we're generating a PDF, the first HTML document in the file list will set the entire PDF-document title (the name of the PDF, which can be set in a PDF reader to display in the document tab).

But, if we are outputting a PDF comprising more than one HTML file, we want the PDF-document title to be the *book title*, not only the first document's title. E.g. when generating the *Samples* book, the first file by default is the half-title page. We don't want the PDF-document title to be 'Samples: Half-title page'. We just want it to be 'Samples'.

That said, if we're generating a PDF comprising only one file, e.g. `01` as 'Chapter 1', then we *do* want the PDF-document title to be, say, 'Samples: Chapter 1', because we might deliberately be generating a single chapter, and this PDF-document title makes the most sense in that case.

So, this new logic checks whether we have more than one file in our PDF file list. If we do, it uses only the book title. Otherwise, it uses the book title, colon, page title, as usual.