### PR TITLE
Allow hiding books as 'unpublished'

### DIFF
--- a/_docs/setup/setting-up-a-book.md
+++ b/_docs/setup/setting-up-a-book.md
@@ -32,6 +32,12 @@ To create a new book in a new project:
 1.  Inside each book's folder, store images in the `images/_source` folder. Add a `cover.jpg` image of your book's front cover there, too.
 1. In each book's `styles` folder, edit the values in `print-pdf.scss`, `screen-pdf.scss`, `web.scss` and `epub.scss`.
 
+### Marking a book as 'unpublished'
+
+Sometimes you are working on a book but you do not yet want it to be included in places like navigation lists and the content API. To mark it as unpublished, add `published: false` to its `default.yml` file.
+
+Its HTML files will still be generated (unless you exclude them in a `_config` file), but it will not be listed in places that draw book data from `_data/works`.
+
 ## Creating book content
 
 Each markdown file in `space-potatoes` is a part of a book, such as a table of contents or a chapter. Each file must start with:

--- a/_includes/files-listed.html
+++ b/_includes/files-listed.html
@@ -5,6 +5,14 @@
 
     {% for work in site.data.works %}
 
+        {% comment %} If this work is not published, skip it. {% endcomment %}
+        {% if work[1][variant].published == false %}
+            {% continue %}
+        {% endif %}
+        {% if work[1].default.published == false %}
+            {% continue %}
+        {% endif %}
+
         {% capture list-of-files-work-directory %}{{ work[0] }}{% endcapture %}
 
         {% include files-listed-by-work.html directory=list-of-files-work-directory %}

--- a/_includes/metadata-work.html
+++ b/_includes/metadata-work.html
@@ -25,6 +25,14 @@ Also, where a value for a variant isn't available,
 we fall back to the value in the work's default.yml.
 {% endcomment %}
 
+{% comment %} We assume a work is published unless `published` is false. {% endcomment %}
+{% assign published = true %}
+{% if work[work-variant].published == false %}
+    {% assign published = false %}
+{% elsif work.default.published == false %}
+    {% assign published = false %}
+{% endif %}
+
 {% if work[work-variant].title and work[work-variant].title != "" %}
     {% capture title %}{{ work[work-variant].title }}{% endcapture %}
 {% elsif work.default.title and work.default.title != "" %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -119,6 +119,14 @@
                         {% assign this-work = work[1] %}
                     {% endif %}
 
+                    {% comment %} If this work is not published, skip it. {% endcomment %}
+                    {% if this-work[variant].published == false %}
+                        {% continue %}
+                    {% endif %}
+                    {% if this-work.default.published == false %}
+                        {% continue %}
+                    {% endif %}
+
                     {% comment %}Use the relevant output's nav, all fallback to web nav.{% endcomment %}
                     {% if this-work[variant].products[site.output].nav and this-work[variant].products[site.output].nav != "" %}
                         {% assign home-nav-work-tree = this-work[variant].products[site.output].nav %}
@@ -154,6 +162,14 @@
                             {% endif %}
                         {% else %}
                             {% assign this-work = work[1] %}
+                        {% endif %}
+
+                        {% comment %} If this work is not published, skip it. {% endcomment %}
+                        {% if this-work[variant].published == false %}
+                            {% continue %}
+                        {% endif %}
+                        {% if this-work.default.published == false %}
+                            {% continue %}
                         {% endif %}
 
                         {% comment %}Use the relevant output's nav, all fallback to web nav.{% endcomment %}


### PR DESCRIPTION
I was working on a project recently that includes many books, some of which are still in development. I needed a way to keep them in the repo, but prevent them from being included in the web and app outputs.

This PR proposes a way to do that. It lets you add `published: false` to a given book's YAML file(s) in `_data` (e.g. to `_data/works/book/default.yml`). If that is set, then the book will not appear in navigation or the content API (or other processes that use `files-listed`).
