### PR TITLE
`@footnote`, not `@footnotes`

### DIFF
--- a/_sass/template/partials/_print-notes.scss
+++ b/_sass/template/partials/_print-notes.scss
@@ -79,7 +79,7 @@ $print-notes: true !default;
 
     // The page-footnotes area
     @page {
-        @footnotes {
+        @footnote {
             margin-top: $line-height-default / 2;
             padding-top: $line-height-default / 2;
             font-size: $font-size-default * $font-size-smaller;


### PR DESCRIPTION
The page area for footnotes is described in an `@footnote` area.

See:
- https://www.w3.org/TR/css-gcpm-3/#footnote-area
- https://www.princexml.com/doc/styling/#styling-and-behavior-of-footnotes
- https://www.antenna.co.jp/AHF/help/en/ahf-float.html#FootnoteCSS