### PR TITLE
Fix margin/indent on page footnotes in blockquotes

### DIFF
--- a/_sass/template/partials/_print-notes.scss
+++ b/_sass/template/partials/_print-notes.scss
@@ -70,10 +70,11 @@ $print-notes: true !default;
         }
 
     // Avoid page-footnotes created by footnotes.js
-    // from inheriting blockquote indentation
+    // from inheriting blockquote indentation by
+    // reiterating properties that blockquote might override.
     blockquote .page-footnote {
-        text-indent: 0;
-        margin-left: 0;
+        text-indent: -($line-height-default);
+        margin-left: $line-height-default;
     }
 
     // The page-footnotes area


### PR DESCRIPTION
This fixes an issue I addressed incorrectly in https://github.com/electricbookworks/electric-book/commit/62ff2127590a3163ff3597a2d050a576f0fe7440#diff-18b5b6d4f595eedd343bc5ea59de9b0cb10df72ad1512a9b490293726b06463fR105.