### PR TITLE
Search and accordion settings, fixes

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -80,6 +80,10 @@ web:
   # particular heading level? Default h2, set in accordion.js.
   # Set this to true to enable, or false to disable.
   accordion: false
+  # Set the heading level that defines an accordion section
+  accordion-level: h3
+  # Should opening a new section close the others?
+  accordion-auto-close: false
   # Enable annotation
   # You can have annotation on for development and/or for live.
   # Set each to either true or false
@@ -123,6 +127,16 @@ web:
   nav:
     home:
       expand-books: false
+  # --------------
+  # Search
+  # --------------
+  search:
+    # Set where you want the 'Jump to first result' box
+    # to show on pages linked from search results.
+    # Define this as a querySelector string, targeting
+    # the element before which the box should be shown.
+    # Or for the main page heading, use the default 'mainHeading'.
+    jump-box-location: "mainHeading"
   # --------------
   # Monetization
   # --------------
@@ -202,6 +216,10 @@ app:
   # particular heading level? Default h2, set in accordion.js.
   # Set this to true to enable, or false to disable.
   accordion: false
+  # Set the heading level that defines an accordion section
+  accordion-level: h3
+  # Should opening a new section close the others?
+  accordion-auto-close: false
   # -----------------
   # Bookmarks
   # -----------------
@@ -222,6 +240,16 @@ app:
   nav:
     home:
       expand-books: false
+  # --------------
+  # Search
+  # --------------
+  search:
+    # Set where you want the 'Jump to first result' box
+    # to show on pages linked from search results.
+    # Define this as a querySelector string, targeting
+    # the element before which the box should be shown.
+    # Or for the main page heading, use the default 'mainHeading'.
+    jump-box-location: "mainHeading"
 
 # ----------------------------------------------------------
 # External media settings

--- a/assets/js/accordion.js
+++ b/assets/js/accordion.js
@@ -1,20 +1,20 @@
 /*jslint browser, for */
 /*global window, ebLazyLoadImages, searchTerm, videoShow
-    locales, pageLanguage, console, Element, HTMLDocument, Node,
-    Node, MutationObserver */
+    locales, pageLanguage, console, Element, HTMLDocument,
+    settings, Node, MutationObserver */
 
 // console.log('Debugging accordions.js');
 
 // --------------------------------------------------------------
-// Options
+// Options, defined in _data/settings.yml
 //
 // 1. Use CSS selectors to list the headings that will
 //    define each accordion section, e.g. '#content h2'
-var accordionHeads = '#content h2';
+var accordionHeads = '#content ' + settings[settings.site.output].accordion.level;
 // 2. Which heading's section should we show by default?
-var defaultAccordionHead = '#content h2:first-of-type';
+var defaultAccordionHead = '#content ' + settings[settings.site.output].accordion.level + ':first-of-type';
 // 3. Auto close last accordion when you open a new one?
-var autoCloseAccordionSections = false;
+var autoCloseAccordionSections = settings[settings.site.output].accordion.autoClose;
 // --------------------------------------------------------------
 
 function ebAccordionInit() {
@@ -29,11 +29,21 @@ function ebAccordionInit() {
         pageAccordionOff = true;
     }
 
+    // Check if there are any headings on the page
+    // to make into an accordion.
+    var availableAccordionHeads = document.querySelectorAll(accordionHeads);
+    var noAccordionHeadings = false;
+    if (!availableAccordionHeads
+            || availableAccordionHeads.length === 0) {
+        noAccordionHeadings = true;
+    }
+
     return navigator.userAgent.indexOf('Opera Mini') === -1 &&
             document.querySelectorAll !== "undefined" &&
             window.addEventListener !== "undefined" &&
             !!Array.prototype.forEach &&
-            !pageAccordionOff;
+            !pageAccordionOff &&
+            !noAccordionHeadings;
 }
 
 function ebAccordionPageSetting() {
@@ -587,11 +597,6 @@ function ebAccordionShowAllButton() {
 function ebAccordify() {
     'use strict';
 
-    // early exit for older browsers
-    if (!ebAccordionInit()) {
-        return;
-    }
-
     // Signal that we're loading the accordion
     document.body.setAttribute('data-accordion-active', 'true');
 
@@ -656,12 +661,14 @@ function ebExpand() {
 
 function ebLoadAccordion() {
     'use strict';
-    ebAccordify();
-    ebExpand();
-    ebAccordionListenForAnchorClicks();
-    ebAccordionListenForHeadingClicks();
-    ebAccordionListenForNavClicks();
-    ebAccordionListenForHashChange();
+    if (ebAccordionInit()) {
+        ebAccordify();
+        ebExpand();
+        ebAccordionListenForAnchorClicks();
+        ebAccordionListenForHeadingClicks();
+        ebAccordionListenForNavClicks();
+        ebAccordionListenForHashChange();
+    }
 }
 
 // Wait for data-index-targets to be loaded

--- a/assets/js/search-terms.js
+++ b/assets/js/search-terms.js
@@ -1,5 +1,5 @@
 /*jslint browser, for */
-/*globals window, locales, pageLanguage, Mark */
+/*globals window, locales, pageLanguage, Mark, settings */
 
 // get query search term from GET query string
 function getQueryVariable(variable) {
@@ -80,7 +80,12 @@ function jumpToSearchResult() {
         var mainHeading = document.querySelector('#content h1, #content h2, #content h3, #content h4, #content h5, #content h6');
         var contentDiv = document.querySelector('#content');
 
-        if (mainHeading) {
+        if (settings[settings.site.output].search.jumpBoxLocation
+                && settings[settings.site.output].search.jumpBoxLocation !== 'mainheading'
+                && document.querySelector(settings[settings.site.output].search.jumpBoxLocation)) {
+            var insertJumpBoxAfter = document.querySelector(settings[settings.site.output].search.jumpBoxLocation);
+            contentDiv.insertBefore(searchResultsSummary, insertJumpBoxAfter);
+        } else if (mainHeading) {
             contentDiv.insertBefore(searchResultsSummary, mainHeading.nextSibling);
         } else {
             contentDiv.insertBefore(searchResultsSummary, contentDiv.firstChild);

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -24,11 +24,38 @@ var settings = {
                 include: '#content [id]',
                 exclude: ''
             }
+        },
+        accordion: {
+            enabled: true,
+            level: 'h2'
+        },
+        search: {
+            jumpBoxLocation: 'mainHeading'
+        }
+    },
+    app: {
+        bookmarks: {
+            enabled: true,
+            elements: {
+                include: '#content [id]',
+                exclude: ''
+            }
+        },
+        accordion: {
+            enabled: true,
+            level: 'h2',
+            autoClose: false
+        },
+        search: {
+            jumpBoxLocation: 'mainHeading'
         }
     }
 };
 
 // Override default settings from Jekyll config
+
+// Web settings
+
 {% if site.baseurl %}
 settings.site.baseurl = '{{ site.baseurl }}';
 {% endif %}
@@ -44,4 +71,38 @@ settings.web.images.lazyload = {{ site.data.settings.web.images.lazyload }};
 
 {% if site.data.settings.web.bookmarks != nil %}
 settings.web.bookmarks.enabled = {{ site.data.settings.web.bookmarks }};
+{% endif %}
+
+{% if site.data.settings.web.accordion != nil %}
+settings.web.accordion.enabled = {{ site.data.settings.web.accordion }};
+{% endif %}
+
+{% if site.data.settings.web.accordion-level != nil %}
+settings.web.accordion.level = '{{ site.data.settings.web.accordion-level }}';
+{% endif %}
+
+{% if site.data.settings.web.accordion-auto-close != nil %}
+settings.web.accordion.autoClose = {{ site.data.settings.web.accordion-auto-close }};
+{% endif %}
+
+{% if site.data.settings.web.search.jump-box-location != nil %}
+settings.web.search.jumpBoxLocation = '{{ site.data.settings.web.search.jump-box-location }}';
+{% endif %}
+
+// App settings
+
+{% if site.data.settings.app.accordion != nil %}
+settings.app.accordion.enabled = {{ site.data.settings.app.accordion }};
+{% endif %}
+
+{% if site.data.settings.app.accordion-level != nil %}
+settings.app.accordion.level = '{{ site.data.settings.app.accordion-level }}';
+{% endif %}
+
+{% if site.data.settings.app.accordion-auto-close != nil %}
+settings.app.accordion.autoClose = {{ site.data.settings.app.accordion-auto-close }};
+{% endif %}
+
+{% if site.data.settings.app.search.jump-box-location != nil %}
+settings.app.search.jumpBoxLocation = '{{ site.data.settings.app.search.jump-box-location }}';
 {% endif %}


### PR DESCRIPTION
This PR implements fixes to issues found in real-life projects at EBW:

1. Moves some options (like which heading levels are used for accordion sections) from Javascript files into `settings.yml`. This is important because JS files are not the place to be storing project-specific settings.
2. Fixes a JS bug that broke `bundle.js` on pages with a 'jump to first result' box, in projects where the chapter-opener structure is unique/customised, and not compatible with the EBT's default 'jump to first result' box.
3. Fixes a bug that added event listeners to internal links for accordion management, even when the page had no accordion headings.