### PR TITLE
Optimise styles structure

### DIFF
--- a/_docs/layout/design.md
+++ b/_docs/layout/design.md
@@ -11,7 +11,7 @@ order: 1
 * Page contents
 {:toc}
 
-The design of your books is created in CSS stylesheets. These are written in a syntaxes called CSS or Sass. Each output format has a dedicated stylesheet:
+The design of your books is created in CSS stylesheets. These are written in Sass or CSS syntax. Each output format has a dedicated stylesheet:
 
 - `print-pdf.scss`
 - `screen-pdf.scss`
@@ -19,18 +19,25 @@ The design of your books is created in CSS stylesheets. These are written in a s
 - `epub.scss`
 - `app.scss`
 
+By default, the screen PDF inherits its styles from the print PDF design, except for trim and crop marks (none on screen PDF) and the colour profile (RBG in screen PDF, CMYK in print PDF). Also by default, the app inherits the web styles.
+
 Some aspects of design are easy for non-technical users to change. Some advanced design features need to be coded by an experienced CSS developer.
 
-Each project comes with a library of predefined styles. Then each book's styles can build on or override the predefined project styles.
+Each project comes with a library of predefined styles in the `_sass` folder. That's where you set or change styles taht affect all books in a project.
 
-By default, you cannot edit the project's predefined styles in the Electric Book Manager.
+Then, each book's styles can build on or override those project-wide styles in the `.scss` files in its own `styles` folder (e.g. `book/styles/web.scss`).
 
-> Technical note: files that non-technical users need not see in the EBM, such as advanced technical files, are hidden by adding them to the `ignore` list in `/_prose.yml`. These are hidden in the EBM with `display: none`; so they can be revealed by turning off `display: none` with a browser's Inspect tools.
+> **Electric Book Manager users**
+>
+> By default, you cannot edit the project's predefined styles in the Electric Book Manager.
+>
+> Files that non-technical users need not see in the EBM, such as advanced technical files, are hidden by adding them to the `ignore` list in `/_prose.yml`.
+{:.box}
 
 To edit a book's styles:
 
-1. From the editor, click on the `.scss` file for the output format that you want to edit. For example, for print-PDF styles for the `book` directory, edit `book/styles/print-pdf.scss`.
-2. Many of a book's design features are set as variables, which start with `$` signs. E.g. `$page-width`. Change the values you see there for each variable as needed. For instance, you can easily edit variables that set page size, colours, running heads, and so on.
-3. If you know how to write CSS or Sass, add your own custom CSS at the bottom of the `.scss` file.
+1. Open the `.scss` file for the output format that you want to edit. For example, to change the print-PDF styles only for the book in the `book` directory, edit `book/styles/print-pdf.scss`.
+2. Many of a book's design features are set as variables, which start with `$` signs. E.g. `$page-width`. Change the values you see there for each variable as needed. For instance, you can change the values for page size, colours, running heads, and so on.
+3. If you know how to write CSS or Sass, add your own custom styles at the bottom of the `.scss` file.
 
 Output the relevant format to see how your changes look. If the output fails, you may have used invalid CSS or Sass syntax. For more on editing Sass, see [sass-lang.com/guide](http://sass-lang.com/guide).

--- a/_docs/layout/design.md
+++ b/_docs/layout/design.md
@@ -23,7 +23,7 @@ By default, the screen PDF inherits its styles from the print PDF design, except
 
 Some aspects of design are easy for non-technical users to change. Some advanced design features need to be coded by an experienced CSS developer.
 
-Each project comes with a library of predefined styles in the `_sass` folder. That's where you set or change styles taht affect all books in a project.
+Each project comes with a library of predefined styles in the `_sass` folder. That's where you set or change styles that affect all books in a project.
 
 Then, each book's styles can build on or override those project-wide styles in the `.scss` files in its own `styles` folder (e.g. `book/styles/web.scss`).
 

--- a/_sass/app.scss
+++ b/_sass/app.scss
@@ -1,6 +1,6 @@
 // What is this?
 // -------------
-// This is typography for the Electric Book Elements theme (see http://electricbook.works).
+// This is typography for the Electric Book template (see http://ebw.co/template).
 // It is built with Sass. (See http://sass-lang.com, and http://jekyllrb.com/docs/assets for how Jekyll implements Sass.)
 // It sets defaults that can be overridden in each book's own stylesheets, where the variables here are duplicated.
 // 
@@ -9,9 +9,6 @@
 // Edit the default variables below.
 // Comment/uncomment or add font imports below.
 // Add your own custom CSS at the bottom.
-
-// First, let's set character encoding. Don't change this.
-@charset "utf-8";
 
 // -------------
 // Set variables
@@ -23,304 +20,37 @@ $output-format: "app" !default;
 // Edition suffix: identifies this edition in certain classes (e.g. in _epub-fitting.scss).
 $edition-suffix: null !default;
 
-// Max width of main body area
-$max-width-default: 40em !default;
+// The path to project-wide assets like fonts and colour profiles.
+// By default this is the assets folder in the project root directory.
+// Override this for translation styles, which need an extra leading ../
+$path-to-root-directory: "../.." !default;
 
-// We name font variables for two categories:
-// - 'text' fonts are used for body text and some page features;
-// - 'display' fonts are used for headings and similar short-string features.
-// For each category, we set a main font and a secondary font, allowing up to four fonts.
-// Finally, we set a fifth, monospace font for elements like computer code.
-$font-text-main: "Apple Garamond", "Baskerville", "Cambria", "Droid Serif", "Times","Source Serif Pro", serif !default;
-$font-text-secondary: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !default;
-$font-display-main: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !default;
-$font-display-secondary: "Apple Garamond", "Baskerville", "Cambria", "Droid Serif", "Times","Source Serif Pro", serif !default;
-$font-code: "SF Mono", "Monaco", "Inconsolata", "Fira Mono", "Droid Sans Mono", "Source Code Pro", monospace !default;
-
-// Set font size and line-height in ems or px.
-// These values, especially $line-height-default, are used to compute vertical rhythm
-// for many features in this theme. So do not use a unitless value for line-height,
-// and don't use percentages, which will break layouts computed by multiplying this value.
-$font-size-default: 1.2em !default;
-$line-height-default: 1.6em !default;
-$font-size-smaller: 0.7 !default; // How much smaller than font-size-default for features like sidenotes and footers?
-$font-size-bigger: 2 !default; // How many times bigger than font-size-default for features like headings and pullquotes?
-
-// Do you want space between paragraphs, rather than a text-indent? true or false
-$spaced-paras: true !default;
-// If not spacing paras, how large is the first-line indent on paragraphs?
-$paragraph-indent: 1em !default;
-
-// Rounded corners
-$button-border-radius: 0.1rem !default; // Roundness of button corners
-$box-border-radius: 0.1rem !default; // Roundness of box corners
-
-// Shadows
-$box-shadow: 1px 2px 7px grey !default;
-
-// Rules, lines
-$rule-thickness: 1px !default;
-
-// Colours
-$color-text-main: #262626 !default;
-$color-text-secondary: #262626 !default;
-$color-background: #f9f9f9 !default;
-$color-light: #e0e0e0 !default;
-$color-mid: #9c9c9c !default;
-$color-accent: #009E7F !default;
-$color-links: #5f738c !default;
-$color-buttons: $color-accent !default;
-$color-buttons-hover: darken( $color-buttons, 20% ) !default;
-$color-highlight: #ffd54d !default;
-$color-notification-low-text: $color-light !default;
-$color-notification-medium-text: $color-light !default;
-$color-notification-high-text: $color-light !default;
-$color-notification-low-background: #009E7F !default;
-$color-notification-medium-background: #ffe388 !default;
-$color-notification-high-background: #ff7c4d !default;
-
-// Some features rearrange at certain screen sizes.
-// What are your screen-width break points?
-$break-width-small: 600px !default;
-$break-width-medium: 900px !default;
-$break-width-large: 1200px !default;
-$break-height-small: 600px !default;
-$break-height-medium: 900px !default;
-$break-height-large: 1200px !default;
-
-// Set the default start-depth of pages.
-// This is the distance from the top of the page to the first element on the first page.
-$start-depth: $line-height-default * 2 !default;
-
-// Hyphenation
-// Variables here apply to p, ul, ol, dl.
-// Note: Most browsers and ereaders do not support hyphenation rules.
-$hyphenation: manual !default; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)
-$hyphenation-dictionary: "" !default; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic".
-$hyphenation-custom: add !default; // add or replace. Whether your dictionary adds to or replaces the built-in Prince dictionaries
-$hyphenate-after: 3 !default; // Minimum letters on new line after hyphen
-$hyphenate-before: 3 !default; // Minimum letters at end of line before hyphen
-$hyphenate-lines: 1 !default; // Maximum number of consecutive lines ending with hyphens
-
-// Text dividers
-// For breaks created with *** in markdown.
-// If using an image, set $text-divider-image in CSS URL syntax, e.g.
-// $text-divider-image: url('../images/epub/text-divider.jpg');
-$text-divider-text: "" !default; // Empty leaves space. \2022 is a bullet
-$text-divider-image: "" !default;
-$text-divider-image-width: $line-height-default * 2 !default;
-
-// Footer
-$footer-text-color: $color-text-main !default;
-$footer-background-color: $color-accent !default;
-$footer-border-color: $color-accent !default;
-
-// Website masthead
-$masthead-text-color: $color-light !default;
-$masthead-background-color: $color-accent !default;
-$masthead-border-color: $color-light !default;
-$masthead-breadcrumb-divider: "\2044" !default; // 2044 is a fraction slash
-
-// Website sidebar/navigation
-$nav-bar-text-size: 0.8em !default;
-$nav-bar-item-collapse: false !default; // Does the nav list fully expand, or collapse until mouseover?
-$nav-bar-close: "\00D7" !default; // &times; ×
-$nav-bar-children-prompt: "+" !default;
-$nav-bar-children-prompt-hide: "\2212" !default; // \2212 is an actual minus sign
-$nav-bar-scrollbar: true !default;
-$nav-bar-width: 15em !default;
-$nav-bar-fixed: true !default; // fixed is not fully supported on many mobile browsers
-$nav-bar-back-button-hide: true !default;
-$nav-bar-title-color: $color-text-secondary !default;
-$nav-bar-label-color: $color-light !default;
-$nav-bar-label-background-color: $masthead-background-color !default;
-$nav-bar-label-border-color: transparent !default;
-$nav-bar-border-color: $color-light !default;
-$nav-bar-background-color: $color-background !default;
-$nav-bar-search-background-color: $color-background !default;
-$nav-bar-parent-background-color: $color-background !default;
-$nav-bar-parent-text-color: $color-text-main !default;
-$nav-bar-parent-hover-color: $color-accent !default;
-$nav-bar-parent-text-hover-color: $color-background !default;
-$nav-bar-children-prompt-color: $color-mid !default;
-$nav-bar-child-background-color: $color-light !default;
-$nav-bar-child-text-color: $color-text-main !default;
-$nav-bar-child-hover-color: $color-accent !default;
-$nav-bar-child-text-hover-color: $color-background !default;
-
-// Language selector
-$language-select-icon-color: $color-accent !default;
-$language-select-text-color: $color-text-secondary !default;
-$language-select-links-color: $color-links !default;
-$language-select-background-color: $color-background !default;
-
-// Annotator
-$annotator-sidebar-width: 16em !default;
-$annotator-icon-line-color-active: $color-light !default;
-$annotator-icon-line-color-inactive: $color-mid !default;
-$annotator-icon-background-color-active: $color-accent !default;
-$annotator-icon-background-color-inactive: $color-background !default;
-$annotator-icon-thickness: 1.5px !default;
-
-// Bookmarks
-$bookmark-border-color: $color-light !default;
-$bookmark-text-color: $color-text-main !default;
-$bookmark-text-color-secondary: $color-mid !default;
-$bookmark-background-color: $color-background !default;
-$bookmark-icon-color-inactive: $color-background !default;
-$bookmark-icon-color-active: $color-accent !default;
-$bookmark-icon-outline-color-inactive: $color-accent !default;
-$bookmark-icon-outline-color-active: $color-accent !default;
-$bookmark-icon-text-size: 1em !default;
-
-// ---------------------------------
-// Set to false to turn partials off
-// ---------------------------------
-
-// Reset browser CSS as best we can
-$web-css-reset: true !default;
-
-// Structural HTML components
-$web-wrappers: true !default;
-
-// Conventional helper classes
-$web-helpers: true !default;
-
-// Default typography
-$web-base-typography: true !default;
-
-// Navigation
-$web-masthead: true !default;
-$web-search: true !default;
-$web-nav-bar: true !default;
-$web-footer: true !default;
-$web-accordion: true !default;
-
-// Book parts
-$web-cover: true !default;
-$web-previous-publications-page: true !default;
-$web-title-pages: true !default;
-$web-copyright-page: true !default;
-$web-dedications: true !default;
-$web-epigraphs: true !default;
-$web-toc: true !default;
-
-// Book-feature classes
-$web-bibliographies: true !default;
-$web-boxes: true !default;
-$web-buttons: true !default;
-$web-code: true !default;
-$web-dialogue: true !default;
-$web-figures: true !default;
-$web-highlighter: true !default;
-$web-glossaries: true !default;
-$web-index: true !default;
-$web-maths: true !default;
-$web-notes: true !default;
-$web-openers: true !default;
-$web-pullquotes: true !default;
-$web-sources: true !default;
-$web-tables: true !default;
-$web-letters: true !default;
-$web-verse: true !default;
-$web-video: true !default;
-$web-pagination: true !default;
-$web-questions: true !default;
-$web-select-questions: true !default;
-
-// Docs
-$web-docs: true !default;
-
-// Type-control classes
-$web-smallcaps: true !default;
-$web-fitting: true !default;  // E.g. tracking and shrinking
-
-// Controls
-$web-controls: true !default;
-$web-language-select: true !default;
-$web-annotator: true !default;
-
-// Logic (if this then that)
-$web-reset-sequences: true !default; // This should stay last in the @import list
 
 // ----------------------------------------------------
 // Import font files (@font-face) for fonts you specify
 // ----------------------------------------------------
 
-// Import fonts from book-specific CSS.
+// For apps, load local fonts, and do not use
+// the web font loader that is used for the web.
+// Use #{$path-to-root-directory} to allow overriding per translation. E.g.:
+// `src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Regular.ttf);`
 
-// ---------------------
-// Theme modules
-// ---------------------
+// -------------
+// Master theme
+// -------------
 
-// Reset browser CSS as best we can
-@import "partials/web-css-reset";
+// By default, we assume apps look exactly like web versions.
+// So import and inherit master web styles.
+@import 'web';
 
-// Load general-purpose mixins
-@import "partials/web-mixins--buttons";
-@import "partials/web-mixins--sidenotes";
-@import "partials/web-mixins--dialogs";
+// -------------
+// Custom styles
+// -------------
 
-// Structural HTML components
-@import "partials/web-wrappers";
+// Add any custom app styles here.
 
-// Conventional helper classes
-@import "partials/web-helpers";
+.nav-back-button {
 
-// Default typography
-@import "partials/web-base-typography";
-
-// Navigation
-@import "partials/web-masthead";
-@import "partials/web-nav-bar";
-@import "partials/web-search";
-@import "partials/web-footer";
-@import "partials/web-accordion";
-
-// Book parts
-@import "partials/web-cover";
-@import "partials/web-previous-publications-page";
-@import "partials/web-title-pages";
-@import "partials/web-copyright-page";
-@import "partials/web-dedications";
-@import "partials/web-epigraphs";
-@import "partials/web-toc";
-
-// Book-feature classes
-@import "partials/web-bibliographies";
-@import "partials/web-boxes";
-@import "partials/web-buttons";
-@import "partials/web-code";
-@import "partials/web-dialogue";
-@import "partials/web-figures";
-@import "partials/web-glossaries";
-@import "partials/web-highlighter";
-@import "partials/web-index";
-@import "partials/web-maths";
-@import "partials/web-notes";
-@import "partials/web-openers";
-@import "partials/web-pullquotes";
-@import "partials/web-sources";
-@import "partials/web-tables";
-@import "partials/web-letters";
-@import "partials/web-verse";
-@import "partials/web-video";
-@import "partials/web-pagination";
-@import "partials/web-questions";
-@import "partials/web-select-questions";
-
-// Docs
-@import "partials/web-docs";
-
-// Type-control classes
-@import "partials/web-smallcaps";
-@import "partials/web-fitting";  // E.g. tracking and shrinking
-
-// User features
-@import "partials/web-controls";
-@import "partials/web-annotator";
-@import "partials/web-language-select";
-@import "partials/web-bookmarks";
-
-// Logic (if this then that)
-@import "partials/web-reset-sequences"; // This should stay last in the @import list
+    // Hidden on web, shown in app
+    display: inline;
+}

--- a/_sass/epub.scss
+++ b/_sass/epub.scss
@@ -1,6 +1,6 @@
 // What is this?
 // -------------
-// This is typography for the Electric Book Elements theme (see http://electricbook.works).
+// This is typography for the Electric Book template (see http://ebw.co/template).
 // It is built with Sass. (See http://sass-lang.com, and http://jekyllrb.com/docs/assets for how Jekyll implements Sass.)
 // It sets defaults that can be overridden in each book's own stylesheets, where the variables here are duplicated.
 // 
@@ -9,9 +9,6 @@
 // Edit the default variables below.
 // Comment/uncomment or add font imports below.
 // Add your own custom CSS at the bottom.
-
-// First, let's set character encoding. Don't change this.
-@charset "utf-8";
 
 // -------------
 // Set variables

--- a/_sass/epub.scss
+++ b/_sass/epub.scss
@@ -23,6 +23,10 @@ $output-format: "epub" !default;
 // Edition suffix: identifies this edition in certain classes (e.g. in _epub-fitting.scss).
 $edition-suffix: null !default;
 
+// The path to the project root, for settings paths to things like project assets.
+// Override this for translation styles, which need an extra leading ../
+$path-to-root-directory: "../.." !default;
+
 // We name font variables for two categories:
 // - 'text' fonts are used for body text and some page features;
 // - 'display' fonts are used for headings and similar short-string features.

--- a/_sass/partials/_print-font-faces.scss
+++ b/_sass/partials/_print-font-faces.scss
@@ -1,90 +1,91 @@
+$path-to-root-directory: "../.." !default;
 $print-font-faces: true !default;
 @if $print-font-faces {
 
     // Crimson Pro https://github.com/Fonthausen/CrimsonPro
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-ExtraLight.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-ExtraLight.ttf);
         font-weight: 200;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-ExtraLightItalic.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-ExtraLightItalic.ttf);
         font-weight: 200;
         font-style: italic;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-Light.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Light.ttf);
         font-weight: 300;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-LightItalic.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-LightItalic.ttf);
         font-weight: 300;
         font-style: italic;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-Regular.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Regular.ttf);
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-Italic.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Italic.ttf);
         font-style: italic;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-Medium.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Medium.ttf);
         font-weight: 500;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-MediumItalic.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-MediumItalic.ttf);
         font-weight: 500;
         font-style: italic;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-SemiBold.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-SemiBold.ttf);
         font-weight: 600;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-SemiBoldItalic.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-SemiBoldItalic.ttf);
         font-weight: 600;
         font-style: italic;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-Bold.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Bold.ttf);
         font-weight: bold;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-BoldItalic.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-BoldItalic.ttf);
         font-weight: bold;
         font-style: italic;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-ExtraBold.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-ExtraBold.ttf);
         font-weight: 800;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-ExtraBoldItalic.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-ExtraBoldItalic.ttf);
         font-weight: 800;
         font-style: italic;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-Black.otf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Black.otf);
         font-weight: 900;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(../../assets/fonts/CrimsonPro-BlackItalic.otf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-BlackItalic.otf);
         font-weight: 900;
         font-style: italic;
     }
@@ -92,67 +93,67 @@ $print-font-faces: true !default;
     // Source Sans Pro https://www.google.com/fonts/specimen/Source+Sans+Pro
     @font-face {
         font-family: "Source Sans Pro";
-        src: url(../../assets/fonts/SourceSansPro-Black.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/SourceSansPro-Black.ttf);
         font-weight: 900;
     }
     @font-face {
         font-family: "Source Sans Pro";
-        src: url(../../assets/fonts/SourceSansPro-BlackIt.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/SourceSansPro-BlackIt.ttf);
         font-weight: 900;
         font-style: italic;
     }
     @font-face {
         font-family: "Source Sans Pro";
-        src: url(../../assets/fonts/SourceSansPro-Bold.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/SourceSansPro-Bold.ttf);
         font-weight: 700;
     }
     @font-face {
         font-family: "Source Sans Pro";
-        src: url(../../assets/fonts/SourceSansPro-BoldIt.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/SourceSansPro-BoldIt.ttf);
         font-weight: 700;
         font-style: italic;
     }
     @font-face {
         font-family: "Source Sans Pro";
-        src: url(../../assets/fonts/SourceSansPro-ExtraLight.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/SourceSansPro-ExtraLight.ttf);
         font-weight: 200;
     }
     @font-face {
         font-family: "Source Sans Pro";
-        src: url(../../assets/fonts/SourceSansPro-ExtraLightIt.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/SourceSansPro-ExtraLightIt.ttf);
         font-weight: 200;
         font-style: italic;
     }
     @font-face {
         font-family: "Source Sans Pro";
-        src: url(../../assets/fonts/SourceSansPro-It.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/SourceSansPro-It.ttf);
         font-weight: 400;
         font-style: italic;
     }
     @font-face {
         font-family: "Source Sans Pro";
-        src: url(../../assets/fonts/SourceSansPro-Light.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/SourceSansPro-Light.ttf);
         font-weight: 300;
     }
     @font-face {
         font-family: "Source Sans Pro";
-        src: url(../../assets/fonts/SourceSansPro-LightIt.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/SourceSansPro-LightIt.ttf);
         font-weight: 300;
         font-style: italic;
     }
     @font-face {
         font-family: "Source Sans Pro";
-        src: url(../../assets/fonts/SourceSansPro-Regular.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/SourceSansPro-Regular.ttf);
         font-weight: 400;
     }
     @font-face {
         font-family: "Source Sans Pro";
-        src: url(../../assets/fonts/SourceSansPro-Semibold.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/SourceSansPro-Semibold.ttf);
         font-weight: 600;
     }
     @font-face {
         font-family: "Source Sans Pro";
-        src: url(../../assets/fonts/SourceSansPro-SemiboldIt.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/SourceSansPro-SemiboldIt.ttf);
         font-weight: 600;
         font-style: italic;
     }
@@ -160,21 +161,21 @@ $print-font-faces: true !default;
     // Ubuntu Mono http://font.ubuntu.com/
     @font-face {
         font-family: "Ubuntu Mono";
-        src: url(../../assets/fonts/UbuntuMono-R.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/UbuntuMono-R.ttf);
     }
     @font-face {
         font-family: "Ubuntu Mono";
-        src: url(../../assets/fonts/UbuntuMono-RI.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/UbuntuMono-RI.ttf);
         font-style: italic;
     }
     @font-face {
         font-family: "Ubuntu Mono";
-        src: url(../../assets/fonts/UbuntuMono-B.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/UbuntuMono-B.ttf);
         font-weight: bold;
     }
     @font-face {
         font-family: "Ubuntu Mono";
-        src: url(../../assets/fonts/UbuntuMono-BI.ttf);
+        src: url(#{$path-to-root-directory}/assets/fonts/UbuntuMono-BI.ttf);
         font-weight: bold;
         font-style: italic;
     }

--- a/_sass/partials/_print-pdf-view.scss
+++ b/_sass/partials/_print-pdf-view.scss
@@ -1,3 +1,4 @@
+$path-to-root-directory: "../.." !default;
 $print-pdf-view: true !default;
 @if $print-pdf-view {
 
@@ -13,7 +14,7 @@ $print-pdf-view: true !default;
         prince-pdf-profile: $pdf-profile;
         prince-pdf-display-doc-title: true; // only supported from Prince 13
         // Note colour profiles are stored in the non-generated Jekyll root, not in _site
-        prince-pdf-output-intent: url("../../../_tools/profiles/#{$color-profile}");
+        prince-pdf-output-intent: url("#{$path-to-root-directory}/_tools/profiles/#{$color-profile}");
         @if $output-format == "print-pdf" {
             prince-filter-resolution: 300dpi;
         }

--- a/_sass/partials/_print-pdf-view.scss
+++ b/_sass/partials/_print-pdf-view.scss
@@ -14,7 +14,7 @@ $print-pdf-view: true !default;
         prince-pdf-profile: $pdf-profile;
         prince-pdf-display-doc-title: true; // only supported from Prince 13
         // Note colour profiles are stored in the non-generated Jekyll root, not in _site
-        prince-pdf-output-intent: url("#{$path-to-root-directory}/_tools/profiles/#{$color-profile}");
+        prince-pdf-output-intent: url("#{$path-to-root-directory}/../_tools/profiles/#{$color-profile}");
         @if $output-format == "print-pdf" {
             prince-filter-resolution: 300dpi;
         }

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -1,6 +1,6 @@
 // What is this?
 // -------------
-// This is typography for the Electric Book Elements theme (see http://electricbook.works).
+// This is typography for the Electric Book template (see http://ebw.co/template).
 // It is built with Sass. (See http://sass-lang.com, and http://jekyllrb.com/docs/assets for how Jekyll implements Sass.)
 // It sets defaults that can be overridden in each book's own stylesheets, where the variables here are duplicated.
 // 
@@ -9,9 +9,6 @@
 // Edit the default variables below.
 // Comment/uncomment or add font imports below.
 // Add your own custom CSS at the bottom.
-
-// First, let's set character encoding. Don't change this.
-@charset "utf-8";
 
 // -------------
 // Set variables

--- a/_sass/print-pdf.scss
+++ b/_sass/print-pdf.scss
@@ -26,6 +26,10 @@ $output-format: "print-pdf" !default;
 // If you're only planning one edition and use default tags ({:.tighten} not {:.tighten-schools-edn}), leave as null.
 $edition-suffix: null !default;
 
+// The path to the project root, for settings paths to fonts and colour profiles.
+// Override this for translation styles, which need an extra leading ../
+$path-to-root-directory: "../.." !default;
+
 // First, we set several variables related to overall page setup.
 $page-width: 152mm !default;
 $page-height: 229mm !default;
@@ -350,6 +354,11 @@ $print-page-setup-lightning-source: false !default; // Removes crop marks and se
 // ----------------------------------------------------
 
 // Default font-face rules added by print-font-faces partial below.
+// Or add @font-face rules for fonts you specify here.
+// Add the actual font files to `../fonts` or `../../assets/fonts`.
+// Use #{$path-to-root-directory} to allow overriding per translation. E.g.:
+// `src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Regular.ttf);`
+// For snippets, try https://github.com/arthurattwell/font-faces
 
 // ---------------------
 // Import theme partials

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -1,6 +1,6 @@
 // What is this?
 // -------------
-// This is typography for the Electric Book Elements theme (see http://electricbook.works).
+// This is typography for the Electric Book template (see http://ebw.co/template).
 // It is built with Sass. (See http://sass-lang.com, and http://jekyllrb.com/docs/assets for how Jekyll implements Sass.)
 // It sets defaults that can be overridden in each book's own stylesheets, where the variables here are duplicated.
 // 
@@ -9,9 +9,6 @@
 // Edit the default variables below.
 // Comment/uncomment or add font imports below.
 // Add your own custom CSS at the bottom.
-
-// First, let's set character encoding. Don't change this.
-@charset "utf-8";
 
 // -------------
 // Set variables

--- a/_sass/screen-pdf.scss
+++ b/_sass/screen-pdf.scss
@@ -14,6 +14,9 @@
 // Set variables
 // -------------
 
+// In screen PDF, we inherit all defaults from print-pdf.scss
+// except for screen-PDF-specific ones overridden here.
+
 // Provide a variable for site output
 $output-format: "screen-pdf" !default;
 
@@ -24,43 +27,12 @@ $output-format: "screen-pdf" !default;
 $edition-suffix: null !default;
 
 // First, we set several variables related to overall page setup.
-$page-width: 152mm !default;
-$page-height: 229mm !default;
-$margin-top: 60pt !default; // set in points to align with baseline grid
-$margin-bottom: 60pt !default;
-$margin-outside: 20mm !default;
-$margin-inside: 20mm !default;
 $bleed: 0 !default;
 $trim: 0 !default;
 $crop-marks: none !default; // crop | none
-$page-info-offset: 5mm !default;
-$columns-default: 1 !default;
-
-// Optional sidebar setup
-// If you want a sidebar, set these values and change $print-sidebar
-// to 'true' in the list of partials below, where it is disabled by default.
-// For guidance on sidebar variables, see partials/_pdf-sidebar.scss.
-// 1. Set the margin between the page edge and the sidebar:
-$sidebar-margin-outside: 10mm !default;
-// 2. The number of 'columns' in your page grid:
-$grid-columns: 3 !default;
-// 3. As a single integer, set the ratio of the column width to column-gap width.
-//    That is, how wide is a column, as a multiple of the column-gap?
-//    A higher number makes the column wider, and the gap smaller.
-//    A lower number makes the column narrower, and the gap wider.
-$column-gap-ratio: 10 !default;
-// 4. Then use @mixin sidebar() to move elements into the sidebar
 
 // Colours
 $colorspace: rgb !default; // auto | none | rgb | cmyk | gray
-$color-text-main: cmyk(0,0,0,1) !default;
-$color-text-secondary: cmyk(0,0,0,0.8) !default;
-$color-background: transparent !default;
-$color-light: cmyk(0,0,0,0.2) !default;
-$color-mid: cmyk(0,0,0,0.4) !default;
-$color-accent: cmyk(0,0,0,1) !default;
-$color-links: inherit !default;
-$color-highlight: #ffd54d !default;
 
 // PDF file setup options
 // Options for pdf-profile: PDF/A-1b, PDF/A-3b, PDF/X-1a:2001, PDF/X-1a:2003, PDF/X-3:2002, PDF/X-3:2003, PDF/X-4
@@ -72,342 +44,17 @@ $color-highlight: #ffd54d !default;
 // are in the same colour space as the document for X-1a compliance.
 $pdf-profile: "PDF/A-3b" !default;
 $color-profile: "sRGB_v4_ICC_preference_displayclass.icc" !default;
-$black-ink: true !default; // true or rich (true for pure black or rich for rich black)
-$convert-images-to-color-profile: false !default; // 'true' may convert true black to rich black in images
 
-// We name font variables for two categories:
-// - 'text' fonts are used for body text and some page features;
-// - 'display' fonts are used for headings and similar short-string features.
-// For each category, we set a main font and a secondary font, allowing up to four fonts.
-// Finally, we set a fifth, monospace font for elements like computer code.
-// Using prince-no-fallback triggers a warning and aborts PDF creation
-// if any glyphs are not found in the specified font, instead of switching to another one.
-// This is recommended for books where perfect reproduction among users is important.
-$font-text-main: "Crimson Pro", prince-no-fallback !default;
-$font-text-secondary: "Source Sans Pro", prince-no-fallback !default;
-$font-display-main: "Source Sans Pro", prince-no-fallback !default;
-$font-display-secondary: "Crimson Pro", prince-no-fallback !default;
-$font-code: "Ubuntu Mono", prince-no-fallback !default;
+// -------------
+// Master theme
+// -------------
 
-// Finally, we set variables related to text flow.
-$font-size-default: 11pt !default;
-$line-height-default: 15pt !default; // Set in points. For consistent baselines, all other line heights and vertical spaces are based on this.
-$font-size-smaller: 0.8 !default; // How much smaller than font-size-default for features like sidenotes and footers?
-$font-size-bigger: 2 !default; // How many times bigger than font-size-default for features like headings and pullquotes? Use whole numbers to preserve baseline grid.
-$text-align: justify !default; // left or right or inside or outside or justify or center
-$orphans: 1 !default; // Minimum number of lines that must be left at the bottom of the first page
-$widows: 1 !default; // Minimum number of lines that must be left at the top of the second page
-$letter-spacing-text: 0em !default; // Default letter-spacing for p, ul, ol, dl. Set in ems, e.g. 0.01em for 10/1000s of an em.
-$math-size-percent: 85%; // Adjust this to make math character size match your body font
+// By default, we assume screen-PDFs look exactly like print-PDF versions,
+// Except for variables changes above. So import and inherit those styles.
+@import 'print-pdf';
 
-// Do you want space between paragraphs, rather than a text-indent? true or false
-$spaced-paras: false !default;
-// If not spacing paras, how large is the first-line indent on paragraphs?
-$paragraph-indent: $font-size-default !default;
+// -------------
+// Custom styles
+// -------------
 
-// Rounded corners
-$button-border-radius: 0.1rem !default; // Roundness of button corners
-$box-border-radius: 0.5rem !default; // Roundness of box corners
-
-// Rules, lines
-$rule-thickness: 0.5pt !default;
-
-// Hyphenation
-// Variables here apply to p, ul, ol, dl
-$hyphenation: manual !default; // Can be auto, none, or manual (only breaks on hyphens and soft hyphens)
-$hyphenation-dictionary: "" !default; // Path to dictionary file, relative to `/book/styles`. E.g. "../../assets/hyph.dic". Overrides PrinceXML built-in hyphenation.
-$hyphenate-after: 3 !default; // Minimum letters on new line after hyphen
-$hyphenate-before: 3 !default; // Minimum letters at end of line before hyphen
-$hyphenate-lines: 2 !default; // Preferred maximum number of consecutive lines ending with hyphens
-
-// Text dividers
-// For breaks created with *** in markdown.
-// If using an image, set $text-divider-image in CSS URL syntax, e.g.
-// $text-divider-image: url('../images/epub/text-divider.jpg');
-$text-divider-text: "" !default; // Empty leaves space. \2022 is a bullet
-$text-divider-image: "" !default;
-$text-divider-image-height: $line-height-default !default;
-
-// Should chapters start on a right-hand page (recto) or on any page?
-// This setting applies to the frontmatter, dedication-page, epigraph-page and chapter page styles.
-// (The halftitle-page, title-page and contents-page page styles always start on a recto.)
-$start-on: right !default; // right or auto or left ()
-
-// Set the default start-depth of pages.
-// This is the distance from the top of the page to the first element on the first page.
-// Set it in multiples of $line-height-default to preserve your baseline grid.
-$start-depth: $line-height-default * 6 !default;
-
-// Style of page numbers on frontmatter pages
-// Remember to tag links to front matter pages in your TOC with {:.frontmatter-reference}
-$frontmatter-reference-style: lower-roman !default; // lower-roman, decimal, see http://www.princexml.com/doc/gen-content/#idp54010640
-
-// Set the content of headers and footers.
-//
-// * For no content: normal
-// * For a page number: counter(page)
-// * For the body element's title attribute: string(page-header)
-//   Set this body title attribute with `header: Your Title` in a file's YAML frontmatter.
-//   If you don't set a page header in YAML, string(page-header) will fallback to the page title.
-//   You can also set string(page-header-left) and string(page-header-right) with page YAML
-//   `header-left: "Your Left Header"` and `header-right: "Your Right Header"` respectively.
-// * For the title attribute of the last h1 (increment to h2, h3, h4, h5, h6 as needed): string(h1-title, last)
-//   By default, this uses the heading text, unless you manually set a title attribute for a given heading.
-//   In kramdown, use {: title="Your Title Here" } after the heading to set the title manually.
-// * For the last h1 (increment to h2, h3, h4, h5, h6 as needed): string(h1-text, last)
-//   Instead of last (last on page) you can also use first (first on page) or start (string set on previous page).
-// * For a phrase: "Any phrase in quotes"
-// * For an em space: "\2003"
-// * For other special characters, see CSS (ISO) at https://brajeshwar.github.io/entities/
-
-// Verso (left-hand-page)
-$verso-top: string(page-header) !default;
-$verso-top-left: normal !default;
-$verso-top-right: normal !default;
-$verso-top-left-corner: normal !default;
-$verso-top-right-corner: normal !default;
-$verso-bottom: counter(page) !default;
-$verso-bottom-left: normal !default;
-$verso-bottom-right: normal !default;
-$verso-bottom-left-corner: normal !default;
-$verso-bottom-right-corner: normal !default;
-$verso-left: normal !default;
-$verso-left-top: normal !default;
-$verso-left-bottom: normal !default;
-$verso-right: normal !default;
-$verso-right-top: normal !default;
-$verso-right-bottom: normal !default;
-
-// Recto (right-hand-page)
-$recto-top: string(h2-title, last) !default;
-$recto-top-left: normal !default;
-$recto-top-right: normal !default;
-$recto-top-left-corner: normal !default;
-$recto-top-right-corner: normal !default;
-$recto-bottom: counter(page) !default;
-$recto-bottom-left: normal !default;
-$recto-bottom-right: normal !default;
-$recto-bottom-left-corner: normal !default;
-$recto-bottom-right-corner: normal !default;
-$recto-left: normal !default;
-$recto-left-top: normal !default;
-$recto-left-bottom: normal !default;
-$recto-right: normal !default;
-$recto-right-top: normal !default;
-$recto-right-bottom: normal !default;
-
-// Verso (left-hand-page) for .frontmatter pages (`style: frontmatter`)
-$verso-top-frontmatter: string(page-header) !default;
-$verso-top-left-frontmatter: normal !default;
-$verso-top-right-frontmatter: normal !default;
-$verso-top-left-corner-frontmatter: normal !default;
-$verso-top-right-corner-frontmatter: normal !default;
-$verso-bottom-frontmatter: counter(page, $frontmatter-reference-style) !default;
-$verso-bottom-left-frontmatter: normal !default;
-$verso-bottom-right-frontmatter: normal !default;
-$verso-bottom-left-corner-frontmatter: normal !default;
-$verso-bottom-right-corner-frontmatter: normal !default;
-$verso-left-frontmatter: normal !default;
-$verso-left-top-frontmatter: normal !default;
-$verso-left-bottom-frontmatter: normal !default;
-$verso-right-frontmatter: normal !default;
-$verso-right-top-frontmatter: normal !default;
-$verso-right-bottom-frontmatter: normal !default;
-
-// Recto (right-hand-page) for .frontmatter pages (`style: frontmatter`)
-$recto-top-frontmatter: string(h2-title, last) !default;
-$recto-top-left-frontmatter: normal !default;
-$recto-top-right-frontmatter: normal !default;
-$recto-top-left-corner-frontmatter: normal !default;
-$recto-top-right-corner-frontmatter: normal !default;
-$recto-bottom-frontmatter: counter(page, $frontmatter-reference-style) !default;
-$recto-bottom-left-frontmatter: normal !default;
-$recto-bottom-right-frontmatter: normal !default;
-$recto-bottom-left-corner-frontmatter: normal !default;
-$recto-bottom-right-corner-frontmatter: normal !default;
-$recto-left-frontmatter: normal !default;
-$recto-left-top-frontmatter: normal !default;
-$recto-left-bottom-frontmatter: normal !default;
-$recto-right-frontmatter: normal !default;
-$recto-right-top-frontmatter: normal !default;
-$recto-right-bottom-frontmatter: normal !default;
-
-// Set styles for headers and footers
-$header-font: $font-text-secondary !default;
-$footer-font: $font-text-secondary !default;
-$header-font-size: $font-size-default * $font-size-smaller !default;
-$footer-font-size: $font-size-default * $font-size-smaller !default;
-$header-font-weight: normal !default;
-$footer-font-weight: normal !default;
-$header-case: uppercase !default; // none|capitalize|uppercase|lowercase|initial|inherit;
-$footer-case: uppercase !default; // none|capitalize|uppercase|lowercase|initial|inherit;
-$header-letter-spacing: 0.1em !default;
-$footer-letter-spacing: 0.1em !default;
-$header-space-from-top: $margin-top / 2 + ($line-height-default / 4) !default; // should align with baseline grid
-$header-space-from-text: $line-height-default !default;
-$footer-space-from-bottom: $margin-bottom / 2 !default;
-$footer-space-from-text: $line-height-default !default;
-$header-text-align: center !default;
-$footer-text-align: center !default;
-$header-text-color: $color-text-main !default;
-$footer-text-color: $color-text-main !default;
-$left-margin-font: $header-font !default;
-$left-margin-font-size: $header-font-size !default;
-$left-margin-font-weight: $header-font-weight !default;
-$left-margin-case: $header-case !default;
-$left-margin-letter-spacing: $header-letter-spacing !default;
-$left-margin-alignment: top !default;
-$left-margin-space-from-edge: $margin-outside / 2 !default;
-$left-margin-space-from-text: $margin-outside / 2 - $left-margin-font-size !default;
-$left-margin-text-align: $header-text-align !default;
-$left-margin-text-color: $color-text-main !default;
-$right-margin-font: $header-font !default;
-$right-margin-font-size: $header-font-size !default;
-$right-margin-font-weight: $header-font-weight !default;
-$right-margin-case: $header-case !default;
-$right-margin-letter-spacing: $header-letter-spacing !default;
-$right-margin-alignment: top !default;
-$right-margin-space-from-edge: $margin-outside / 2 + $right-margin-font-size !default;
-$right-margin-space-from-text: $margin-outside / 2 - $right-margin-font-size !default;
-$right-margin-text-align: $header-text-align !default;
-$right-margin-text-color: $color-text-main !default;
-
-// Special highlights for temporary debugging/viewing:
-// Specify a colour for highlighting; use 'inherit' for none.
-$highlight-tightened: inherit !default;
-$highlight-loosened: inherit !default;
-
-// Show or hide a baseline grid, based on line-height-default.
-// Set to true to show or false to hide.
-$show-baseline-grid: false !default;
-
-// ---------------------------------
-// Set to false to turn partials off
-// ---------------------------------
-
-// Reset PrinceXML CSS
-$print-css-reset: true !default;
-
-// Conventional helper classes
-$print-helpers: true !default;
-
-// Add default font-face rules
-$print-font-faces: true !default;
-
-// Page setup and control, avoid changing these
-$print-pdf-view: true !default; // Sets the default initial view on PDFs
-$print-page-setup: true !default; // Sets up the page from your variables
-$print-page-break-tools: true !default; // Provides classes for semantic page breaks
-$print-hide-non-printing: true !default; // Hides anything .non-printing
-$print-fitting: true !default; // Classes for floating, tracking, shrinking, etc.
-$print-hyphenation: true !default; // Sets hyphenation dictionary
-
-// Book features
-$print-start-on-recto-or-verso: true !default; // Starts chapters on a left- or right-hand-page
-$print-page-start-depth: true !default; // Sets a top margin on opening pages
-$print-base-typography: true !default; // Default typography for HTML elements
-$print-columns: true !default;
-$print-buttons: true !default;
-$print-verse: true !default; // Default typography for verse, poetry, lyrics
-$print-bibliographies: true !default;
-$print-dialogue: true !default;
-$print-epigraphs: true !default;
-$print-dedications: true !default;
-$print-glossaries: true !default; // Including .glossary
-$print-highlighter: true !default;
-$print-pullquotes: true !default; // Supports .pullquote
-$print-boxes: true !default;
-$print-code: true !default; // For computer code and preformatted text
-$print-tables: true !default;
-$print-figures: true !default;
-$print-notes: true !default; // Footnotes, endnotes, sidenotes
-$print-previous-publications-page: true !default; // The 'also by the author' frontmatter apge
-$print-title-pages: true !default; // Half-title and title pages
-$print-copyright-page: true !default;
-$print-toc: true !default; // Tables of contents
-$print-cover: true !default; // Front-cover image for PDF ebooks
-$print-video: true !default;
-$print-smallcaps: true !default;
-$print-maths: true !default;
-$print-letters: true !default;
-$print-sources: true !default;
-$print-openers: true !default;
-$print-index: true !default;
-$print-questions: true !default;
-$print-select-questions: true !default;
-$print-cross-refs: true !default;
-$print-sidebar: false !default; // Note that this is disabled by default here and in the partial, remove !default to override partial
-$print-reset-sequences: true !default; // Resets p indents, margins after other elements. Must be last @import in list.
-$print-page-headers-footers-content: true !default; // Sets content for headers and footers
-$print-page-headers-footers-style: true !default; // Sets styling for headers and footers
-
-// ----------------------------------------------------
-// Import font files (@font-face) for fonts you specify
-// ----------------------------------------------------
-
-// Default font-face rules added by print-font-faces partial below.
-
-// ---------------------
-// Import theme partials
-// ---------------------
-
-// Reset PrinceXML CSS
-@import "partials/print-css-reset";
-
-// Load general-purpose mixins
-@import "partials/print-mixins--buttons";
-@import "partials/print-mixins--sidenotes";
-
-// Conventional helper classes
-@import "partials/print-helpers";
-
-// Add font-face rules
-@import "partials/print-font-faces";
-
-// Page setup and control, avoid changing these
-@import "partials/print-pdf-view"; // Sets the default initial view on PDFs
-@import "partials/print-sidebar"; // redefines margins if $print-sidebar is true
-@import "partials/print-page-setup"; // Sets up the page from your variables
-@import "partials/print-page-break-tools"; // Provides classes for semantic page breaks
-@import "partials/print-hide-non-printing"; // Hides anything .non-printing
-@import "partials/print-fitting"; // Classes for floating, tracking, shrinking, etc.
-@import "partials/print-hyphenation"; // Sets hyphenation dictionary
-@import "partials/print-baseline-grid"; // Shows a baseline grid
-
-// Book features
-@import "partials/print-start-on-recto-or-verso"; // Starts chapters on a left- or right-hand-page
-@import "partials/print-page-start-depth"; // Sets a top margin on opening pages
-@import "partials/print-base-typography"; // Default typography for HTML elements
-@import "partials/print-columns";
-@import "partials/print-buttons";
-@import "partials/print-verse"; // Default typography for verse, poetry, lyrics
-@import "partials/print-bibliographies";
-@import "partials/print-epigraphs";
-@import "partials/print-dedications";
-@import "partials/print-dialogue";
-@import "partials/print-glossaries"; // Including .glossary
-@import "partials/print-highlighter";
-@import "partials/print-pullquotes"; // Supports .pullquote
-@import "partials/print-boxes";
-@import "partials/print-code"; // For computer code and preformatted text
-@import "partials/print-tables";
-@import "partials/print-figures";
-@import "partials/print-notes"; // Footnotes, endnotes, sidenotes
-@import "partials/print-previous-publications-page"; // Also by the author page in frontmatter
-@import "partials/print-title-pages"; // Half-title and title pages
-@import "partials/print-copyright-page";
-@import "partials/print-toc"; // Tables of contents
-@import "partials/print-cover"; // Front-cover image for PDF ebooks
-@import "partials/print-video";
-@import "partials/print-smallcaps";
-@import "partials/print-maths";
-@import "partials/print-letters";
-@import "partials/print-sources";
-@import "partials/print-openers";
-@import "partials/print-index";
-@import "partials/print-questions";
-@import "partials/print-select-questions";
-@import "partials/print-cross-refs";
-@import "partials/print-reset-sequences"; // Resets p indents, margins after other elements. Must be last @import in list.
-@import "partials/print-page-headers-footers-content"; // Sets content for headers and footers
-@import "partials/print-page-headers-footers-style"; // Sets styling for headers and footers
+// Add any custom screen-PDF styles here.

--- a/_sass/web.scss
+++ b/_sass/web.scss
@@ -1,6 +1,6 @@
 // What is this?
 // -------------
-// This is typography for the Electric Book Elements theme (see http://electricbook.works).
+// This is typography for the Electric Book template (see http://ebw.co/template).
 // It is built with Sass. (See http://sass-lang.com, and http://jekyllrb.com/docs/assets for how Jekyll implements Sass.)
 // It sets defaults that can be overridden in each book's own stylesheets, where the variables here are duplicated.
 // 
@@ -9,9 +9,6 @@
 // Edit the default variables below.
 // Comment/uncomment or add font imports below.
 // Add your own custom CSS at the bottom.
-
-// First, let's set character encoding. Don't change this.
-@charset "utf-8";
 
 // -------------
 // Set variables

--- a/book/styles/app.scss
+++ b/book/styles/app.scss
@@ -34,6 +34,8 @@ $edition-suffix: null;
 
 // Add @font-face rules for fonts you specify here.
 // Add the actual font files to `../fonts` or `../../assets/fonts`.
+// Use #{$path-to-root-directory} to allow overriding per translation. E.g.:
+// `src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Regular.ttf);`
 // For snippets, try https://github.com/arthurattwell/font-faces
 
 

--- a/book/styles/print-pdf.scss
+++ b/book/styles/print-pdf.scss
@@ -37,7 +37,9 @@ $edition-suffix: null;
 
 // Add @font-face rules for fonts you specify here.
 // Add the actual font files to `../fonts` or `../../assets/fonts`.
-// For snippets, try https://github.com/arthurattwell/font-faces.
+// Use #{$path-to-root-directory} to allow overriding per translation. E.g.:
+// `src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Regular.ttf);`
+// For snippets, try https://github.com/arthurattwell/font-faces
 // By default, a print-font-faces partial will include rules
 // for Crimson Pro, Source Sans Pro, and Ubuntu Mono.
 

--- a/book/styles/screen-pdf.scss
+++ b/book/styles/screen-pdf.scss
@@ -37,7 +37,9 @@ $edition-suffix: null;
 
 // Add @font-face rules for fonts you specify here.
 // Add the actual font files to `../fonts` or `../../assets/fonts`.
-// For snippets, try https://github.com/arthurattwell/font-faces.
+// Use #{$path-to-root-directory} to allow overriding per translation. E.g.:
+// `src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Regular.ttf);`
+// For snippets, try https://github.com/arthurattwell/font-faces
 // By default, a print-font-faces partial will include rules
 // for Crimson Pro, Source Sans Pro, and Ubuntu Mono.
 

--- a/samples/styles/app.scss
+++ b/samples/styles/app.scss
@@ -34,6 +34,8 @@ $edition-suffix: null;
 
 // Add @font-face rules for fonts you specify here.
 // Add the actual font files to `../fonts` or `../../assets/fonts`.
+// Use #{$path-to-root-directory} to allow overriding per translation. E.g.:
+// `src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Regular.ttf);`
 // For snippets, try https://github.com/arthurattwell/font-faces
 
 

--- a/samples/styles/print-pdf.scss
+++ b/samples/styles/print-pdf.scss
@@ -37,7 +37,9 @@ $edition-suffix: null;
 
 // Add @font-face rules for fonts you specify here.
 // Add the actual font files to `../fonts` or `../../assets/fonts`.
-// For snippets, try https://github.com/arthurattwell/font-faces.
+// Use #{$path-to-root-directory} to allow overriding per translation. E.g.:
+// `src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Regular.ttf);`
+// For snippets, try https://github.com/arthurattwell/font-faces
 // By default, a print-font-faces partial will include rules
 // for Crimson Pro, Source Sans Pro, and Ubuntu Mono.
 

--- a/samples/styles/screen-pdf.scss
+++ b/samples/styles/screen-pdf.scss
@@ -37,7 +37,9 @@ $edition-suffix: null;
 
 // Add @font-face rules for fonts you specify here.
 // Add the actual font files to `../fonts` or `../../assets/fonts`.
-// For snippets, try https://github.com/arthurattwell/font-faces.
+// Use #{$path-to-root-directory} to allow overriding per translation. E.g.:
+// `src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Regular.ttf);`
+// For snippets, try https://github.com/arthurattwell/font-faces
 // By default, a print-font-faces partial will include rules
 // for Crimson Pro, Source Sans Pro, and Ubuntu Mono.
 


### PR DESCRIPTION
Two main aims here:

1. **Make app and screen-PDF outputs inherit web and print-PDF styles respectively.** In practice, we've found that they are almost always identical, and this will save time when setting up and maintaining these outputs.
2. **Enable changing fonts in translations.** In another project, we needed to change the font for a specific language (for script reasons). CSS needs path to the fonts, and this path is different in translation styles. So I've introduced a `path-to-root-directory` variable, which can be changed in translated-book-specific styles. E.g. in the default styles used in `book/styles/web.scss`:

   ```
   $path-to-root-directory: "../..";
   ```

   But in a Vietnamese translation, you could create `book/vi/styles/web.scss` and set:

   ```
   $path-to-root-directory: "../../..";
   ```
