### PR TITLE
Add SVG font-style management

### DIFF
--- a/assets/js/svg-management.js
+++ b/assets/js/svg-management.js
@@ -28,6 +28,20 @@ function ebSVGFontFixes(svg) {
             oldFontFace: 'OpenSans-Bold',
             newFontFace: 'Open Sans',
             newFontWeight: 'bold'
+        },
+        {
+            oldFontFace: 'Inter-Regular',
+            newFontFace: 'Inter'
+        },
+        {
+            oldFontFace: 'Inter-Medium',
+            newFontFace: 'Inter',
+            newFontWeight: '500'
+        },
+        {
+            oldFontFace: 'Inter-Italic',
+            newFontFace: 'Inter',
+            newFontStyle: 'italic'
         }
     ];
 
@@ -46,6 +60,10 @@ function ebSVGFontFixes(svg) {
                     ebFontFixElements[i].setAttribute('font-weight',
                             fontsToChange[j].newFontWeight);
                 }
+                if (fontsToChange[j].newFontStyle) {
+                    ebFontFixElements[i].setAttribute('font-style',
+                        fontsToChange[j].newFontStyle);
+                }
             }
 
             // Change font properties in style attributes
@@ -53,6 +71,9 @@ function ebSVGFontFixes(svg) {
                 ebFontFixElements[i].style.fontFamily = fontsToChange[j].newFontFace;
                 if (ebFontFixElements[i].style.fontWeight) {
                     ebFontFixElements[i].style.fontWeight = fontsToChange[j].newFontWeight;
+                }
+                if (ebFontFixElements[i].style.fontStyle) {
+                    ebFontFixElements[i].style.fontStyle = fontsToChange[j].newFontStyle;
                 }
             }
         }


### PR DESCRIPTION
When we inject SVGs, those SVGs' style attributes often specify fonts differently from how CSS needs them named. For instance, the SVG might include 'OpenSans-Bold', but we need that to be 'Open Sans' with a separate attribute for 'bold', in order for our CSS to apply the correct font.

These mappings are managed in `svg-management.js`. We've long managed font names and weights. This change adds the ability to manage font styles, too (i.e. italic in most cases). Our default `svg-management.js` includes examples to follow when adding new fonts.
