### PR TITLE
`.otf` -> `.ttf`

### DIFF
--- a/_sass/template/partials/_print-font-faces.scss
+++ b/_sass/template/partials/_print-font-faces.scss
@@ -80,12 +80,12 @@ $print-font-faces: true !default;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Black.otf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-Black.ttf);
         font-weight: 900;
     }
     @font-face {
         font-family: "Crimson Pro";
-        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-BlackItalic.otf);
+        src: url(#{$path-to-root-directory}/assets/fonts/CrimsonPro-BlackItalic.ttf);
         font-weight: 900;
         font-style: italic;
     }


### PR DESCRIPTION
CrimsonPro-Black and CrimsonPro-BlackItalic files in repository are `.ttf`, not `.otf`.