### PR TITLE
Scripting SVG manipulation

### DIFF
--- a/_docs/advanced/javascript.md
+++ b/_docs/advanced/javascript.md
@@ -47,3 +47,7 @@ To limit a script to a given output format, use `site.output`:
 All scripts to be used in your epub should be included in `assets/js/bundle.js`, and not added to pages as separate files. This is because you must not have any scripts in your epub that you aren't using, or it won't validate; and we only support including `bundle.js` in epub output.
 
 If you don't want any Javsacript at all in your epub, you can disable it in `_data/settings.yml` by setting `epub` > `javascript` > `enabled` to `false`.You should then also exclude `assets/js/bundle.js` in the exclude list in `_configs/_config.epub.yml`.
+
+## Manipulating SVGs
+
+To script SVG manipulation during `gulp` preprocessing, see ['SVG processing'](../images/svg-processing.html) in the Images section.

--- a/_docs/images/svg-processing.md
+++ b/_docs/images/svg-processing.md
@@ -1,0 +1,79 @@
+---
+title: "SVG processing"
+categories: images
+order: 5
+---
+
+# SVG processing
+{:.no_toc}
+
+* toc
+{:toc}
+
+This is a technically advanced section for those who need to grapple with how SVGs are processed.
+
+Also see the ['Settings'](../setup/settings.html#svg-injection) section in Setup for how SVGs are injected into web pages.
+
+
+## Default optimisation
+
+Our built-in image-preparation process automatically optimises SVG images, for instance by removing unnecessary data from their code. This happens when you run the 'Convert source images to output formats' option in the output script.
+
+We use a library called [SVGO](https://github.com/svg/svgo) for this optimisation. SVGO has many configuration options. We've carefully preset options based on our experience, and they are written into the `images:svg` task in `gulpfile.js`. If you need to change them, tread carefully and be careful not to overwrite your changes if you update `gulpfile.js` (e.g. by copying the latest version from the template or another project).
+
+
+## Manipulating SVGs automatically
+
+Sometimes you need to make specific and/or manual changes to SVGs. For instance, we like to include Google Fonts CSS in SVGs so that, at least when you're online, the fonts in an SVG still load even when that SVG is viewed outside of its book web page (e.g. opened in a new tab).
+
+This can be tedious to do manually, or impossible to do in tools like Adobe Illustrator. Or the SVGO optimisation process breaks your manual changes.
+
+So, the Electric Book template includes a way for you to write Javascript functions that manipulate your SVGs for you during image processing. These functions run *after* SVGO optimisation.
+
+These functions are in scripts saved to book specific folders in `_tools/gulp/images/functions`. You can create one file and function per SVG image, or one file and function that applies to *all* SVGs images in a book.
+
+
+### Single-image functions
+
+Add a file for the relevant SVG to the `_tools/gulp/images/functions` folder, in a subfolder with the same name as the image's book directory. Its filename should be identical to the image filename, but with:
+
+- spaces removed
+- underscores instead of hyphens
+- underscores instead of full stops
+- a `.js` file extension.
+
+For example, `naples_svg.js` will contain a function that runs on the `naples.svg` file in the `samples` book. It should be in `_tools/gulp/images/functions/samples`.
+
+Behind the scenes, the function will be run by [gulp-edit-xml](https://www.npmjs.com/package/gulp-edit-xml), which parses SVG files as Javascript objects. For more detail on this approach and syntax, see the docs for [xml2js](https://github.com/Leonidas-from-XIV/node-xml2js). In particular, note that:
+
+- you refer to your SVG as `xml` in your function.
+- your script must include an `exports` statement after the function. E.g. `exports.naples_svg = naples_svg;`
+
+Here is a full example of a file that would be saved as `_tools/gulp/images/functions/naples_svg.js`, and which inserts a font-face import into an SVG. (Note that this function will entirely replace any existing `<style>` element in the SVG.)
+
+```js
+function naples_svg(xml) {
+
+    xml.svg.defs = {
+        style: '@import url("https://fonts.googleapis.com/css?family=Asap:400,400i,600,600i");'
+    };
+
+    return xml;
+}
+
+exports.naples_svg = naples_svg;
+
+```
+
+
+### Global functions
+
+You can also create one function per book that will apply to *all* SVG images in that book. You need to name it in the same place and format as above, but with the word 'all' instead of the filename. E.g. in the `samples` book, the script would be saved as `all_svg.js`, and the function would be called `all_svg`:
+
+```js
+function all_svg(xml) {
+    // logic here
+    return xml;
+}
+exports.all_svg = all_svg;
+```

--- a/_docs/setup/settings.md
+++ b/_docs/setup/settings.md
@@ -107,3 +107,5 @@ Injecting SVGs can have side-effects, depending how your SVGs are created and co
 - Your SVGs should have inline styles (Illustrator called these 'Style attributes'), not stylesheets in `<style>` elements. If different SVGs use the same class names for different styles, they all inherit each other's styles, ruining your SVGs.
 - If font names in your SVGs are different from the font names you use in your site CSS, adjust the font names in `assets/js/svg-management.js`. That script can replace font-family names in SVGs after injection.
 - All SVGs must have a [`viewBox` attribute](https://css-tricks.com/scale-svg/#article-header-id-3) for correct sizing. Good programs like Illustrator will add this automatically. Otherwise you should add it yourself to the SVG you save in your book's `_source` images.
+
+For more on SVG processing, see ['SVG processing'](../images/svg-processing.html) in the Images section.

--- a/_tools/gulp/images/README.md
+++ b/_tools/gulp/images/README.md
@@ -35,3 +35,13 @@ function samplesNaplesSvg(xml) {
 exports.samplesNaplesSvg = samplesNaplesSvg;
 
 ```
+
+You can also create a function that will apply to *all* SVG images in a book. You only need to name it in the same format, but with the word 'All' instead of the filename. E.g. in the `samples` book, the script would be saved as `samplesAllSvg.js`, and the function would be called `samplesAllSvg`:
+
+```
+function samplesAllSvg(xml) {
+    // logic here
+    return xml;
+}
+exports.samplesAllSvg = samplesAllSvg;
+```

--- a/_tools/gulp/images/README.md
+++ b/_tools/gulp/images/README.md
@@ -1,0 +1,37 @@
+# Adding image functions
+
+This folder lets you define functions for adjusting SVG images during gulp image-processing.
+
+Add a function for the relevant SVG to the functions folder. Its filename should be in camelcase, with no hyphens, in this format that includes the book folder, filename, and file extension:
+
+```
+bookFileSvg.js
+```
+
+For example, this function run on the `naples.svg` file in the `samples` book:
+
+```
+samplesNaplesSvg.js
+```
+
+The function will be run by `gulp-edit-xml` (https://www.npmjs.com/package/gulp-edit-xml), which parses SVG files as Javascript objects.
+
+- Give your function the same names as the file (without the `.js`).
+- Refer to your SVG as `xml` in your function.
+- Your function file must include an `exports` statement after the function. E.g. `exports.samplesNaplesSvg = samplesNaplesSvg;`
+
+Here is a full example that inserts a font-face import into an SVG. (Note that this function will entirely replace any existing `<style> element in the SVG.)
+
+```js
+function samplesNaplesSvg(xml) {
+
+    xml.svg.defs = {
+        style: '@import url("https://fonts.googleapis.com/css?family=Asap:400,400i,600,600i");'
+    };
+
+    return xml;
+}
+
+exports.samplesNaplesSvg = samplesNaplesSvg;
+
+```

--- a/_tools/gulp/images/README.md
+++ b/_tools/gulp/images/README.md
@@ -2,46 +2,4 @@
 
 This folder lets you define functions for adjusting SVG images during gulp image-processing.
 
-Add a function for the relevant SVG to the functions folder. Its filename should be in camelcase, with no hyphens, in this format that includes the book folder, filename, and file extension:
-
-```
-bookFileSvg.js
-```
-
-For example, this function run on the `naples.svg` file in the `samples` book:
-
-```
-samplesNaplesSvg.js
-```
-
-The function will be run by `gulp-edit-xml` (https://www.npmjs.com/package/gulp-edit-xml), which parses SVG files as Javascript objects.
-
-- Give your function the same names as the file (without the `.js`).
-- Refer to your SVG as `xml` in your function.
-- Your function file must include an `exports` statement after the function. E.g. `exports.samplesNaplesSvg = samplesNaplesSvg;`
-
-Here is a full example that inserts a font-face import into an SVG. (Note that this function will entirely replace any existing `<style> element in the SVG.)
-
-```js
-function samplesNaplesSvg(xml) {
-
-    xml.svg.defs = {
-        style: '@import url("https://fonts.googleapis.com/css?family=Asap:400,400i,600,600i");'
-    };
-
-    return xml;
-}
-
-exports.samplesNaplesSvg = samplesNaplesSvg;
-
-```
-
-You can also create a function that will apply to *all* SVG images in a book. You only need to name it in the same format, but with the word 'All' instead of the filename. E.g. in the `samples` book, the script would be saved as `samplesAllSvg.js`, and the function would be called `samplesAllSvg`:
-
-```
-function samplesAllSvg(xml) {
-    // logic here
-    return xml;
-}
-exports.samplesAllSvg = samplesAllSvg;
-```
+See the docs for detail: /_docs/images/svg-processing.md.

--- a/_tools/gulp/images/functions/.gitignore
+++ b/_tools/gulp/images/functions/.gitignore
@@ -1,0 +1,5 @@
+# Don't ignore this file
+# This ensures that this folder
+# is tracked in version control
+# even if it is empty.
+!.gitignore

--- a/_tools/gulp/images/functions/samples/figure_01_02_a_svg.js
+++ b/_tools/gulp/images/functions/samples/figure_01_02_a_svg.js
@@ -8,7 +8,7 @@
 // - replacing 'Asap-Medium' with 'Asap', font-weight 600
 // - replacing 'Asap-Regular' with 'Asap'
 
-function samplesFigure0102ASvg(xml) {
+function figure_01_02_a_svg(xml) {
 
     xml.svg.defs = {
         style: '@import url("https://fonts.googleapis.com/css?family=Asap:400,400i,600,600i");'
@@ -58,4 +58,4 @@ function samplesFigure0102ASvg(xml) {
     return xml;
 }
 
-exports.samplesFigure0102ASvg = samplesFigure0102ASvg;
+exports.figure_01_02_a_svg = figure_01_02_a_svg;

--- a/_tools/gulp/images/functions/samplesFigure0102ASvg.js
+++ b/_tools/gulp/images/functions/samplesFigure0102ASvg.js
@@ -46,7 +46,12 @@ function samplesFigure0102ASvg(xml) {
 
         if (element.$['font-family'] === 'Asap-Medium') {
             element.$['font-family'] = 'Asap';
-            element.$['font-weight'] = '600';
+            element.$['font-weight'] = '500';
+        }
+
+        if (element.$['font-family'] === 'Asap Medium') {
+            element.$['font-family'] = 'Asap';
+            element.$['font-weight'] = '500';
         }
     });
 

--- a/_tools/gulp/images/functions/samplesFigure0102ASvg.js
+++ b/_tools/gulp/images/functions/samplesFigure0102ASvg.js
@@ -1,0 +1,56 @@
+/*jslint node */
+
+// This is a sample file included in the Electric Book Template
+// for demonstration purposes.
+
+// This function makes fonts display correctly, by doing three things:
+// - adding a style element that imports Google fonts
+// - replacing 'Asap-Medium' with 'Asap', font-weight 600
+// - replacing 'Asap-Regular' with 'Asap'
+
+function samplesFigure0102ASvg(xml) {
+
+    xml.svg.defs = {
+        style: '@import url("https://fonts.googleapis.com/css?family=Asap:400,400i,600,600i");'
+    };
+
+    // Get text element children of the SVG
+    var svgTextElements = xml.svg.text;
+
+    // Add text elements in g elements`recursively
+    // to the svgTextElements array.
+    function addGText(element) {
+        var gElements = element.g;
+
+        gElements.forEach(function (g) {
+            var gTextElements = g.text;
+            if (gTextElements) {
+                gTextElements.forEach(function (gTextElement) {
+                    svgTextElements.push(gTextElement);
+                });
+            }
+
+            // If g contains another g, recur
+            if (g.g) {
+                addGText(g);
+            }
+        });
+    }
+    addGText(xml.svg);
+
+    svgTextElements.forEach(function (element) {
+
+        if (element.$['font-family'] === 'Asap-Regular') {
+            element.$['font-family'] = 'Asap';
+        }
+
+        if (element.$['font-family'] === 'Asap-Medium') {
+            element.$['font-family'] = 'Asap';
+            element.$['font-weight'] = '600';
+        }
+    });
+
+    return xml;
+}
+
+exports.samplesFigure0102ASvg = samplesFigure0102ASvg;

--- a/_tools/update/files.txt
+++ b/_tools/update/files.txt
@@ -836,6 +836,8 @@ _sass/template/web.scss
 
 # Note that we include this files.txt file here.
 
+_tools/gulp/README.md
+_tools/gulp/functions/.gitignore
 _tools/package/package.js
 _tools/profiles/Grey_Fogra39L.icc
 _tools/profiles/Grey_Fogra52L.icc

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,10 @@ var gulp = require('gulp'),
     cheerio = require('gulp-cheerio'),
     tap = require('gulp-tap'),
     iconv = require('iconv-lite'),
-    gulpif = require('gulp-if');
+    gulpif = require('gulp-if'),
+    camelcase = require('camelcase'),
+    xmlEdit = require('gulp-edit-xml'),
+    imageFunctions = require('require-all')(__dirname + '/_tools/gulp/images');
 
     // Utilities copied from elsewhere in this repo
     var { ebSlugify } = require('./assets/js/utilities.js');
@@ -290,6 +293,7 @@ gulp.task('images:svg', function (done) {
     console.log('Processing SVG images from ' + paths.img.source);
 
     var prefix = ''; // does this ever get overwritten incorrectly due to async piping?
+    var bookFile = {};
 
     // Since SVGs are used as-as for all output formats,
     // we can perform this check with gulpif based only
@@ -303,6 +307,7 @@ gulp.task('images:svg', function (done) {
     gulp.src(paths.img.source + '*.svg')
         .pipe(tap(function (file) {
             prefix = getFileDetailsFromTap(file).prefix;
+            bookFile = camelcase(book + '-' + getFileDetailsFromTap(file).filename);
         }))
         .pipe(debug({title: 'Processing SVG '}))
         .pipe(gulpif(modifyImage, svgmin({
@@ -573,6 +578,14 @@ gulp.task('images:svg', function (done) {
         }).on('error', function (e) {
             console.log(e);
         })))
+        .pipe(xmlEdit(function(xml) {
+            console.log(bookFile);
+            if(imageFunctions.functions[bookFile]) {
+                console.log('Running ' + [bookFile] + ' function on ' + filename);
+                imageFunctions.functions[bookFile][bookFile](xml)
+            }
+            return xml;
+        }))
         .pipe(gulp.dest(paths.img.printpdf))
         .pipe(gulp.dest(paths.img.screenpdf))
         .pipe(gulp.dest(paths.img.web))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -581,8 +581,12 @@ gulp.task('images:svg', function (done) {
         .pipe(xmlEdit(function(xml) {
 
             if(imageFunctions.functions[bookFile]) {
-                console.log('Running ' + [bookFile] + ' function on ' + filename);
+                console.log('Running the ' + [bookFile] + ' function on ' + filename);
                 imageFunctions.functions[bookFile][bookFile](xml)
+            }
+            if(imageFunctions.functions[book + 'AllSvg']) {
+                console.log('Running the ' + [book + 'AllSvg'] + ' function on ' + filename);
+                imageFunctions.functions[book + 'AllSvg'][book + 'AllSvg'](xml)
             }
             return xml;
         }))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -579,7 +579,7 @@ gulp.task('images:svg', function (done) {
             console.log(e);
         })))
         .pipe(xmlEdit(function(xml) {
-            console.log(bookFile);
+
             if(imageFunctions.functions[bookFile]) {
                 console.log('Running ' + [bookFile] + ' function on ' + filename);
                 imageFunctions.functions[bookFile][bookFile](xml)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/electricbookworks/electric-book#readme",
   "devDependencies": {
+    "camelcase": "^3.0.0",
     "cordova-android": "^8.0.0",
     "cordova-ios": "^5.0.1",
     "cordova-plugin-whitelist": "^1.3.3",
@@ -29,6 +30,7 @@
     "gulp-cheerio": "^0.6.3",
     "gulp-debug": "^4.0.0",
     "gulp-each": "^0.5.0",
+    "gulp-edit-xml": "^3.1.1",
     "gulp-gm": "^0.0.9",
     "gulp-if": "^3.0.0",
     "gulp-mathjax-page": "github:arthurattwell/gulp-mathjax-page",
@@ -43,6 +45,7 @@
     "make-runnable": "^1.3.8",
     "path": "^0.12.7",
     "puppeteer": "^9.1.1",
+    "require-all": "^3.0.0",
     "yargs": "^15.3.1"
   },
   "cordova": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "https://github.com/electricbookworks/electric-book#readme",
   "devDependencies": {
-    "camelcase": "^3.0.0",
     "cordova-android": "^8.0.0",
     "cordova-ios": "^5.0.1",
     "cordova-plugin-whitelist": "^1.3.3",


### PR DESCRIPTION
At EBW, we've sometimes needed to make the same tedious changes to the code of specific SVGs, and then avoid overwriting them during image pre-processing. Following the 'exclude-from-preprocessing' ability added in #609, this PR adds the ability to script specific changes to specific SVGs during preprocessing.

The [docs added here](https://github.com/electricbookworks/electric-book/compare/svg-manipulation?expand=1#diff-9aacbe123e5da9a4bec1f8a6e5587cf3f0de390eef83eb87903a10078bbea19c) explain how this works. 

This work includes a real example for reference, in `_tools/gulp/images/functions/samples/figure_01_02_a_svg.js`.