### PR TITLE
Temporarily disable kramdown v2 dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,5 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # For what ~> means, see https://robots.thoughtbot.com/rubys-pessimistic-operator
 
 # Update Kramdown parser, see https://jekyllrb.com/news/2020/08/05/jekyll-3-9-0-released/
-gem "kramdown-parser-gfm"
+# Uncomment the line below if you use Jekyll v3.9 or later
+# gem "kramdown-parser-gfm"


### PR DESCRIPTION
This will be resolved in #509. For now, if we try to use kramdown v2 dependencies with Jekyll 3.8 or lower, bundler will error because kramdown-parser-gfm depends on kramdown v2. This error breaks builds on Netlify. GH Pages will build either way because it ignore the Gemfile and currently uses Jekyll 3.9 anyway.