### PR TITLE
Add option for images not to open when clicked

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -108,6 +108,7 @@ web:
   # -----------------
   images:
     lazyload: true
+    open-image-on-click: true
   # -----------------
   # Bookmarks
   # -----------------

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -108,6 +108,7 @@ web:
   # -----------------
   images:
     lazyload: true
+    # Do you want images to open as a standalone file when clicked?
     open-image-on-click: true
   # -----------------
   # Bookmarks

--- a/_includes/figure
+++ b/_includes/figure
@@ -45,7 +45,7 @@ because https://github.com/jekyll/jekyll/issues/2248.
         {% capture image-extension-with-full-stop %}.{{ image-file-extension }}{% endcapture %}
         {% assign image-without-file-extension = image | replace: image-extension-with-full-stop, "" %}
 
-        {% if include.link %}<a href="{{ include.link }}">{% elsif site.output == "web" %}<a href="{{ images }}/{{ image }}">{% endif %}
+        {% if include.link %}<a href="{{ include.link }}">{% elsif site.output == "web" and  site.data.settings.web.images.open-image-on-click == true %}<a href="{{ images }}/{{ image }}">{% endif %}
 
             {% if site.output == "web" %}
 
@@ -87,7 +87,7 @@ because https://github.com/jekyll/jekyll/issues/2248.
 
             {% endif %}
 
-        {% if include.link or site.output == "web" %}</a>{% endif %}
+        {% if include.link or site.output == "web" and site.data.settings.web.images.open-image-on-click == true %}</a>{% endif %}
     {% endfor %}
 </div>
 {% endif %}


### PR DESCRIPTION
This adds a switch in _data/setttings.yml, `open-image-on-click`, which when set to `false` will prevent figures in web output from being opened as standalone files in the browser. 

This may be particularly useful in cases where font management for SVGs is being handled in the SCSS for the site, so that SVGs opened outside of the site will not have access to the correct fonts.