### PR TITLE
Avoid initialising multiple times

### DIFF
--- a/assets/js/bookmarks.js
+++ b/assets/js/bookmarks.js
@@ -1195,11 +1195,15 @@ function ebPrepareForBookmarks() {
     'use strict';
 
     var bookmarksObserver = new MutationObserver(function (mutations) {
+
+        var readyForBookmarks = false;
         mutations.forEach(function (mutation) {
-            if (mutation.type === "attributes") {
+            if (mutation.type === "attributes" && readyForBookmarks === false) {
                 if (document.body.getAttribute('data-ids-assigned')
                         && document.body.getAttribute('data-fingerprints-assigned')) {
+                    readyForBookmarks = true;
                     ebBookmarksInit();
+                    bookmarksObserver.disconnect();
                 }
             }
         });


### PR DESCRIPTION
We were setting the listener on the bookmarks icon multiple times by not exiting the mutationObserver loop when calling `ebBookmarksInit()`. This resolves that problem.

I noticed it on the EBT's plain-text samples chapter, where the bookmarks modal was opening and closing an odd number of extra times, meaning it appeared to not open at all.

@bertuss I seem to remember you spotted this or something like it when working on bookmark syncing recently? You may have fixed it another way in your work.