### PR TITLE
Fix whitespace on same-page footnotes inside verse

### DIFF
--- a/_sass/template/partials/_print-verse.scss
+++ b/_sass/template/partials/_print-verse.scss
@@ -54,6 +54,12 @@ $print-verse: true !default;
 	// If verse is in a list, we can preserve line breaks and white space
 	ul.verse li {
 		white-space: pre-wrap;
+
+		// When a footnote is inside verse, do not let
+		// it inherit the pre-wrap
+		.page-footnote {
+			white-space: normal;
+		}
 	}
 	ul.verse li h1,
 	ul.verse li h2,


### PR DESCRIPTION
Our PDF footnotes JS can place endnotes on the same page as footnotes. To achieve this, the script moves the footnote element inside the body-text element containing the footnote reference in the DOM. As a result, the footnote can inherit CSS properties from the footnote-reference's parent element.

As a consequence, footnotes on verse have been getting `white-space: pre-wrap;`, which creates unexpected whitespace behaviour in footnotes. This fixes that.