### PR TITLE
Add 'copy-to-clipboard' functionality

### DIFF
--- a/_data/locales.yml
+++ b/_data/locales.yml
@@ -203,6 +203,10 @@ en:
     language-select: "Select language"
   video:
     options-button: "Other video options"
+  copy:
+    copy: "Copy"
+    copied: "Copied"
+    copy-failed: "Sorry, try again"
 # eo:
 #   iso-name: "Esperanto"
 #   local-name: ""
@@ -298,6 +302,10 @@ fr:
     language-select: "Sélectionnez la langue"
   video:
     options-button: "Autres options vidéo"
+  copy:
+    copy: "Copie"
+    copied: "Copié"
+    copy-failed: "Désolé, essayez encore"
 # ff:
 #   iso-name: "Fula, Fulah, Pulaar, Pular"
 #   local-name: ""

--- a/_sass/partials/_web-buttons.scss
+++ b/_sass/partials/_web-buttons.scss
@@ -67,4 +67,12 @@ $web-buttons: true !default;
         margin-bottom: $line-height-default;
     }
 
+    button.copy-to-clipboard {
+        background-color: $color-background;
+        border: $rule-thickness solid $color-mid;
+        box-shadow: none;
+        color: $color-mid;
+        font-weight: normal;
+        margin-left: 1rem;
+    }
 }

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -27,6 +27,7 @@ layout: null
     {% include_relative tables.js %}
     {% include_relative footnote-popups.js %}
     {% include_relative show-hide.js %}
+    {% include_relative copy-to-clipboard.js %}
 
     {% if site.data.settings.web.svg.inject == true %}
         {% include_relative vendor/svg-inject.min.js %}

--- a/assets/js/copy-to-clipboard.js
+++ b/assets/js/copy-to-clipboard.js
@@ -1,0 +1,63 @@
+/*jslint browser */
+/*globals locales, pageLanguage */
+
+// Set default button text.
+var ebCopyToClipboardButtonText = locales[pageLanguage].copy.copy;
+var ebCopyToClipboardSuccessText = locales[pageLanguage].copy.copied;
+var ebCopyToClipboardFailText = locales[pageLanguage].copy['copy-failed'];
+
+// Show that copying was done
+function ebCopyButtonFeedback(button, text) {
+    'use strict';
+    button.innerHTML = text;
+
+    if (text === ebCopyToClipboardSuccessText) {
+        button.classList.add('copy-to-clipboard-success');
+    }
+
+    window.setTimeout(function() {
+        button.innerHTML = ebCopyToClipboardButtonText;
+        button.classList.remove('copy-to-clipboard-success');
+    }, 2000 );
+}
+
+// Copy an element's text to the clipboard.
+function ebCopyToClipboard(element, button) {
+    'use strict';
+    var text = element.textContent;
+    navigator.clipboard.writeText(text).then(function() {
+        // success
+        ebCopyButtonFeedback(button, ebCopyToClipboardSuccessText)
+    }, function() {
+        // failure
+        ebCopyButtonFeedback(button, ebCopyToClipboardFailText)
+    });
+}
+
+// Add a copy button, ready for clicking.
+function ebAddCopyButton(element, buttonText) {
+    'use strict';
+    
+    var button = document.createElement('button');
+    button.classList.add('copy-to-clipboard');
+    button.setAttribute('type', 'button');
+    button.innerHTML = buttonText;
+    element.insertAdjacentElement('afterend', button);
+
+    button.addEventListener('click', function () {
+        ebCopyToClipboard(element, button);
+    });
+}
+
+// Find all elements that need copy buttons,
+// by their 'copy-to-clipboard` class.
+function ebAddCopyButtons() {
+    'use strict';
+    var elementsThatNeedButtons = document.querySelectorAll('.copy-to-clipboard');
+    elementsThatNeedButtons.forEach(function (element) {
+        ebAddCopyButton(element, ebCopyToClipboardButtonText);
+    });
+}
+
+// Go
+ebAddCopyButtons();


### PR DESCRIPTION
Add the class `.copy-to-clipboard` to any span to show a 'Copy' button beside it. Useful for things like phone numbers and email addresses.