### PR TITLE
Also highlight search-query-stems in pages linked from search

### DIFF
--- a/assets/js/search-results.js
+++ b/assets/js/search-results.js
@@ -1,5 +1,6 @@
 /*jslint browser */
-/*globals window, locales, pageLanguage, index, searchTerm, store, fillSearchBox */
+/*globals window, locales, pageLanguage, elasticlunr
+        index, searchTerm, store, fillSearchBox */
 
 // Display the search results
 function displaySearchResults(results, store) {
@@ -29,7 +30,20 @@ function displaySearchResults(results, store) {
         for (i = 0; i < results.length; i += 1) {
             item = store[results[i].ref];
             appendString += '<li>';
-            appendString += '<h3><a href="' + item.url + '?query=' + searchTerm + '">' + item.title + ' </a></h3>';
+            appendString += '<h3><a href="'
+                    + item.url
+                    + '?query='
+                    + searchTerm
+
+                    // Also add the stem that elasticlunr
+                    // used to find this in the index.
+                    // E.g. a search for 'processing'
+                    // will look for the stem 'process'.
+                    + '&search_stem='
+                    + elasticlunr.stemmer(searchTerm)
+                    + '">'
+                    + item.title
+                    + ' </a></h3>';
             appendString += '<p>' + item.excerpt + '</p>';
             appendString += '</li>';
         }

--- a/assets/js/search-terms.js
+++ b/assets/js/search-terms.js
@@ -95,10 +95,25 @@ function jumpToSearchResult() {
     }
 }
 
-// Ask mark.js to mark all the search terms
+// Ask mark.js to mark all the search terms.
+// We mark both the searchTerm and the search-query stem
 var markInstance = new Mark(document.querySelector("#wrapper"));
-if (searchTerm) {
-    markInstance.unmark().mark(searchTerm);
+if (searchTerm || getQueryVariable('search_stem')) {
+
+    // Create an array containing the search term
+    // and the search stem to pass to mark.js
+    var arrayToMark = [];
+
+    // Add them to the array if they exist
+    if (searchTerm) {
+        arrayToMark.push(searchTerm);
+    }
+    if (getQueryVariable('search_stem')) {
+        arrayToMark.push(getQueryVariable('search_stem'));
+    }
+
+    // Mark their instances on the page
+    markInstance.unmark().mark(arrayToMark);
 }
 
 if (isSearchPage() === false) {


### PR DESCRIPTION
When we search, elasticlunr actually searches for the 'stems' of the words in our query. E.g. if we search for 'processing' elasticlunr searches the index for 'process' and therefore finds terms like 'process', 'processed' and 'processor'.

This is smart. But when we click through to a search result, mark.js currently only highlights on the page our original search query, 'processing'. If the page only contains the word 'processed', nothing will be highlighted, which is very confusing. To the user, the search highlighting seems broken.

This change fixes that by adding an extra URL parameter to URLs on search-result pages: `search_stem`. And it makes mark.js also highlight those search stems in addition to the original search query. This way, users will more easily find where on the page elasticlunr matched a phrase to their search query.