### PR TITLE
Add new rightsholder metadata

### DIFF
--- a/_data/meta.yml
+++ b/_data/meta.yml
@@ -55,6 +55,7 @@ works:
     language: "en" # use ISO 639-1, 639-2, or 639-3 codes (in that order of preference)
     relation: "" # e.g. other edition ISBN
     coverage: "" # e.g. geographic place or chronological time span
+    rightsholder: "" # who owns the copyright?
     rights: "All rights reserved. No part of this book may be reproduced or transmitted in any form or by any electronic or mechanical means, including photocopying and recording, or any other information storage or retrieval system, without written permission from the publisher." # e.g. a copyright statement
     image: "cover.jpg"
     products: # Metadata for each product for this title (only use values that override parent metadata)
@@ -213,6 +214,7 @@ works:
     language: "en" # use ISO 639-1, 639-2, or 639-3 codes (in that order of preference)
     relation: "" # e.g. other edition ISBN
     coverage: "" # e.g. geographic place or chronological time span
+    rightsholder: "" # who owns the copyright?
     rights: "This work is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/). This means you are free to share (copy and redistribute the material in any medium or format) and adapt it (remix, transform, and build upon the material) for any purpose, even commercially, as long as you give appropriate credit, with a link to your source, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use." # e.g. a copyright statement
     products: # Metadata for each product for this title (only use values that override parent metadata)
       print-pdf:

--- a/_includes/metadata
+++ b/_includes/metadata
@@ -219,6 +219,7 @@ and book content as a Liquid output tag e.g. {{ title }}
     {% capture parent-language %}{{ work.language }}{% endcapture %}
     {% capture relation %}{{ work.relation }}{% endcapture %}
     {% capture coverage %}{{ work.coverage }}{% endcapture %}
+    {% capture rightsholder %}{{ work.rightsholder }}{% endcapture %}
     {% capture rights %}{{ work.rights }}{% endcapture %}
     {% capture image %}{{ work.image }}{% endcapture %}
 
@@ -371,6 +372,7 @@ defined in meta.yml for the given translation.
             {% if work.language %}{% capture language %}{{ work.language }}{% endcapture %}{% endif %}
             {% if work.relation %}{% capture relation %}{{ work.relation }}{% endcapture %}{% endif %}
             {% if work.coverage %}{% capture coverage %}{{ work.coverage }}{% endcapture %}{% endif %}
+            {% if work.rightsholder %}{% capture rightsholder %}{{ work.rightsholder }}{% endcapture %}{% endif %}
             {% if work.rights %}{% capture rights %}{{ work.rights }}{% endcapture %}{% endif %}
             {% if work.image %}{% capture image %}{{ work.image }}{% endcapture %}{% endif %}
 
@@ -494,6 +496,7 @@ override any metadata set for that variant.{% endcomment %}
             {% if data.language %}{% capture language %}{{ data.language }}{% endcapture %}{% endif %}
             {% if data.relation %}{% capture relation %}{{ data.relation }}{% endcapture %}{% endif %}
             {% if data.coverage %}{% capture coverage %}{{ data.coverage }}{% endcapture %}{% endif %}
+            {% if data.rightsholder %}{% capture rightsholder %}{{ data.rightsholder }}{% endcapture %}{% endif %}
             {% if data.rights %}{% capture rights %}{{ data.rights }}{% endcapture %}{% endif %}
             {% if data.image %}{% capture image %}{{ data.image }}{% endcapture %}{% endif %}
 

--- a/_includes/page-info
+++ b/_includes/page-info
@@ -77,6 +77,7 @@ See all the metadata gathered for a given page.
 | Book language                         | Defined in `meta.yml` for main book, and overriden there by any `translations` or `variants`, or `variants` of `translations` | `language`      | {{ language }}              | String |
 | Book's relation (i.e. a related work) | Defined in `meta.yml` for main book, and overriden there by any `translations` or `variants`, or `variants` of `translations` | `relation`      | {{ relation }}              | String |
 | Book's coverage                       | Defined in `meta.yml` for main book, and overriden there by any `translations` or `variants`, or `variants` of `translations` | `coverage`      | {{ coverage }}              | String |
+| Book rightsholder                     | Defined in `meta.yml` for main book, and overriden there by any `translations` or `variants`, or `variants` of `translations` | `rightsholder`  | {{ rightsholder }}          | String |
 | Book rights statement                 | Defined in `meta.yml` for main book, and overriden there by any `translations` or `variants`, or `variants` of `translations` | `rights`        | {{ rights }}                | String |
 | Book's image                          | Defined in `meta.yml` for main book, and overriden there by any `translations` or `variants`, or `variants` of `translations` | `image`         | {{ image }}                 | String |
 

--- a/book/text/0-2-copyright.md
+++ b/book/text/0-2-copyright.md
@@ -12,7 +12,7 @@ style: copyright-page
 {:.non-printing}
 
 *{{ title }}*\\
-Text © {{ creator }}
+Text © {% if rightsholder != "" %}{{ rightsholder }}{% else %}{{ creator }}{% endif %}
 
 {% include identifiers scheme="ISBN" %}
 

--- a/samples/text/00-04-copyright-page.md
+++ b/samples/text/00-04-copyright-page.md
@@ -12,7 +12,7 @@ style: copyright-page
 {:.non-printing}
 
 *{{ title }}*\\
-Text © {{ creator }}
+Text © {% if rightsholder != "" %}{{ rightsholder }}{% else %}{{ creator }}{% endif %}
 
 {% include identifiers scheme="ISBN" %}
 


### PR DESCRIPTION
Till now, the template has assumed that the creator/author is the rightsholder, which is often not the case. This lets us set a rightsholder per work, and fall back to creator when there is no rightsholder set.