### PR TITLE
Do not bubble show-hide click events

### DIFF
--- a/assets/js/show-hide.js
+++ b/assets/js/show-hide.js
@@ -12,6 +12,12 @@ var ebShowHideOptions = {
 // Toggle visuallyhidden
 function ebTogglePreviousSiblingVisibility(event) {
     'use strict';
+
+    // Do not trigger listeners on the parent element.
+    // This lets us use show-hide in parent containers
+    // that have their own listeners.
+    event.stopPropagation();
+
     var button = event.target;
     var elementToHide = button.previousElementSibling;
     if (elementToHide.classList.contains('visuallyhidden')) {


### PR DESCRIPTION
Sometimes we need to use a show-hide in a parent container (e.g. a box) that has its own event listener. We should not by default trigger those listeners when show-hide is clicked.