### PR TITLE
Create setting to make all PDF images grayscale

### DIFF
--- a/_data/images.yml
+++ b/_data/images.yml
@@ -9,3 +9,10 @@
 #
 # Possible values
 # - print-PDF colorspace: cmyk | gray
+#
+# To apply settings to all images at once,
+# use "all" instead of a filename.
+# E.g.
+# - file: "all"
+#   print-pdf:
+#     colorspace: "gray"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -438,7 +438,7 @@ gulp.task('images:printpdf', function (done) {
 
                 // Look up image colour settings
                 imageSettings.forEach(function (image) {
-                    if (image.file === thisFilename) {
+                    if (image.file === thisFilename || image.file == "all") {
                         if (image['print-pdf'].colorspace === 'gray') {
                             thisColorProfile = printPDFColorProfileGrayscale;
                             thisColorSpace = printPDFColorSpaceGrayscale;


### PR DESCRIPTION
In the past, it's been possible to single out specific images to be converted to grayscale for PDF output. The use case was a book that was mostly in colour, but where certain images needed to be in grayscale.

This enhancement makes it possible to make *all* print-PDF images grayscale with a single setting in `images.yml`. Previously, to get this behaviour we had to edit the gulp tasks directly, which is inadvisable and trickier.