### PR TITLE
Add gitpod config and Dockerfile

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,3 +1,8 @@
+# This Dockerfile defines a virtual machine for gitpod.io
+# so that you can  use this Electric Book template project
+# in your browser (i.e. an online development environment).
+# See https://www.gitpod.io/docs/config-docker
+
 FROM ubuntu:20.04
 
 # Set default locale for the environment

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:20.04
+
+# Set default locale for the environment
+ENV LC_ALL C.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Install dependencies required to set timezone 
+RUN apt-get update && apt-get install -y \
+  locales libcurl4 curl
+
+# Set timezone
+RUN ln -snf /usr/share/zoneinfo/$(curl https://ipapi.co/timezone) /etc/localtime
+
+# Add node source for nodejs version 12, instead of Ubuntu installed node (version 10)
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
+
+# Main dependency installation and clear apt cache to make image smaller
+RUN apt-get update && apt-get install -y \
+  software-properties-common \
+  make \
+  gcc \
+  build-essential \
+  git \
+  wget \
+  libgif7 \
+  libpixman-1-0 \
+  libffi-dev \
+  libreadline-dev \
+  zlib1g-dev \
+  nodejs \
+  ruby \
+  ruby-dev \
+  graphicsmagick && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install PrinceXML for printing to PDF
+RUN wget https://www.princexml.com/download/prince_11.4-1_ubuntu18.04_amd64.deb && \
+  dpkg -i prince_11.4-1_ubuntu18.04_amd64.deb
+
+# Install pandoc for document conversion
+RUN wget https://github.com/jgm/pandoc/releases/download/2.5/pandoc-2.5-1-amd64.deb && \
+  dpkg -i pandoc-2.5-1-amd64.deb
+
+# Pin RubyGems to 3.0.8
+# (https://github.com/rubygems/rubygems/issues/3068)
+RUN gem update --system 3.0.8 --no-document
+
+# Install Bundler and latest EBT-compatible Jekyll
+RUN gem install bundler jekyll:3.9.2
+
+# Install Gulp cli app
+RUN npm install --global gulp-cli
+
+# Copy the build to where it will run
+WORKDIR /app
+COPY . /app
+
+# Install gems in Gemfile
+RUN bundle install
+
+# Install modules in package.json
+RUN npm install \
+  && npm install gulp-cli

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,25 +3,13 @@
 # in your browser (i.e. an online development environment).
 # See https://www.gitpod.io/docs/config-docker
 
-FROM ubuntu:20.04
+FROM gitpod/workspace-ruby-2
 
-# Set default locale for the environment
-ENV LC_ALL C.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
+# Need to be root to apt install
+USER root
 
-# Install dependencies required to set timezone 
-RUN apt-get update && apt-get install -y \
-  locales libcurl4 curl
-
-# Set timezone
-RUN ln -snf /usr/share/zoneinfo/$(curl https://ipapi.co/timezone) /etc/localtime
-
-# Add node source for nodejs version 12, instead of Ubuntu installed node (version 10)
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
-
-# Main dependency installation and clear apt cache to make image smaller
-RUN apt-get update && apt-get install -y \
+# Main dependency installation
+RUN sudo apt-get update && apt-get install -y \
   software-properties-common \
   make \
   gcc \
@@ -33,11 +21,31 @@ RUN apt-get update && apt-get install -y \
   libffi-dev \
   libreadline-dev \
   zlib1g-dev \
-  nodejs \
-  ruby \
-  ruby-dev \
-  graphicsmagick && \
-  rm -rf /var/lib/apt/lists/*
+  graphicsmagick
+
+# Dependencies specifically for Puppeteer on unix
+RUN sudo apt-get install -y \
+  libasound2 \
+  libatk1.0-0 \
+  libatk-bridge2.0-0 \
+  libcairo2 \
+  libdrm2 \
+  libgbm1 \
+  libnss3 \
+  libpango-1.0-0 \
+  libxkbcommon-x11-0 \
+  libxcomposite1 \
+  libxdamage1 \
+  libxfixes3 \
+  libxrandr2
+
+# # Clear apt cache to make image smaller
+RUN sudo apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+# Add node source for new nodejs, instead of old Ubuntu-installed node.
+# That install script also prompts to do sudo apt-get install -y nodejs
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
+RUN sudo apt-get install -y nodejs
 
 # Install PrinceXML for printing to PDF
 RUN wget https://www.princexml.com/download/prince_11.4-1_ubuntu18.04_amd64.deb && \
@@ -47,23 +55,28 @@ RUN wget https://www.princexml.com/download/prince_11.4-1_ubuntu18.04_amd64.deb 
 RUN wget https://github.com/jgm/pandoc/releases/download/2.5/pandoc-2.5-1-amd64.deb && \
   dpkg -i pandoc-2.5-1-amd64.deb
 
-# Pin RubyGems to 3.0.8
-# (https://github.com/rubygems/rubygems/issues/3068)
-RUN gem update --system 3.0.8 --no-document
-
-# Install Bundler and latest EBT-compatible Jekyll
-RUN gem install bundler jekyll:3.9.2
+# Update npm
+RUN npm install -g npm@latest
 
 # Install Gulp cli app
 RUN npm install --global gulp-cli
 
-# Copy the build to where it will run
-WORKDIR /app
-COPY . /app
+# Switch to the gitpod user
+USER gitpod
 
-# Install gems in Gemfile
-RUN bundle install
+# Set paths for Ruby gems
+RUN echo '# Define Ruby Gems path' >> ~/.bashrc
+RUN echo 'export GEM_HOME="$HOME/.rvm/gems/ruby-2.7.6"' >> ~/.bashrc
+RUN echo 'export PATH="$HOME/.rvm/gems/ruby-2.7.6:$PATH"' >> ~/.bashrc
+RUN bash -lc "source ~/.bashrc"
 
-# Install modules in package.json
-RUN npm install \
-  && npm install gulp-cli
+# Install gems.
+# Note we do this here, not in a gitpod `init` task
+# because changes to files outside /workspace,
+# like gem installs, are lost in prebuilds, which
+# only save the /workspace. We could also try installing
+# these dependencies in a `before` task, but that would
+# run twice, potentially making builds slower.
+# (https://www.gitpod.io/docs/configure/projects/prebuilds#workspace-directory-only)
+COPY Gemfile .
+RUN bash -lc "bundle install"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,8 +5,49 @@
 image:
   file: .gitpod.Dockerfile
 
+tasks:
+  - name: Setup and show EB commands
+    init: |
+      npm install
+      npm run eb
+
 ports:
   - name: Electric Book server
-    description: A web output of your Electric Book project 
+    description: A web output of your Electric Book project
     port: 4000
-    onOpen: open-browser
+
+vscode:
+
+  # This extension lets us see live-refreshing PDF outputs
+  # in the browser, e.g. during page refinement.
+  extensions:
+    - yandeu.five-server
+
+github:
+
+  # Tells Gitpod to build workspaces automatically
+  # when these events happen, so that they open quickly.
+  prebuilds:
+
+    # Enable for the default branch (defaults to true)
+    master: true
+
+    # Enable for all branches in this repo (defaults to false)
+    branches: true
+
+    # Enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+
+    # Enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+
+    # Add a check to pull requests (defaults to true)
+    addCheck: true
+
+    # Add a "Review in Gitpod" button as a comment
+    # to pull requests (defaults to false)
+    addComment: false
+
+    # Add a "Review in Gitpod" button to the pull request's
+    # description (defaults to false)
+    addBadge: false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,5 @@
+# This file defines how gitpod.io should make this project
+# available for editing in its browser-based IDE.
 # See https://www.gitpod.io/docs/config-gitpod-file
 
 image:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+# See https://www.gitpod.io/docs/config-gitpod-file
+
+image:
+  file: .gitpod.Dockerfile
+
+ports:
+  - name: Electric Book server
+    description: A web output of your Electric Book project 
+    port: 4000
+    onOpen: open-browser


### PR DESCRIPTION
This makes it possible to use the Electric Book template entirely online using https://gitpod.io's online IDE. This is new and experimental for the Electric Book template, so your mileage may vary. If/when it works for you, it replaces the need to set up any Electric Book dependencies on your local machine for web, PDF and epub output (app development still requires local tooling).
