### PR TITLE
Don't open browser to avoid opening at wrong URL

### DIFF
--- a/run-linux.sh
+++ b/run-linux.sh
@@ -246,18 +246,7 @@ Enter a number and hit enter. "
 		echo "my/base"
 		read baseurl
 		# let the user know we're on it!
-		echo "Getting your site ready...
-You may need to reload the web page once this server is running."
-		# Open the web browser, without or, then, with the baseurl
-		# (This is before jekyll s, because jekyll s pauses the script.)
-		if [ "$baseurl" = "" ]
-		then
-			# (for OSX, this is open, not xdg-open)
-			xdg-open "http://127.0.0.1:4000/"
-		else
-			# (for OSX, this is open, not xdg-open)
-			xdg-open "http://127.0.0.1:4000/$baseurl/"
-		fi
+		echo "Getting your site ready..."
 		# We're going to let users run this over and over by pressing enter
 		repeat=""
 		while [ "$repeat" = "" ]

--- a/run-mac.command
+++ b/run-mac.command
@@ -249,18 +249,7 @@ Enter a number and hit enter. "
 		echo "my/base"
 		read baseurl
 		# let the user know we're on it!
-		echo "Getting your site ready...
-You may need to reload the web page once this server is running."
-		# Open the web browser, without or, then, with the baseurl
-		# (This is before jekyll s, because jekyll s pauses the script.)
-		if [ "$baseurl" = "" ]
-		then
-			# (for Linux, this is xdg-open, not open)
-			open "http://127.0.0.1:4000/"
-		else
-			# (for Linux, this is xdg-open, not open)
-			open "http://127.0.0.1:4000/$baseurl/"
-		fi
+		echo "Getting your site ready..."
 		# We're going to let users run this over and over by pressing enter
 		repeat=""
 		while [ "$repeat" = "" ]

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -302,17 +302,12 @@ set /p process=Enter a number and hit return.
         :: let the user know we're on it!
         :webreadytoserve
         echo Getting your site ready...
-        echo You may need to reload the web page once this server is running.
 
         :: Two routes to go: with or without a baseurl
         if "%baseurl%"=="" goto servewithoutbaseurl
 
             :: Route 1, for serving with a baseurl
             :servewithbaseurl
-
-                :: Open the web browser
-                :: (This is before jekyll s, because jekyll s pauses the script.)
-                start "" "http://127.0.0.1:4000/%baseurl%/"
 
                 :: Run Jekyll, with MathJax enabled if necessary
                 if not "%webmathjax%"=="y" goto webnomathjax
@@ -329,10 +324,6 @@ set /p process=Enter a number and hit return.
 
             :: Route 2, for serving without a baseurl
             :servewithoutbaseurl
-
-                :: Open the web browser
-                :: (This is before jekyll s, because jekyll s pauses the script.)
-                start "" "http://127.0.0.1:4000/"
 
                 :: Run Jekyll, with MathJax enabled if necessary
                 if not "%webmathjax%"=="y" goto webnomathjax


### PR DESCRIPTION
Ever since https://github.com/electricbookworks/electric-book/pull/397, if you have any `baseurl` defined in `_config.yml`, the output script opens the browser to localhost without the `baseurl` in the URL, which is pointless because there is no site there.

This removes the browser-launch, because it is less inconvenient to have to copy the correct site URL from Jekyll's prompt in the terminal than to have your browser open a tab at the incorrect URL.