### PR TITLE
Do not include assets/fonts in epub output

### DIFF
--- a/_configs/_config.epub.yml
+++ b/_configs/_config.epub.yml
@@ -58,6 +58,7 @@ exclude:
   - /assets/js/bookmarks.js
 
   # Exclude files we don't need for epub
+  - /assets/fonts
   - /*/styles/print-pdf.scss
   - /*/styles/screen-pdf.scss
   - /*/styles/web.scss


### PR DESCRIPTION
Epub fonts are added separately in _epub/fonts, so that unused fonts do not end up in epubs creating epubcheck warnings.