### PR TITLE
Allow underline for content links for accessibility

### DIFF
--- a/_sass/partials/_epub-base-typography.scss
+++ b/_sass/partials/_epub-base-typography.scss
@@ -174,7 +174,6 @@ $epub-base-typography: true !default;
     // Links
 
     a {
-        text-decoration: none;
         color: $color-links;
     }
 

--- a/_sass/partials/_epub-index.scss
+++ b/_sass/partials/_epub-index.scss
@@ -15,15 +15,20 @@ $epub-index: true !default;
             li {
                 margin: 0;
             }
-            a:after {
-                content: ", ";
-            }
-            a:last-of-type:after {
-                content: "";
-            }
-            a.indexed {
-                color: inherit;
+
+            a {
                 text-decoration: none;
+
+                &:after {
+                    content: ", ";
+                }
+                &:last-of-type:after {
+                    content: "";
+                }
+                &.indexed {
+                    color: inherit;
+                    text-decoration: none;
+                }
             }
         }
     }

--- a/_sass/partials/_epub-toc.scss
+++ b/_sass/partials/_epub-toc.scss
@@ -4,29 +4,47 @@ $epub-toc: true !default;
 	// Tables of contents
 
 	.contents-page {
+
 		#content { // Only applies to #content in contents-page, i.e. not to the nav or footer
+
 			ol, ul {
 				list-style-type: none;
 				margin: 0;
 				padding: 0;
-				ol, ul {
-					margin-left: $paragraph-indent;
+
+				li {
+
+					ol, ul {
+						margin-left: $paragraph-indent;
+					}
+
+					a {
+						text-decoration: none;
+					}
 				}
 			}
 		} // #content
 	} // .contents-page
 
-		/* TOCs in individual pages, created in kramdown with a placeholder ol/ul followed by {:toc} */
+	// TOCs in individual pages, created in kramdown
+	// with a placeholder ol/ul followed by {:toc}
 
 	#content {
+
 		#markdown-toc, .markdown-toc {
 			font-family: $font-text-secondary;
 			list-style-type: none;
 			margin: $line-height-default 0;
+
 			li {
 				margin: 0;
+
 				ol, ul {
 					margin-bottom: $line-height-default;
+				}
+
+				a {
+					text-decoration: none;
 				}
 			}
 		} // #markdown-toc
@@ -36,5 +54,4 @@ $epub-toc: true !default;
 	nav[hidden] {
 		display: none;
 	}
-
 }

--- a/_sass/partials/_web-base-typography.scss
+++ b/_sass/partials/_web-base-typography.scss
@@ -157,7 +157,6 @@ $web-base-typography: true !default;
     // Links
 
     a {
-        text-decoration: none;
         color: $color-links;
     }
 

--- a/_sass/partials/_web-bookmarks.scss
+++ b/_sass/partials/_web-bookmarks.scss
@@ -178,6 +178,7 @@ $web-bookmarks: true !default;
 
                     a {
                         color: $color-links;
+                        text-decoration: none;
                     }
 
                     .bookmark-title {
@@ -415,6 +416,7 @@ $web-bookmarks: true !default;
 
         a {
             color: $color-links;
+            text-decoration: none;
             white-space: nowrap;
         }
 

--- a/_sass/partials/_web-index.scss
+++ b/_sass/partials/_web-index.scss
@@ -7,25 +7,34 @@ $web-index: true !default;
     ul.reference-index {
         margin-left: $paragraph-indent;
         list-style-type: none;
+
         ul, ol {
             list-style-type: none;
         }
+
         li {
             text-indent: -($paragraph-indent);
+
             li {
                 margin: 0;
             }
-            a:after {
-                content: ", ";
-            }
-            a:last-of-type:after {
-                content: "";
-            }
-            a.indexed {
-                color: inherit;
+
+            a {
                 text-decoration: none;
+
+                &:after {
+                    content: ", ";
+                }
+                &:last-of-type:after {
+                    content: "";
+                }
+                &.indexed {
+                    color: inherit;
+                    text-decoration: none;
+                }
             }
         }
+
         .duplicate {
             display: none;
         }

--- a/_sass/partials/_web-masthead.scss
+++ b/_sass/partials/_web-masthead.scss
@@ -17,7 +17,9 @@ $web-masthead: true !default;
         }
         a {
             color: $masthead-text-color;
+            text-decoration: none;
         }
+
         ul {
             list-style-type: none;
             margin: 0 auto;

--- a/_sass/partials/_web-notes.scss
+++ b/_sass/partials/_web-notes.scss
@@ -50,6 +50,10 @@ $web-notes: true !default;
 
     .footnotes {
         color: $color-text-secondary;
+
+        .reversefootnote {
+            text-decoration: none;
+        }
     }
 
     .footnote-detail {

--- a/_sass/partials/_web-pagination.scss
+++ b/_sass/partials/_web-pagination.scss
@@ -8,6 +8,11 @@ $web-pagination: true !default;
         padding: $line-height-default;
         max-width: $max-width-default / 2;
         margin: auto;
+
+        a {
+            text-decoration: none;
+        }
+
         .pagination-previous {
             float: left;
             a {

--- a/_sass/partials/_web-toc.scss
+++ b/_sass/partials/_web-toc.scss
@@ -4,33 +4,53 @@ $web-toc: true !default;
 	// Tables of contents
 
 	.contents-page {
+
 		#content { // Only applies to #content in contents-page, i.e. not to the nav or footer
+
 			ol, ul {
 				list-style-type: none;
 				margin: 0;
 				padding: 0;
-				ol, ul {
-					margin-left: $paragraph-indent;
+
+				li {
+
+					ol, ul {
+						margin-left: $paragraph-indent;
+					}
+
+					a {
+						text-decoration: none;
+					}
 				}
 			}
 		} // #content
 	} // .contents-page
 
-		/* TOCs in individual pages, created in kramdown with a placeholder ol/ul followed by {:toc} */
+
+	// TOCs in individual pages, created in kramdown
+	// with a placeholder ol/ul followed by {:toc}
 
 	#content {
+
 		#markdown-toc, .markdown-toc {
 			font-family: $font-text-secondary;
 			list-style-type: none;
 			border: $rule-thickness solid $color-mid;
 			padding: ($line-height-default / 2) ($paragraph-indent / 2);
 			margin: 0 0 $line-height-default 0;
+
 			li {
 				margin: 0;
+
 				ol, ul {
 					margin-bottom: 0;
 				}
+
+				a {
+					text-decoration: none;
+				}
 			}
+
 			&.markdown-toc-wide {
 				box-sizing: border-box;
 				float: none;


### PR DESCRIPTION
Early in the template's life I made the opinionated decision to turn off underline on all links. This is not a good accessibility decision to make by default, and is more opinionated than I'd like the template to be. 

So this change removes the default `a { text-decoration: none; }` and makes adjustments to links that should not have underline accordingly.
