### PR TITLE
Higher Prince filter resolution for screen PDF

### DIFF
--- a/_sass/template/partials/_print-pdf-view.scss
+++ b/_sass/template/partials/_print-pdf-view.scss
@@ -17,6 +17,8 @@ $print-pdf-view: true !default;
         prince-pdf-output-intent: url("#{$path-to-root-directory}/../_tools/profiles/#{$color-profile}");
         @if $output-format == "print-pdf" {
             prince-filter-resolution: 300dpi;
+        } @else {
+            prince-filter-resolution: 200dpi;
         }
     }
 


### PR DESCRIPTION
When we apply a CSS `filter` to an SVG, Prince rasterizes the image to apply the filter. By default, [Prince rasterizes at 96dpi](https://www.princexml.com/doc/properties/prince-filter-resolution/), which is far too low for good screen PDF resolution. We do already override this for print PDF, and rasterise at 300dpi.

With this PR, we effectively set the default filter-rasterization resolution to 200dpi for screen PDFs.