### PR TITLE
Add protocol to path for puppeteer

### DIFF
--- a/assets/js/render-book-index.js
+++ b/assets/js/render-book-index.js
@@ -57,7 +57,8 @@ function generateTargetsIndex() {
             }
 
             // Go to the page path.
-            await page.goto(path);
+            // Puppeteer requires the protocol (file://) on OSX.
+            await page.goto('file://' + path);
 
             // Check that any index targets for the page have been processed.
             // This is done by assets/js/index-targets.js (in bundle.js).


### PR DESCRIPTION
While page.goto seems to work without the protocol on Windows, it does not seem to on OSX.

See https://stackoverflow.com/a/52101893/1781075.