### PR TITLE
Make all figure images max-height, allowing override

### DIFF
--- a/_sass/template/partials/_web-figures.scss
+++ b/_sass/template/partials/_web-figures.scss
@@ -24,20 +24,19 @@ $web-figures: true !default;
         }
         img, p img {
             margin: 0 auto;
+            max-height: 80vh;  // ensure figures are always visible
             max-width: 100%; 
             object-fit: contain;
             display: block;
         }
-        @media screen and (max-height: $break-height-small) {
+
+        // Enable removing max-height on a figure's images
+        &.web-max-height-none {
             img, p img {
-                max-height: $break-height-small / 2;
+                max-height: none;
             }
         }
-        @media screen and (max-height: ($break-height-small * 0.7)) {
-            img, p img {
-                max-height: $break-height-small * 0.35;
-            }
-        }
+
         .figure-body {
             .figure-images {
                 text-align: center;


### PR DESCRIPTION
Sometimes portrait-orientation images are too tall to fit in one screen. We need to limit their height so that the user doesn't need to scroll to see the whole image. However, some figures' images *do* need to be taller than the viewport to be readable (e.g. a large poster with small text). So we need to be able to override a default max height.

This PR sets the default max height to 80% of the viewport height (that includes the image and some or all of the caption). To override the default, and allow a figure's images to be taller than 80% of the viewport height in web outputs, add a `web-max-height-none` class to the figure. E.g.

```liquid
{% include figure
    image="figure-01.jpg"
    class="web-max-height-none"
%}
```

Note that this is only implemented for web outputs at this point.