### PR TITLE
Update Ruby setup in build checker

### DIFF
--- a/.github/workflows/build-checker.yml
+++ b/.github/workflows/build-checker.yml
@@ -13,7 +13,7 @@ jobs:
                 fetch-depth: 2
 
             - name: Set up Ruby 2.7
-              uses: actions/setup-ruby@v1
+              uses: ruby/setup-ruby@v1
               with:
                 ruby-version: 2.7
 


### PR DESCRIPTION
Following GitHub Actions build error and advice at https://github.com/actions/setup-ruby#readme:

> This action [actions/ruby-setup@v1] is deprecated and should no longer be used. The team at GitHub has ceased making and accepting code contributions or maintaining issues tracker. Please, migrate your workflows to the ruby/setup-ruby, which is being actively maintained by the official Ruby organization.