### PR TITLE
Suggest Jekyll v4 when managing own Jekyll version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 # change this to match what it supports: https://pages.github.com/versions/
 # or use the github-pages gem below. To control your own Jekyll version,
 # uncomment the following line and comment out the github-pages gem below.
-# gem 'jekyll', '~>3.9'
+# gem 'jekyll', '~>4.2'
 
 # GitHub Pages recommends using the github-pages gem to ensure
 # that your site will build exactly as it will on GitHub Pages.


### PR DESCRIPTION
Note that GitHub Pages still only supports Jekyll 3.9. So our default will remain the github-pages gem, and by implication, for now, Jekyll 3.9. Users who don't need GitHub Pages can set their own Jekyll version in `Gemfile`.

Note relevant background in

- https://github.com/electricbookworks/electric-book/issues/411
- https://github.com/electricbookworks/electric-book/pull/509