### PR TITLE
Add flag for docx export

### DIFF
--- a/_configs/_config.docx.yml
+++ b/_configs/_config.docx.yml
@@ -1,0 +1,4 @@
+# Config flags for export to .docx
+
+export:
+  format: docx

--- a/run-linux.sh
+++ b/run-linux.sh
@@ -963,7 +963,7 @@ Enter a number and hit enter. "
 
 			# We turn off the math engine so that we get raw TeX output,
 			# and because Pandoc does not support SVG output anyway.
-			bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,_configs/_config.math-disabled.yml,$config"
+			bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,_configs/_config.math-disabled.yml,_configs/_config.docx.yml,$config"
 
 			# Return to default error handling
 			set +e

--- a/run-mac.command
+++ b/run-mac.command
@@ -929,7 +929,7 @@ Enter a number and hit enter. "
 
 			# We turn off the math engine so that we get raw TeX output,
 			# and because Pandoc does not support SVG output anyway.
-			bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,_configs/_config.math-disabled.yml,$config"
+			bundle exec jekyll build --config="_config.yml,_configs/_config.$fromformat.yml,_configs/_config.math-disabled.yml,_configs/_config.docx.yml,$config"
 
 			# Return to default error handling
 			set +e

--- a/run-windows.bat
+++ b/run-windows.bat
@@ -889,7 +889,7 @@ set /p process=Enter a number and hit return.
             :: ...and run Jekyll to build new HTML.
             :: We turn off the math engine so that we get raw TeX output,
             :: and because Pandoc does not support SVG output anyway.
-            call bundle exec jekyll build --config="_config.yml,_configs/_config.%fromformat%.yml,_configs/_config.math-disabled.yml,%config%" || exit /b
+            call bundle exec jekyll build --config="_config.yml,_configs/_config.%fromformat%.yml,_configs/_config.math-disabled.yml,_configs/_config.docx.yml,%config%" || exit /b
 
             :: Navigate to the HTML we just generated
             if "%subdirectory%"=="" cd _site\%bookfolder%\text


### PR DESCRIPTION
This allows us to use `site.export.format` as a flag in markdown and includes for testing whether we are outputting HTML for Word export. For example, if we need to modify the question include to show which MCQ answers are correct in Word outputs for authors, we can add:

```liquid
{% comment %} Note correct answers explicitly in docx exports {% endcomment %}
{% if site.export.format == "docx" %}
<p>
	<strong>Correct answer{% if question-correct-options.size > 1 %}s{% endif %}:
		{% for number in question-correct-options %}
			{{ number }}{% unless forloop.last %}, {% endunless %}
		{% endfor %}
	</strong>
</p>
{% endif %}
```