### PR TITLE
Simpler JS and fonts in epub

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -152,6 +152,16 @@ epub:
     project-name: false
     # Override the language in epub OPF metadata (use a subtag, e.g. en)
     language: ""
+  # ----------
+  # Javascript
+  # ----------
+  # Javascript in bundle.js is included by default.
+  # If your epub should not include any Javascript,
+  # set disabled to true. This does not disable MathJax.
+  # Enable or disable MathJax in _config.
+  # You may also want to exclude js in _config.epub.yml.
+  javascript:
+    disabled: false
 
 # ----------------------------------------------------------
 # App settings

--- a/_docs/advanced/javascript.md
+++ b/_docs/advanced/javascript.md
@@ -9,13 +9,11 @@ categories: advanced
 * Page contents
 {:toc}
 
-Unless there's a good reason to put them elsewhere, scripts should live in `assets/js`. In addition, scripts for epub output should be in `_epub/js`, [as described below](#adding-scripts-to-epubs).
+Unless there's a good reason to put them elsewhere, scripts should live in `assets/js`, and be included in `bundle.js`, and not added separately. This is especially important in epubs. (More on [scripts in epubs below](#adding-scripts-to-epubs).
 
-To add them to your `<head>` elements, add `<script>` tags to `_includes/head-elements`. 
+If you must add scripts that are not included in bundle.js, add them to your `<head>` elements by adding `<script>` tags to `_includes/head-elements`. And to add them just before the `</body>` tag, add `<script>` tags to `_includes/end-elements`.
 
-To add them just before the `</body>` tag, add `<script>` tags to `_includes/end-elements`. 
-
-You can also link to remote scripts here, without the need to place the actual scripts in the `js` folder.
+For web outputs, you can also link to remote scripts this way, without the need to save the actual scripts in the `js` folder.
 
 Keep in mind that anything you add to `head-elements` will be added to all books in the project folder, and to all their formats.
 
@@ -44,30 +42,8 @@ To limit a script to a given output format, use `site.output`:
 ```
 {% endraw %}
 
-## Adding scripts to epubs
+## Scripts in epub
 
-Scripts in epub are special. While web and PDF scripts should be in `/assets/js`, all scripts to be used in your epub should be in `_epub/js`. This is because you must not have any scripts in your epub that you aren't using, or it won't validate. By keeping epub scripts separate, only your epub scripts will end up in the epub package.
+All scripts to be used in your epub should be included in `assets/js/bundle/js`, and not added to pages as separate files. This is because you must not have any scripts in your epub that you aren't using, or it won't validate; and we only support including `bundle.js` in epub output.
 
-Also, epub scripts must have a YAML frontmatter block, and use a layout with no HTML:
-
-``` md
----
-layout: min
----
-```
-
-This block tells Jekyll to process the script, which means it knows about it, which the epub packager needs in order to include it in the epub manifest.
-
-### Linking to scripts for epub
-
-In the finished epub, these scripts will end up in a `js` folder alongside `text`, `styles`, `images` and `fonts`. So all links to scripts that you want to include in epub output should be in `site.output == "epub"` tags.
-
-To ensure that links to scripts work from both parent-language and translation-language files, use the {% raw %}`{{ path-to-book-directory }}`{% endraw %} tag in the path to the epub scripts:
-
-{% raw %}
-``` html
-{% if site.output == "epub" %}
-<script src="{{ path-to-book-directory }}js/foo.js"></script>
-{% endif %}
-```
-{% endraw %}
+If you don't want any Javsacript at all in your epub, you can disable it in `_data/settings.yml` by setting `epub` > `javascript` > `enabled` to `false`.You should then also exclude `assets/js/bundle.js` in the exclude list in `_configs/_config.epub.yml`.

--- a/_docs/advanced/javascript.md
+++ b/_docs/advanced/javascript.md
@@ -44,6 +44,6 @@ To limit a script to a given output format, use `site.output`:
 
 ## Scripts in epub
 
-All scripts to be used in your epub should be included in `assets/js/bundle/js`, and not added to pages as separate files. This is because you must not have any scripts in your epub that you aren't using, or it won't validate; and we only support including `bundle.js` in epub output.
+All scripts to be used in your epub should be included in `assets/js/bundle.js`, and not added to pages as separate files. This is because you must not have any scripts in your epub that you aren't using, or it won't validate; and we only support including `bundle.js` in epub output.
 
 If you don't want any Javsacript at all in your epub, you can disable it in `_data/settings.yml` by setting `epub` > `javascript` > `enabled` to `false`.You should then also exclude `assets/js/bundle.js` in the exclude list in `_configs/_config.epub.yml`.

--- a/_docs/output/epub-output.md
+++ b/_docs/output/epub-output.md
@@ -48,14 +48,13 @@ Your epub will build correctly only if you have provided sufficient, accurate in
 
 ## Fonts
 
-To embed fonts in an epub:
+To embed font files in an epub (for `@import`ing in your epub's CSS), add the font files to `_epub/fonts`.
 
-1. add the font files to `_epub/fonts`;
-2. list the font files in `_data/settings.yml` at `epub-fonts`.
+Font files stored anywhere else in your project (e.g. in `assets/fonts`) are not included in epub outputs. This ensures that the epub includes only those font files that are specifically required for your epub.
 
 ## Javascript
 
-Add any scripts to `_epub/js`. See the [Javascript](../advanced/javascript.html) section for more detail.
+See the [Javascript](../advanced/javascript.html) section for more detail.
 
 ## Validation
 

--- a/_epub/js/.gitignore
+++ b/_epub/js/.gitignore
@@ -1,2 +1,0 @@
-# Don't ignore this file
-!.gitignore

--- a/_includes/close-body.html
+++ b/_includes/close-body.html
@@ -1,3 +1,5 @@
+{% comment %} The path to bundle.js differs in epub, because of how
+epubs are constructed after Jekyll processing. {% endcomment %}
 {% if site.output == "epub" %}
     {% unless site.data.settings.epub.javascript.disabled == true %}
         <script src="{{ path-to-book-directory }}js/bundle.js"></script>

--- a/_includes/close-body.html
+++ b/_includes/close-body.html
@@ -1,6 +1,10 @@
-{% unless site.output == "epub" %}
-	<script src="{{ path-to-root-directory }}assets/js/bundle.js"></script>
-{% endunless %}
+{% if site.output == "epub" %}
+    {% unless site.data.settings.epub.javascript.disabled == true %}
+        <script src="{{ path-to-book-directory }}js/bundle.js"></script>
+    {% endunless %}
+{% else %}
+    <script src="{{ path-to-root-directory }}assets/js/bundle.js"></script>
+{% endif %}
 
 {% if site.output == "web" or site.output == "app" %}
     {% if is-project-search or is-book-search %}

--- a/_includes/epub-package
+++ b/_includes/epub-package
@@ -85,12 +85,12 @@
             {% endfor %}
 
             {% capture properties %}
-                {% if site.mathjax-enabled == true or epub-scripts-exist == true %}scripted {% endif %}
+                {% if site.mathjax-enabled == true or epub-scripts-disabled != true %}scripted {% endif %}
                 {% if manifest-epub-file-name == epub-contents-page %}nav {% endif %}
             {% endcapture %}
             {% capture properties %}{{ properties | strip_newlines | strip }}{% endcapture %}
 
-            {% comment %}If the file starts with a number, 
+            {% comment %}If the file starts with a number,
             create a prefix for when we use it as an id,
             which can't start with a number.{% endcomment %}
             {% capture file-first-character %}{{ manifest-epub-file-name | strip | truncate: 1, "" }}{% endcapture %}
@@ -107,8 +107,8 @@
                   {% assign file-prefix = "file-" %}
             {% endif %}
 
-        <item id="{% if file-prefix %}{{ file-prefix }}{% endif %}{{ manifest-epub-file-name | strip }}" 
-              media-type="application/xhtml+xml" 
+        <item id="{% if file-prefix %}{{ file-prefix }}{% endif %}{{ manifest-epub-file-name | strip }}"
+              media-type="application/xhtml+xml"
               href="{% if is-translation == true %}{{ book-subdirectory }}/{% endif %}text/{{ manifest-epub-file-name | strip }}.html"
               {% if properties != "" %}properties="{{ properties }}"{% endif %}
               />
@@ -117,14 +117,14 @@
 
         {% comment %}Add the stylesheet{% endcomment %}
 
-        <item id="epub-css" 
-              media-type="text/css" 
+        <item id="epub-css"
+              media-type="text/css"
               href="styles/{{ epub-stylesheet }}"
               />
 
         {% if is-translation and translation-styles-exist %}
-        <item id="epub-css-{{ book-subdirectory }}" 
-              media-type="text/css" 
+        <item id="epub-css-{{ book-subdirectory }}"
+              media-type="text/css"
               href="{{ book-subdirectory }}/styles/{{ epub-stylesheet }}"
               />
         {% endif %}
@@ -144,7 +144,7 @@
 
             {% assign file-extension = file.extname | remove: "." %}
 
-            <item id="image-{{ file.name | slugify }}" 
+            <item id="image-{{ file.name | slugify }}"
                   media-type="{{ site.media-types[file-extension] }}"
                   href="{% if is-translation and translated-images-exist %}{{ book-subdirectory }}/{% endif %}images/epub/{{ file.name }}"
                   {% if properties != "" %}properties="{{ properties }}"{% endif %}
@@ -174,31 +174,35 @@
 
         {% endfor %}
 
-        {% comment %}Add epub fonts listed in settings.{% endcomment %}
-        {% for font in site.data.settings.epub.fonts %}
+        {% comment %}Add epub font files in _epub/fonts.{% endcomment %}
+        {% for collection in site.collections %}
+            {% if collection.label == "epub" %}
+                {% for file in collection.files %}
+                    {% if file.path contains "_epub/fonts/" %}
 
-            {% capture file-name %}{{ font | split: "." | first }}{% endcapture %}
-            {% capture file-extension %}{{ font | split: "." | last }}{% endcapture %}
+                        {% capture file-basename %}{{ file.name | split: "." | first }}{% endcapture %}
+                        {% capture file-extension %}{{ file.name | split: "." | last }}{% endcapture %}
 
-            <item id="font-{{ file-name }}" 
-                  media-type="{{ site.media-types[file-extension] }}"
-                  href="{% if is-translation and translated-images-exist %}{{ book-subdirectory }}/{% endif %}fonts/{{ font }}"
-                  />
+                        <item id="font-{{ file-basename }}"
+                            media-type="{{ site.media-types[file-extension] }}"
+                            href="fonts/{{ file.name }}"
+                            />
 
-        {% endfor %}
-
-        {% comment %}Add scripts if any exist in _epub/js{% endcomment %}
-        {% for file in site.epub %}
-            {% capture file-extension %}{{ file.path | split: "." | last }}{% endcapture %}
-            {% if file-extension == "js" %}
-
-                <item id="script-{{ file.title | slugify }}"
-                      media-type="application/x-javascript"
-                      href="{% if is-translation %}{{ book-subdirectory }}/{% endif %}js/{{ file.path | split: "/" | last }}"
-                      />
-
+                    {% endif %}
+                {% endfor %}
             {% endif %}
         {% endfor %}
+
+        {% comment %} If this epub has JS enabled, include an entry for bundle.js. {% endcomment %}
+        {% unless site.data.settings.epub.javascript.disabled == true %}
+
+            {% comment %} Add the default bundle.js Javascript {% endcomment %}
+            <item id="script-bundle"
+                    media-type="application/x-javascript"
+                    href="js/bundle.js"
+                    />
+
+        {% endunless %}
 
         {% comment %}If we're using mathjax, add the mathjax-manifest{% endcomment %}
         {% if site.mathjax-enabled == true %}
@@ -230,7 +234,7 @@
                 {% endif %}
             {% endfor %}
 
-            {% comment %}If the file starts with a number, 
+            {% comment %}If the file starts with a number,
             create a prefix for when we use it as an id,
             which can't start with a number.{% endcomment %}
             {% capture file-first-character %}{{ epub-file-name | truncate: 1, "" }}{% endcapture %}
@@ -275,7 +279,7 @@
         {% for file in epub-file-list %}
 
             {% comment %}If the file list entry is a hash, add it to the guide,
-            with the hash value as the value.{% endcomment %} 
+            with the hash value as the value.{% endcomment %}
             {% for file-hash in file %}
 
                 {% if file-hash[0] %}
@@ -367,7 +371,7 @@
                     {% endif %}
 
                 {% if reference-type and reference-type != "" %}
-                <reference type="{{ reference-type }}" 
+                <reference type="{{ reference-type }}"
                            href="{% if is-translation %}{{ book-subdirectory }}/{% endif %}text/{{ file-href }}.html"
                            {% if reference-title and reference-title != "" %}title="{{ reference-title }}"{% endif %}
                 />

--- a/_includes/metadata
+++ b/_includes/metadata
@@ -938,16 +938,10 @@ guarantee that the template is in a new state.{% endcomment %}
   {% assign is-docs-page = true %}
 {% endif %}
 
-{% comment %}Check for existence of scripts in _epub/js.
-Note that we can't do this for fonts, because fonts are not
-processed as documents by Jekyll, and aren't accessible that way.{% endcomment %}
-{% assign epub-scripts-exist = false %}
-{% for file in site.epub %}
-  {% if file.path contains "_epub/js/" %}
-    {% assign epub-scripts-exist = true %}
-  {% endif %}
-  {% break %}
-{% endfor %}
+{% comment %}Check if epub Javascript is disabled.{% endcomment %}
+{% if site.data.settings.epub.javascript.disabled == true %}
+    {% assign epub-scripts-disabled = true %}
+{% endif %}
 
 {% comment %} Localisation {% endcomment %}
 

--- a/_includes/page-info
+++ b/_includes/page-info
@@ -217,4 +217,4 @@ See all the metadata gathered for a given page.
 
 |       Description       |              Source              |   Output tag   |   Current result   |   Type  |
 |-------------------------|----------------------------------|----------------|--------------------|---------|
-| Are there epub scripts? | Detected from path to `_epub/js` | `epub-scripts-exist` | {{ epub-scripts-exist }} | Boolean |
+| Is Javascript disabled in epub output? JS is enabled by default. | Set in `_data/settings.yml` | `epub-scripts-disabled` | {{ epub-scripts-disabled }} | Boolean |

--- a/_tools/update/files.txt
+++ b/_tools/update/files.txt
@@ -575,7 +575,6 @@ _docs/troubleshooting/troubleshooting.md
 # when generating epub files.
 
 _epub/fonts/.gitignore
-_epub/js/.gitignore
 _epub/META-INF/com.apple.ibooks.display-options.xml
 _epub/META-INF/container.xml
 _epub/mimetype

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -85,3 +85,7 @@ have different behaviour for web or app. {% endcomment %}
     {% include_relative page-reference.js %}
 
 {% endif %}
+
+{% if site.output == "epub" %}
+    {% include_relative show-hide.js %}
+{% endif %}

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -280,7 +280,7 @@ Enter a number and hit enter. "
 			then
 			bookfolder="book"
 		fi
-		echo "Okay, let's make epub-ready files using $bookfolder..."
+		echo "Okay, let's make an epub of $bookfolder..."
 		# Ask if we're outputting the files from a subdirectory (e.g. a translation)
 		echo "If you're outputting files in a subdirectory (e.g. a translation), type its name. Otherwise, hit enter. "
 		read epubsubdirectory
@@ -322,31 +322,33 @@ Enter a number and hit enter. "
 
 			# Now to assemble the epub
 			echo "Assembling epub..."
-			# Check if there are fonts to include
+			# Check if there are fonts to include.
+			# We check for font extensions to avoid false positives
+			# from files like .gitignore and font licences.
 			echo "Checking for fonts to include..."
 			epubfonts=""
-			countttf=`ls -1 fonts/*.ttf 2>/dev/null | wc -l`
-			if [ $countttf != 0 ]; then 
+			countttf=`ls -1 _epub/fonts/*.ttf 2>/dev/null | wc -l`
+			if [ $countttf != 0 ]; then
 				epubfonts="y"
 			fi
-			countotf=`ls -1 fonts/*.otf 2>/dev/null | wc -l`
-			if [ $countotf != 0 ]; then 
+			countotf=`ls -1 _epub/fonts/*.otf 2>/dev/null | wc -l`
+			if [ $countotf != 0 ]; then
 				epubfonts="y"
 			fi
-			countwoff=`ls -1 fonts/*.woff 2>/dev/null | wc -l`
-			if [ $countwoff != 0 ]; then 
+			countwoff=`ls -1 _epub/fonts/*.woff 2>/dev/null | wc -l`
+			if [ $countwoff != 0 ]; then
 				epubfonts="y"
 			fi
-			countwoff2=`ls -1 fonts/*.woff2 2>/dev/null | wc -l`
-			if [ $countwoff2 != 0 ]; then 
+			countwoff2=`ls -1 _epub/fonts/*.woff2 2>/dev/null | wc -l`
+			if [ $countwoff2 != 0 ]; then
 				epubfonts="y"
 			fi
 			# Check if there are scripts to include
 			echo "Checking for scripts to include..."
-			epubscripts=""
-			countjs=`ls -1 js/*.js 2>/dev/null | wc -l`
-			if [ $countjs != 0 ]; then 
-				epubscripts="y"
+			epubscripts="y"
+			countjs=`ls -1 "$location"/_site/assets/js/bundle.js 2>/dev/null | wc -l`
+			if [ $countjs = 0 ]; then
+				epubscripts=""
 			fi
 			# Copy text (files in file-list only), images, fonts, styles, package.opf and toc.ncx to epub
 			cd "$location"/_site/"$bookfolder"
@@ -362,10 +364,6 @@ Enter a number and hit enter. "
 				if [ -d "$location"/_site/items/images/epub ]; then
 					echo "Found images in _items. Copying to epub..."
 					mkdir -p "$location"/_site/epub/items/images/epub && cp -a "$location"/_site/items/images/epub/. "$location"/_site/epub/items/images/epub/
-				fi
-				if [ "$epubfonts" = "y" ]; then
-					echo "Copying fonts..."
-					mkdir -p "$location"/_site/epub/fonts && cp -a "$location"/_site/$bookfolder/fonts/. "$location"/_site/epub/fonts/
 				fi
 				if [ -d "$location"/_site/$bookfolder/styles ]; then
 					echo "Copying styles..."
@@ -439,7 +437,7 @@ Enter a number and hit enter. "
 			fi
 			if [ "$epubscripts" = "y" ]; then
 				echo "Copying Javascript..."
-				mkdir "$location"/_site/epub/js && cp -a "$location"/_site/js/. "$location"/_site/epub/js/
+				mkdir "$location"/_site/epub/js && cp -a "$location"/_site/assets/js/bundle.js "$location"/_site/epub/js/bundle.js
 			fi
 			# Convert all .html files and internal links to .xhtml
 			echo "Renaming .html to .xhtml..."
@@ -524,21 +522,9 @@ Enter a number and hit enter. "
 					fi
 				fi
 			fi
-			# Add either the parent fonts folder or the translation's fonts folder.
-			# If the translation has a fonts folder, use it. Otherwise, use the parent's
-			# fonts for the translation.
-			if [ "$epubsubdirectory" = "" ]; then
-					if [ -d fonts ]; then
-						cp -a "fonts" "$location/_output/$epubfilename/"
-					fi
-				else
-					if [ -d "$epubsubdirectory/fonts" ]; then
-						cp -a "$epubsubdirectory/fonts" "$location/_output/$epubfilename/$epubsubdirectory/"
-					else
-						if [ -d fonts ]; then
-							cp -a "fonts" "$location/_output/$epubfilename/"
-						fi
-					fi
+			# Add the fonts folder.
+			if [ -d fonts ]; then
+				cp -a "fonts" "$location/_output/$epubfilename/"
 			fi
 			# Add the parent styles folder and the translation's styles folder if it exists.
 			if [ "$epubsubdirectory" = "" ]; then
@@ -560,10 +546,10 @@ Enter a number and hit enter. "
 					cp -a "mathjax" "$location/_output/$epubfilename/"
 				fi
 			fi
-			# If there is a Javascript folder, add it to the epub.
+			# If there is a Javascript bundle, add it to the epub.
 			# Scripts always go to the same place in the epub root, even in translations.
 			if [ -d js ]; then
-				cp -a "js" "$location/_output/$epubfilename/"
+				mkdir "$location"/_output/$epubfilename/js && cp -a "js/bundle.js" "$location/_output/$epubfilename/js/bundle.js"
 			fi
 			# Add the mimetype file
 			if [ -e mimetype ]; then
@@ -844,7 +830,7 @@ Enter a number and hit enter. "
 				then
 				fromformat="epub"
 				wordformatchoice="1"
-			else				
+			else
 				wordformatchoice=""
 			fi
 		done

--- a/run-mac.command
+++ b/run-mac.command
@@ -283,7 +283,7 @@ Enter a number and hit enter. "
 			then
 			bookfolder="book"
 		fi
-		echo "Okay, let's make epub-ready files using $bookfolder..."
+		echo "Okay, let's make an epub of $bookfolder..."
 		# Ask if we're outputting the files from a subdirectory (e.g. a translation)
 		echo "If you're outputting files in a subdirectory (e.g. a translation), type its name. Otherwise, hit enter. "
 		read epubsubdirectory
@@ -325,31 +325,33 @@ Enter a number and hit enter. "
 
 			# Now to assemble the epub
 			echo "Assembling epub..."
-			# Check if there are fonts to include
+			# Check if there are fonts to include.
+			# We check for font extensions to avoid false positives
+			# from files like .gitignore and font licences.
 			echo "Checking for fonts to include..."
 			epubfonts=""
-			countttf=`ls -1 fonts/*.ttf 2>/dev/null | wc -l`
-			if [ $countttf != 0 ]; then 
+			countttf=`ls -1 _epub/fonts/*.ttf 2>/dev/null | wc -l`
+			if [ $countttf != 0 ]; then
 				epubfonts="y"
 			fi
-			countotf=`ls -1 fonts/*.otf 2>/dev/null | wc -l`
-			if [ $countotf != 0 ]; then 
+			countotf=`ls -1 _epub/fonts/*.otf 2>/dev/null | wc -l`
+			if [ $countotf != 0 ]; then
 				epubfonts="y"
 			fi
-			countwoff=`ls -1 fonts/*.woff 2>/dev/null | wc -l`
-			if [ $countwoff != 0 ]; then 
+			countwoff=`ls -1 _epub/fonts/*.woff 2>/dev/null | wc -l`
+			if [ $countwoff != 0 ]; then
 				epubfonts="y"
 			fi
-			countwoff2=`ls -1 fonts/*.woff2 2>/dev/null | wc -l`
-			if [ $countwoff2 != 0 ]; then 
+			countwoff2=`ls -1 _epub/fonts/*.woff2 2>/dev/null | wc -l`
+			if [ $countwoff2 != 0 ]; then
 				epubfonts="y"
 			fi
 			# Check if there are scripts to include
 			echo "Checking for scripts to include..."
-			epubscripts=""
-			countjs=`ls -1 js/*.js 2>/dev/null | wc -l`
-			if [ $countjs != 0 ]; then 
-				epubscripts="y"
+			epubscripts="y"
+			countjs=`ls -1 "$location"/_site/assets/js/bundle.js 2>/dev/null | wc -l`
+			if [ $countjs = 0 ]; then
+				epubscripts=""
 			fi
 			# Copy text (files in file-list only), images, fonts, styles, package.opf and toc.ncx to epub
 			cd "$location"/_site/"$bookfolder"
@@ -365,10 +367,6 @@ Enter a number and hit enter. "
 				if [ -d "$location"/_site/items/images/epub ]; then
 					echo "Found images in _items. Copying to epub..."
 					mkdir -p "$location"/_site/epub/items/images/epub && cp -a "$location"/_site/items/images/epub/. "$location"/_site/epub/items/images/epub/
-				fi
-				if [ "$epubfonts" = "y" ]; then
-					echo "Copying fonts..."
-					mkdir -p "$location"/_site/epub/fonts && cp -a "$location"/_site/$bookfolder/fonts/. "$location"/_site/epub/fonts/
 				fi
 				if [ -d "$location"/_site/$bookfolder/styles ]; then
 					echo "Copying styles..."
@@ -442,7 +440,7 @@ Enter a number and hit enter. "
 			fi
 			if [ "$epubscripts" = "y" ]; then
 				echo "Copying Javascript..."
-				mkdir "$location"/_site/epub/js && cp -a "$location"/_site/js/. "$location"/_site/epub/js/
+				mkdir "$location"/_site/epub/js && cp -a "$location"/_site/assets/js/bundle.js "$location"/_site/epub/js/bundle.js
 			fi
 			# Convert all .html files and internal links to .xhtml
 			echo "Renaming .html to .xhtml..."
@@ -527,21 +525,9 @@ Enter a number and hit enter. "
 					fi
 				fi
 			fi
-			# Add either the parent fonts folder or the translation's fonts folder.
-			# If the translation has a fonts folder, use it. Otherwise, use the parent's
-			# fonts for the translation.
-			if [ "$epubsubdirectory" = "" ]; then
-					if [ -d fonts ]; then
-						cp -a "fonts" "$location/_output/$epubfilename/"
-					fi
-				else
-					if [ -d "$epubsubdirectory/fonts" ]; then
-						cp -a "$epubsubdirectory/fonts" "$location/_output/$epubfilename/$epubsubdirectory/"
-					else
-						if [ -d fonts ]; then
-							cp -a "fonts" "$location/_output/$epubfilename/"
-						fi
-					fi
+			# Add the fonts folder.
+			if [ -d fonts ]; then
+				cp -a "fonts" "$location/_output/$epubfilename/"
 			fi
 			# Add the parent styles folder and the translation's styles folder if it exists.
 			if [ "$epubsubdirectory" = "" ]; then
@@ -563,10 +549,10 @@ Enter a number and hit enter. "
 					cp -a "mathjax" "$location/_output/$epubfilename/"
 				fi
 			fi
-			# If there is a Javascript folder, add it to the epub.
+			# If there is a Javascript bundle, add it to the epub.
 			# Scripts always go to the same place in the epub root, even in translations.
 			if [ -d js ]; then
-				cp -a "js" "$location/_output/$epubfilename/"
+				mkdir "$location"/_output/$epubfilename/js && cp -a "js/bundle.js" "$location/_output/$epubfilename/js/bundle.js"
 			fi
 			# Add the mimetype file
 			if [ -e mimetype ]; then
@@ -845,7 +831,7 @@ Enter a number and hit enter. "
 				then
 				fromformat="epub"
 				wordformatchoice="1"
-			else				
+			else
 				wordformatchoice=""
 			fi
 		done

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -353,7 +353,7 @@ set /p process=Enter a number and hit return.
     :epub
 
         :: Encouraging message
-        echo Okay, let's make an epub.
+        echo Okay, let's make an epub of %bookfolder%...
         :: Remember where we are by assigning a variable to the current directory
         set location=%~dp0
         
@@ -560,13 +560,12 @@ set /p process=Enter a number and hit return.
         :: Go into _site/epub to move some more files and then zip to _output
         cd %location%_site/epub
 
-        :: If there is a js folder, and it has no contents, delete it.
-        :: Otherwise, copy the js folder into the epub folder.
+        :: Copy the bundle.js into the epub's js folder.
         :: (JS lives in the root directory even in translations.)
         :epubMoveJS
-            echo Checking for Javascript...
-            if exist "js" if not exist "js\*.*" rd /s /q "js"
-            echo Javascript checked.
+            echo Copying Javascript to epub...
+            robocopy "%location%_site/assets/js" "%location%_site/epub/js" bundle.js /E /NFL /NDL /NJH /NJS /NC /NS
+            echo Javascript copied.
 
         :: If there is a fonts folder, and it has no contents, delete it.
         :: Otherwise, if this is a translation, move the fonts folder
@@ -574,7 +573,6 @@ set /p process=Enter a number and hit return.
         :epubMoveFonts
             echo Checking for fonts...
             if exist "fonts" if not exist "fonts\*.ttf" if not exist "fonts\*.otf" if not exist "fonts\*.woff" if not exist "fonts\*.woff2" rd /s /q "fonts"
-            if not "%subdirectory%"=="" if exist "fonts\*.*" move "fonts" "%subdirectory%\fonts"
             echo Fonts checked.
 
         :: If MathJax required, fetch boilerplate mathjax directory from /assets/js
@@ -638,7 +636,7 @@ set /p process=Enter a number and hit return.
             if exist "mathjax" robocopy "%location%\_site\epub\mathjax" "%location%\_output\%epubFileName%\mathjax" /E /NFL /NDL /NJH /NJS /NC /NS
             if exist "js" robocopy "%location%\_site\epub\js" "%location%\_output\%epubFileName%\js" /E /NFL /NDL /NJH /NJS /NC /NS
 
-            :: Copy text file if this is not a translation
+            :: Copy text directory if this is not a translation
             if not "%subdirectory%"=="" goto epubZipSubdirectory
             if exist "text" robocopy "%location%\_site\epub\text" "%location%\_output\%epubFileName%\text" /E /NFL /NDL /NJH /NJS /NC /NS
             goto epubAddPackageFiles


### PR DESCRIPTION
This makes it easier to add JS and fonts to epubs.

- The usual `bundle.js` is now included in epub output by default.
- There is no need to maintain separate epub JS in `_epub` any more.
- To add fonts, you only need to add the files to `_epub/fonts` (previously, you had to list the font file names in `settings.yml`)