### PR TITLE
Do not trigger accordion-close on ctrl+click

### DIFF
--- a/assets/js/accordion.js
+++ b/assets/js/accordion.js
@@ -391,6 +391,14 @@ function ebAccordionListenForAnchorClicks(querySelectorString) {
 
             event.stopPropagation();
 
+            // If the link was clicked with a modifier key pressed
+            // (e.g. Ctrl + click), assume user wants a new tab,
+            // and do not continue processing this here.
+            if (event.metaKey || event.ctrlKey || event.shiftKey) {
+                console.log('User was pressing Ctrl, Shift or the meta key.');
+                return;
+            }
+
             // Declare targetID so JSLint knows it's coming in this function.
             var targetID;
 


### PR DESCRIPTION
When accordions are on, and in `accordion.js` they are set to auto-close when a new section is opened, ctrl+clicking an internal link currently closes the current accordion and/or resets the accordions to the default accordion. This fixes that unexpected behaviour, by detecting that the user is opening the internal link with a modifier key often used to open in a new tab.