### PR TITLE
Fix select-list display in PDF

### DIFF
--- a/_includes/select
+++ b/_includes/select
@@ -9,16 +9,13 @@ turn it into an array.{% endcomment %}
 <span class="select-list-wrapper">
     <select class="select-list">
 
-        {% comment %}Blank option to start the list{% endcomment %}
-        <option>
+        {% comment %}Blank option to start the list.
+        Do not show placeholders in PDF output – only show blank space.{% endcomment %}
+        <option class="select-list-placeholder">
             {% if include.placeholder and include.placeholder != "" %}
-                {{ include.placeholder }}
-            {% else %}
-                {% comment %}Use at least a no-break space
-                so that Prince gives the select box its width,
-                and does not collapse the empty element.
-                Use a decimal entity for valid EPUB3.{% endcomment %}
-                &#160;
+                {% unless site.output == "print-pdf" or site.output == "screen-pdf" %}
+                    {{ include.placeholder }}
+                {% endunless %}
             {% endif %}
         </option>
 

--- a/_sass/template/partials/_print-select-questions.scss
+++ b/_sass/template/partials/_print-select-questions.scss
@@ -4,9 +4,16 @@ $print-select-questions: true !default;
     // Select lists
 
     .select-list {
-        width: $line-height-default * 3;
         border: 0;
         border-bottom: $rule-thickness solid $color-text-main;
+
+        option {
+
+            &.select-list-placeholder {
+                display: inline-block;
+                min-width: $paragraph-indent * 3;
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Recent addition of the cheerio gulp pre-processing step inserted errant nbsp; text here. This changes the logic to not display placeholders in PDF output.