### PR TITLE
Refine which files are excluded from PDF outputs

### DIFF
--- a/_configs/_config.print-pdf.yml
+++ b/_configs/_config.print-pdf.yml
@@ -22,6 +22,7 @@ exclude:
   - package.json
   - package-lock.json
   - CNAME
+  - .sass-cache
 
   # Included as-is in other files, no need to process
   - /assets/js/annotation.js
@@ -56,10 +57,11 @@ exclude:
   - /assets/js/bookmarks.js
 
   # Exclude files we don't need for print-pdf
-  - search*
-  - index*
+  - about.md
+  - contact.md
+  - index.md
+  - search.md
   - /assets/styles
-  - /assets/*.jpg
   - /assets/js/accordion.js
   - /assets/js/annotation.js
   - /assets/js/elasticlunr-setup.js

--- a/_configs/_config.screen-pdf.yml
+++ b/_configs/_config.screen-pdf.yml
@@ -22,6 +22,7 @@ exclude:
   - package.json
   - package-lock.json
   - CNAME
+  - .sass-cache
 
   # Included as-is in other files, no need to process
   - /assets/js/annotation.js
@@ -56,10 +57,11 @@ exclude:
   - /assets/js/bookmarks.js
 
   # Exclude files we don't need for screen-pdf
-  - search*
-  - index*
+  - about.md
+  - contact.md
+  - index.md
+  - search.md
   - /assets/styles
-  - /assets/*.jpg
   - /assets/js/accordion.js
   - /assets/js/annotation.js
   - /assets/js/elasticlunr-setup.js


### PR DESCRIPTION
We do have projects that share images in `assets/images` across PDF-format books, so we should not exclude images in `assets` by default.

There are some files that definitely needn't be included in PDF builds, like web `about` and `contact` pages.