### PR TITLE
Add a title-page include with smarter h1

### DIFF
--- a/_includes/title-page
+++ b/_includes/title-page
@@ -41,6 +41,6 @@ as body text despite CSS rules for em size.
 </p>
 
 {% include image
-   file="boundary-bay-classics-logo.svg"
+   file="publisher-logo.jpg"
    class="title-page-logo"
    path="assets/images" %}

--- a/_includes/title-page
+++ b/_includes/title-page
@@ -1,0 +1,46 @@
+{% include metadata %}
+
+{% comment %}
+In PDF, we avoid making the title an h1, so that
+in a PDF reader's built-in navigation the h1s
+that start parts or chapters are not all indented
+or put into a dropdown beneath the title h1, and
+the overall book heading-level heirarchy is sensible.
+Only PDF treats the entire book as one file.
+
+Other formats all treat the title-page as one of
+many files, where using an h1 on this page is okay
+and semantically sensible.
+
+E.g. In epub, we make the title an h1
+to ensure that it's emphasised in epub readers
+(like Thorium) that treat all paragraphs
+as body text despite CSS rules for em size.
+{% endcomment %}
+
+{% if site.output == "print-pdf" or site.output == "screen-pdf" %}
+   <p class="title-page-title">
+      {{ title }}
+   </p>
+{% else %}
+   <h1 class="title-page-title">
+      {{ title }}
+   </h1>
+{% endif %}
+
+<p class="title-page-subtitle">
+   {{ subtitle }}
+</p>
+
+<p class="title-page-author">
+   {{ creator }}
+</p>
+
+<p class="title-page-contributor">
+   {{ contributor }}
+</p>
+
+{% include image
+   file="boundary-bay-classics-logo.svg"
+   class="title-page-logo"
+   path="assets/images" %}

--- a/_sass/template/partials/_epub-title-pages.scss
+++ b/_sass/template/partials/_epub-title-pages.scss
@@ -9,7 +9,7 @@ $epub-title-pages: true !default;
 	.half-title-page {
 		margin: $start-depth auto 0 auto;
 		text-align: center;
-		p {
+		h1, p {
 			text-indent: 0;
 			hyphens: none;
 			text-align: center;
@@ -23,7 +23,7 @@ $epub-title-pages: true !default;
 			font-family: $font-display-main;
 			font-size: $font-size-default * $font-size-bigger;
 			line-height: 1;
-			margin: 0;
+			margin: 0 0 $line-height-default 0;
 			// string-set: book-title content(); // breaks entire CSS file in Adobe Digital Editions
 		}
 		.title-page-subtitle, 
@@ -31,14 +31,14 @@ $epub-title-pages: true !default;
 			font-family: $font-display-main;
 			font-size: $font-size-default * $font-size-bigger;
 			line-height: 1;
-			margin: $line-height-default 0 $line-height-default 0;
+			margin: 0 0 $line-height-default 0;
 			// string-set: book-subtitle content(); // breaks entire CSS file in Adobe Digital Editions
 		}
 		.title-page-author, 
 		.titlepage-author {
 			font-size: $font-size-default * $font-size-bigger;
 			line-height: 1;
-			margin: ($line-height-default * 2) 0;
+			margin: 0 0 $line-height-default 0;
 			// string-set: book-author content(); // breaks entire CSS file in Adobe Digital Editions
 		}
 		.title-page-publisher, 
@@ -48,11 +48,11 @@ $epub-title-pages: true !default;
 		.title-page-logo, 
 		.titlepage-logo {
 			display: block; // In case the class is applied to the image, not the paragraph
+			margin: $line-height-default auto 0 auto;
 			max-width: 30%;
 			img {
 				width: 100%;
 			}
 		}
 	}
-
 }

--- a/book/text/0-1-titlepage.md
+++ b/book/text/0-1-titlepage.md
@@ -3,16 +3,4 @@ title: Title page
 style: title-page
 ---
 
-{% include metadata %}
-
-{{ title }}
-{:.title-page-title}
-
-{{ subtitle }}
-{:.title-page-subtitle}
-
-{{ creator }}
-{:.title-page-author}
-
-{{ publisher }}
-{:.title-page-publisher}
+{% include title-page %}

--- a/samples/fr/text/00-03-title-page.md
+++ b/samples/fr/text/00-03-title-page.md
@@ -3,16 +3,4 @@ title: Name
 style: title-page
 ---
 
-{% include metadata %}
-
-{{ title }}
-{:.title-page-title}
-
-{{ subtitle }}
-{:.title-page-subtitle}
-
-{{ creator }}
-{:.title-page-author}
-
-{{ publisher }}
-{:.title-page-publisher}
+{% include title-page %}

--- a/samples/text/00-03-title-page.md
+++ b/samples/text/00-03-title-page.md
@@ -3,16 +3,4 @@ title: Title page
 style: title-page
 ---
 
-{% include metadata %}
-
-{{ title }}
-{:.title-page-title}
-
-{{ subtitle }}
-{:.title-page-subtitle}
-
-{{ creator }}
-{:.title-page-author}
-
-{{ publisher }}
-{:.title-page-publisher}
+{% include title-page %}


### PR DESCRIPTION
While many book creators will customise the markdown/HTML on their title pages, it can be useful to ship as smart a template as possible for default outputs.

This PR moves the title-page HTML to an include, so that we can apply more sophisticated logic to the output HTML. Right now, this lets us use an `h1` for the book title for some outputs.

In PDF, we avoid making the title-page title an `h1`, so that in a PDF reader's built-in navigation the `h1`s that start parts or chapters are not all indented or put into a dropdown beneath the title `h1`, and the overall book heading-level heirarchy is therefore sensible.

This makes sense in PDF, where the entire output book is one file.

Other formats all treat the title-page as one of many HTML files. In these outputs, using an `h1` for the title on the title page is semantically sensible, and more semantically useful, especially where CSS lets us down. For instance, in epub, making the title an `h1` ensures that it's visually emphasised in the Thorium epub reader (and potentially other readers), which visually renders all `<p>` paragraphs as body text despite any CSS rules for `em` font-size.