### PR TITLE
`text-align` in index was overridden

### DIFF
--- a/_sass/template/partials/_print-index.scss
+++ b/_sass/template/partials/_print-index.scss
@@ -12,11 +12,11 @@ $print-index: true !default;
 		columns: 2;
 		font-size: $font-size-default * $font-size-smaller;
 		margin: $line-height-default 0 0 0;
-		text-align: left;
 		li {
 			list-style-type: none;
 			margin: 0 0 0 ($paragraph-indent * 1);
 			text-indent: $paragraph-indent * (-1);
+			text-align: left;
 			li {
 				margin: 0 0 0 ($paragraph-indent / 2);
 			}


### PR DESCRIPTION
`text-align` in index was overridden by `$text-align` in `_print-base-typography.scss`.