### PR TITLE
Get running-head title, author from meta.yml 

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -70,6 +70,7 @@ we want the doc name to be the book title, not only the first doc's title.
       data-page-info="{% unless site.data.settings.redact == true %}{{ title | truncate: 20 }}: {{ page.title | truncate: 20 }} • {{ page.url | split: "/" | last | split: "." | first | truncate: 20 }} • {% endunless %}{{ site.time | date: "%-d %b %Y, %H:%M" }}"
       {% if site.data.settings.print-pdf.notes == "footnotes" or page.notes == "footnotes" %} data-page-footnotes{% endif %}
       data-title="{% if title %}{{ title }}{% else %}{{ page.title }}{% endif %}"
+      data-creator="{% if creator %}{{ creator }}{% else %}{{ project.project-organisation }}{% endif %}"
       {% if is-translation %} data-translation="{{ language }}"{% endif %}>
 <div id="wrapper">
 
@@ -105,6 +106,7 @@ we want the doc name to be the book title, not only the first doc's title.
       data-page-info="{{ title | truncate: 20 }}: {{ page.title | truncate: 20 }} • {{ page.url | split: "/" | last | split: "." | first }} • {{ site.time | date: "%-d %b %Y, %H:%M" }}"
       {% if site.data.settings.screen-pdf.notes == "footnotes" or page.notes == "footnotes" %} data-page-footnotes{% endif %}
       data-title="{% if title %}{{ title }}{% else %}{{ page.title }}{% endif %}"
+      data-creator="{% if creator %}{{ creator }}{% else %}{{ project.project-organisation }}{% endif %}"
       {% if is-translation %} data-translation="{{ language }}"{% endif %}>
 <div id="wrapper">
 

--- a/_sass/template/partials/_print-page-headers-footers-content.scss
+++ b/_sass/template/partials/_print-page-headers-footers-content.scss
@@ -13,7 +13,9 @@ $print-page-headers-footers-content: true !default;
       page-header attr(data-header),
       page-header-left attr(data-header-left),
       page-header-right attr(data-header-right),
-      page-info attr(data-page-info);
+      page-info attr(data-page-info),
+      book-creator attr(data-creator),
+      book-title attr(data-title);
   }
 
   // Assign strings to use in headers and footers for each level of heading (h1-h6),

--- a/_sass/template/print-pdf.scss
+++ b/_sass/template/print-pdf.scss
@@ -155,6 +155,8 @@ $frontmatter-reference-style: lower-roman !default; // lower-roman, decimal, see
 //
 // * For no content: normal
 // * For a page number: counter(page)
+// * For the book's title: string(book-title)
+// * For the book's creator (usually the author): string(book-creator)
 // * For the body element's title attribute: string(page-header)
 //   Set this body title attribute with `header: Your Title` in a file's YAML frontmatter.
 //   If you don't set a page header in YAML, string(page-header) will fallback to the page title.

--- a/_sass/template/screen-pdf.scss
+++ b/_sass/template/screen-pdf.scss
@@ -20,6 +20,11 @@
 // Provide a variable for site output
 $output-format: "screen-pdf" !default;
 
+// Theme variables
+@import "theme/colors";
+@import "template/colors";
+@import "theme/print-variables";
+
 // Edition suffix: identifies this edition in page-fitting classes (in _print-fitting.scss).
 // For instance, a .tighten class in HTML might apply to your bookshop edition, but not the schools edition.
 // A suffix '-schools-edn' would mean only tags with that suffix would apply to that edition, e.g. {:.tighten-schools-edn}


### PR DESCRIPTION
Till now, to set the book title or author as a running head (or any margin box text), you had to hard-code that into the book's styles. This means that if a project contains multiple books that share a template or theme design, they each need their own running-head variables set in `[book]/styles/*-pdf.scss`.

This PR creates new options for string-set variables that (in effect) read the author and title from `meta.yml`, so that several books in a project can use the same project styles and get their specific titles and authors in their running heads.

As the code comments note:

* For the book's title, use `string(book-title)`
* For the book's creator (usually the author), use `string(book-creator)`

for the relevant margin box. E.g.:

```
$verso-top: string(book-creator) !default;
$recto-top: string(book-title) !default;
```
