### PR TITLE
Load images based on src, not srcset

### DIFF
--- a/assets/js/accordion.js
+++ b/assets/js/accordion.js
@@ -336,7 +336,7 @@ function ebAccordionShow(targetID) {
         tabContents.setAttribute('aria-expanded', 'true');
 
         // lazyload the images inside
-        var lazyimages = sectionToShow.querySelectorAll('[data-srcset]');
+        var lazyimages = sectionToShow.querySelectorAll('[data-src]');
 
         // console.log('lazyimages: ' + lazyimages.innerHTML);
 


### PR DESCRIPTION
SVG images added with our image and figure includes do not use `srcset`, so this would not work for them.