### PR TITLE
Improve layout when printing from browser

### DIFF
--- a/_sass/template/partials/_web-printout.scss
+++ b/_sass/template/partials/_web-printout.scss
@@ -1,0 +1,67 @@
+$web-printout: true !default;
+
+@if $web-printout {
+
+    // Print-from-browser styles
+
+    @media print {
+
+        // Hide web-only elements
+
+        [href="#nav"],
+        .masthead,
+        .pagination,
+        a.accordion-show-all-button,
+        svg.history-icon {
+            display: none
+        }
+
+        [data-accordion="open"]:after,
+        [data-accordion="closed"]:after {
+            content: normal;
+        }
+
+        // Adjust sizes and colours
+
+        body {
+            background: none;
+            font-size: 1rem;
+        }
+
+        #wrapper {
+            background: none;
+        }
+
+        #content,
+        .footer-content {
+            max-width: 60em;
+        }
+
+        h1 {
+            background: none;
+            color: $color-text-main;
+        }
+
+        .reverse-footnote-arrow {
+            width: 1rem;
+            height: 1rem;
+        }
+
+        #footer {
+            background: none;
+            color: $color-text-main;
+
+            p {
+                color: $color-text-main;
+            }
+        }
+
+        // Sidebar elements
+        .sidenote {
+            display: block;
+            float: right;
+            max-width: 40%;
+            margin-bottom: $line-height-default;
+        }
+    }
+}

--- a/_sass/template/web.scss
+++ b/_sass/template/web.scss
@@ -244,8 +244,12 @@ $web-language-select: true !default;
 $web-annotator: true !default;
 $web-bookmarks: true !default;
 
+// Print-out styles
+$web-printout: true !default;
+
 // Logic (if this then that)
 $web-reset-sequences: true !default; // This should stay last in the @import list
+
 
 // ----------------------------------------------------
 // Import font files (@font-face) for fonts you specify
@@ -329,6 +333,9 @@ $web-reset-sequences: true !default; // This should stay last in the @import lis
 @import "template/partials/web-annotator";
 @import "template/partials/web-language-select";
 @import "template/partials/web-bookmarks";
+
+// Print-out styles
+@import "template/partials/web-printout";
 
 // Logic (if this then that)
 @import "template/partials/web-reset-sequences"; // This should stay last in the @import list


### PR DESCRIPTION
People do print out web pages, so we might as well make them look decent when they do. This goes some of the way towards that by hiding some web-only elements, and improving the display of some common features like sidenotes when printed out.