### PR TITLE
Fix PDF footnotes

### DIFF
--- a/_docs/editing/notes.md
+++ b/_docs/editing/notes.md
@@ -14,7 +14,7 @@ There are various options for notes.
 
 ## Endnotes
 
-Endnotes appear at the end of a document (a web page or book chapter). In kramdown and on the web these are often called footnotes. To create them in markdown, follow the [kramdown syntax for footnotes](https://kramdown.gettalong.org/syntax.html#footnotes):
+Endnotes appear at the end of a document (a web page or book chapter). In markdown these are usually called footnotes (because on the web they appear at the bottom of the web page). To create them in markdown, follow the [kramdown syntax for footnotes](https://kramdown.gettalong.org/syntax.html#footnotes):
 
 *	put a `[^1]` where the footnote reference should appear (the `1` there can be any numbers or letters, and should be different for each footnote in a document);
 *	anywhere in the document (we recommend after the paragraph containing the footnote reference), put `[^1]: Your footnote text here.`.
@@ -47,6 +47,8 @@ To create true bottom-of-page footnotes, as opposed to endnotes, use the same sy
   [^20]: The text of the note.
          {:.move-to-footnote}
   ```
+
+Note that converting endnotes to footnotes only affects PDF output. Web, epub and app outputs will still use endnotes.
 
 > Technically, `footnotes.js` and `_print-notes.scss` convert endnotes completely from kramdown footnotes to [PrinceXML footnotes](https://www.princexml.com/doc-prince/#footnotes). They may look similar by default, but they are different elements and can be styled separately.
 {:.box}

--- a/_sass/template/partials/_print-notes.scss
+++ b/_sass/template/partials/_print-notes.scss
@@ -42,48 +42,26 @@ $print-notes: true !default;
         margin: ($line-height-default * 0.75) 0 0 0;
     }
 
-    // True footnotes (we call them page-footnotes for clarity)
-    // For styling see https://www.princexml.com/doc-prince/#footnote-calls
-    .page-footnote {
-        float: footnote;
-        font-size: $font-size-default * $font-size-smaller;
-        footnote-style-position: inside;
-        text-indent: -($paragraph-indent);
-        margin-left: $paragraph-indent;
-        // Rule above
-        &:first-of-type {
-            border-top: $rule-thickness solid $color-text-secondary;
-            padding-top: $line-height-default;
-        }
-        p {
-            margin-bottom: 0;
-            text-indent: 0;
-            &:first-of-type {
-            }
-        }
-    }
-        // The numbers in front of footnote text
-        *::footnote-marker {
-            float: left;
-            font-size: $font-size-default * $font-size-smaller;
-            width: 0;
-        }
-
-    // Avoid page-footnotes created by footnotes.js
-    // from inheriting blockquote indentation by
-    // reiterating properties that blockquote might override.
-    blockquote .page-footnote {
-        text-indent: -($paragraph-indent);
-        margin-left: $paragraph-indent;
-    }
-
     // The page-footnotes area
     @page {
+        counter-reset: manual-footnote;
+
         @footnote {
+            border-top: $rule-thickness solid $color-text-main;
             margin-top: $line-height-default / 2;
             padding-top: $line-height-default / 2;
             font-size: $font-size-default * $font-size-smaller;
         }
+    }
+
+    // True footnotes (we call them page-footnotes for clarity)
+    // For styling see https://www.princexml.com/doc-prince/#footnote-calls
+
+    // The numbers in front of footnote text
+    *::footnote-marker {
+        float: left;
+        font-size: $font-size-default * $font-size-smaller;
+        width: 0;
     }
 
     // The page-footnote references in body text
@@ -94,9 +72,56 @@ $print-notes: true !default;
         font-size: $font-size-default * 0.7;
         vertical-align: super;
         line-height: none;
+
         // Shift down
         top: $font-size-default / 4;
         position: relative;
     }
 
+    .page-footnote {
+        float: footnote;
+        font-size: $font-size-default * $font-size-smaller;
+        footnote-style-position: inside; // a prince-only property
+        text-indent: -($paragraph-indent);
+        margin-left: $paragraph-indent;
+
+        p {
+            margin-bottom: 0;
+            text-indent: 0;
+        }
+    }
+
+    // Avoid page-footnotes created by footnotes.js
+    // from inheriting blockquote indentation by
+    // reiterating properties that blockquote might override.
+    blockquote .page-footnote {
+        text-indent: -($paragraph-indent);
+        margin-left: $paragraph-indent;
+    }
+
+    // Footnotes created with one-by-one 'move-to-footnote'
+    // class need a different kind of counter, because
+    // in a document with some endnotes and some manual footnotes,
+    // they need to have a different numbering system.
+    // Otherwise, they'll appear at the bottom of the page
+    // but be numbered in order with the endnotes.
+
+    .page-footnote {
+        counter-increment: manual-footnote;
+
+        &::footnote-call {
+            content: counter(manual-footnote, asterisks);
+            font-size: $font-size-default * 0.7;
+            vertical-align: super;
+            line-height: none;
+
+            // Shift down
+            top: $font-size-default / 4;
+            position: relative;
+        }
+
+        &::footnote-marker {
+            content: counter(manual-footnote, asterisks);
+        }
+    }
 }

--- a/assets/js/footnotes.js
+++ b/assets/js/footnotes.js
@@ -56,7 +56,6 @@ function ebMoveEndnoteToFootnote (noteReference) {
 
   // Make a div.page-footnote
   var pageFootnote = document.createElement('div')
-  // pageFootnote.className += ' page-footnote'
   pageFootnote.classList.add('page-footnote')
   pageFootnote.id = footnoteReferenceID
 

--- a/assets/js/footnotes.js
+++ b/assets/js/footnotes.js
@@ -1,105 +1,161 @@
-// Move footnotes to bottoms of pages
+/* eslint no-var: off */
 
-console.log('Checking for footnotes to move to endnotes...');
+// The above comment is necessary because Prince 11
+// can't use let and const, as Standard JS would prefer.
 
-function ebFootnotesToMove() {
-    'use strict';
-    // If there are any footnotes...
-    if (document.querySelector('.footnotes')) {
-        // And if the page-footnotes setting is on,
-        // or at least on for one of the footnotes
-        if (document.body.hasAttribute('data-page-footnotes') ||
-                document.querySelector('.footnotes .page-footnote')) {
-            return true;
-        }
+// Move footnote text to the bottoms of pages by moving them
+// from the end of the document (where kramdown gathers them)
+// to a container div beside their in-text references.
+
+// A counter for footnote references created one-by-one,
+// rather than for an entire page or books.
+var manualFootnoteCounter = 1
+
+function ebFootnotesToMove (wrapper) {
+  'use strict'
+
+  // If there are any footnotes ...
+  if (wrapper.querySelector('.footnotes')) {
+    // ... and if the page-footnotes setting is on,
+    // or at least on for one of the footnotes
+    if (wrapper.hasAttribute('data-page-footnotes') ||
+        wrapper.querySelector('.footnotes .move-to-footnote')) {
+      // ... then return true
+      return true
     }
+  }
 }
 
-function ebMoveEndnoteToFootnote(noteReference) {
-    'use strict';
+function ebMoveEndnoteToFootnote (noteReference) {
+  'use strict'
 
-    var footnoteReferenceID, endnote, pageFootnote,
-            containingElement, footnoteReferenceContainer;
+  // Get the footnote ID
+  var footnoteReferenceID = noteReference.hash
 
-    // get the footnote ID
-    footnoteReferenceID = noteReference.hash;
+  // NOTE: Prince's .hash behaviour is unusual: it strips the # out.
+  // So, let's use getElementById instead of querySelector.
+  // If it starts with a hash, chop it out.
+  if (footnoteReferenceID.indexOf('#') === 0) {
+    footnoteReferenceID = footnoteReferenceID.replace('#', '')
+  }
 
-    // NOTE: Prince's .hash behaviour is unusual: it strips the # out
-    // So, let's use getElementById instead of querySelector.
-    // If it starts with a hash, chop it out.
-    if (footnoteReferenceID.indexOf('#') === 0) {
-        footnoteReferenceID = footnoteReferenceID.replace('#', '');
+  // Find the li with the ID from the .footnote's href
+  var endnote = document.getElementById(footnoteReferenceID)
+
+  // Check that we should actually process this footnote.
+  // If the data-page-footnotes setting isn't applied to this doc...
+  var wrapper = noteReference.closest('.wrapper')
+  if (!wrapper.hasAttribute('data-page-footnotes')) {
+    // ...check whether this particular footnote should be moved.
+    if (!endnote.querySelector('.move-to-footnote')) {
+      endnote.classList.add('endnote-text')
+      noteReference.classList.add('endnote-reference')
+      return
     }
+  }
 
-    // Find the li with the ID from the .footnote's href
-    endnote = document.getElementById(footnoteReferenceID);
+  // Make a div.page-footnote
+  var pageFootnote = document.createElement('div')
+  // pageFootnote.className += ' page-footnote'
+  pageFootnote.classList.add('page-footnote')
+  pageFootnote.id = footnoteReferenceID
 
-    // Check that we should actually process this footnote.
-    // If the data-page-footnotes setting isn't applied to this doc...
-    if (!document.body.hasAttribute('data-page-footnotes')) {
-        // ...check whether this particular footnote should be moved.
-        if (!endnote.querySelector('.move-to-footnote')) {
-            return;
-        }
-    }
+  // Add and increment the manual-footnote counter
+  if (endnote.querySelector('.move-to-footnote')) {
+    pageFootnote.setAttribute('page-footnote-counter', manualFootnoteCounter)
+    manualFootnoteCounter += 1
+  }
 
-    // Make a div.page-footnote
-    pageFootnote = document.createElement('div');
-    pageFootnote.className += ' page-footnote';
-    pageFootnote.id = footnoteReferenceID;
+  // Get the sup that contains the footnoteReference a.footnote
+  var footnoteReferenceContainer = noteReference.parentNode
 
-    // Get the sup that contains the footnoteReference a.footnote
-    footnoteReferenceContainer = noteReference.parentNode;
+  // Get the element that contains the footnote reference
+  var containingElement = noteReference.parentNode.parentNode
 
-    // Get the element that contains the footnote reference
-    containingElement = noteReference.parentNode.parentNode;
+  // and add a class to it.
+  containingElement.parentNode.className += ' contains-footnote'
 
-    // and add a class to it.
-    containingElement.parentNode.className += ' contains-footnote';
+  // Move the endnote contents inside the div.page-footnote
+  pageFootnote.innerHTML = endnote.innerHTML
 
-    // Move the endnote contents inside the div.page-footnote
-    pageFootnote.innerHTML = endnote.innerHTML;
+  // Insert the new .page-footnote at the reference.
+  // Technically, before the <sup> that contains the reference <a>.
+  // We have to use insertBefore because Prince borks at insertAdjacentElement.
+  containingElement.insertBefore(pageFootnote, footnoteReferenceContainer)
 
-    // Insert the new .page-footnote at the reference.
-    // Technically, before the <sup> that contains the reference <a>.
-    // We have to use insertBefore because Prince borks at insertAdjacentElement.
-    containingElement.insertBefore(pageFootnote, footnoteReferenceContainer);
-
-    // Remove the old endnote, and the old reference to it
-    // (Prince creates new references to page-footnotes)
-    endnote.parentNode.removeChild(endnote);
-    footnoteReferenceContainer.parentNode.removeChild(footnoteReferenceContainer);
-
+  // Remove the old endnote, and the old reference to it
+  // (Prince creates new references to page-footnotes)
+  endnote.parentNode.removeChild(endnote)
+  footnoteReferenceContainer.parentNode.removeChild(footnoteReferenceContainer)
 }
 
-function ebEndnotesToFootnotes() {
-    'use strict';
+function ebFootnotesRenumberEndnotes () {
+  'use strict'
 
-    // get all the a.footnote links
-    var footnoteReferences = document.querySelectorAll('.footnote');
+  // Get all the endnote lists in the doc
+  var endNoteLists = document.querySelectorAll('div.footnotes ol')
 
-    // Process all the footnotes
-    var i;
-    for (i = 0; i < footnoteReferences.length; i += 1) {
-        ebMoveEndnoteToFootnote(footnoteReferences[i]);
+  // For each list, update the endnote numbers
+  endNoteLists.forEach(function (list) {
+    var endnoteListItems = list.querySelectorAll('li.endnote-text')
 
-        // // If page-footnotes are on for the document,
-        // // move all the endnotes to page footnotes
-        // if (document.body.getAttribute('data-page-footnotes')) {
-        //     ebMoveEndnoteToFootnote(footnoteReferences[i]);
-        // } else {
-        //     // If a given endnote contains .move-to-footnote,
-        //     // move that one endnote.
-        //     console.log('footnoteReferences[i].innerHTML: ' + footnoteReferences[i].innerHTML);
-        //     if (footnoteReferences[i].querySelector('.move-to-footnote')) {
-        //         ebMoveEndnoteToFootnote(footnoteReferences[i]);
-        //     }
-        // }
+    // If we moved any notes to on-page footnotes with .move-to-footnote,
+    // and we still have a list of endnotes, then we must renumber the endnote
+    // references, because now the reference numbers will not match the
+    // auto-numbered list of endnotes.
+    // Note that the endnote *references* might be repeated (e.g. two places
+    // in the text that refer to the same endnote).
+
+    var i
+    for (i = 0; i < endnoteListItems.length; i += 1) {
+      var endnoteNewNumber = i + 1
+      var endnoteOldID = endnoteListItems[i].id
+      var endnoteNewID = endnoteOldID.replace(/fn:\d+$/, 'fn:' + endnoteNewNumber)
+      var endnoteReferences = document.querySelectorAll('[href="#' + endnoteOldID + '"]')
+
+      // Update all the endnote references that refer to the old number
+      endnoteReferences.forEach(function (reference) {
+        reference.innerHTML = endnoteNewNumber
+        reference.hash = endnoteNewID
+      })
+
+      // Update the IDs of the endnotes sequentially
+      endnoteListItems[i].id = endnoteListItems[i].id.replace(/fn:\d+$/, 'fn:' + endnoteNewNumber)
     }
+  })
 }
 
-/// If there are footnotes to move, move them.
-if (ebFootnotesToMove()) {
-    console.log('Yes, we have footnotes to move...');
-    ebEndnotesToFootnotes();
+function ebEndnotesToFootnotes (wrapper) {
+  'use strict'
+
+  // Get all the a.footnote links we want to move
+  var footnoteReferences = wrapper.querySelectorAll('.footnote')
+
+  // Process all those footnotes
+  var i
+  for (i = 0; i < footnoteReferences.length; i += 1) {
+    ebMoveEndnoteToFootnote(footnoteReferences[i])
+
+    if (i === footnoteReferences.length - 1) {
+      console.log('On-page footnotes moved. Now to renumber endnotes ...')
+      ebFootnotesRenumberEndnotes()
+    }
+  }
 }
+
+// If there are footnotes to move, move them.
+function ebFootnotesForPDF () {
+  'use strict'
+
+  var wrappers = document.querySelectorAll('.wrapper')
+
+  wrappers.forEach(function (wrapper) {
+    if (ebFootnotesToMove(wrapper)) {
+      console.log('We have endnotes to move to page footnotes ...')
+      ebEndnotesToFootnotes(wrapper)
+    }
+  })
+}
+
+// Go
+ebFootnotesForPDF()

--- a/samples/01-07-notes.md
+++ b/samples/01-07-notes.md
@@ -4,20 +4,21 @@ title: "Notes"
 
 ## Notes
 
-In Electric Book themes, we aim to support three kinds of notes: footnotes, sidenotes, and (what we call) footer notes.
+In Electric Book themes, we aim to support four kinds of notes: endnotes, footnotes, sidenotes, and (what we call) footer notes.
 
--	**Footnotes**, which appear at the end of a document (web page or book chapter). In book parlance, they are therefore actually endnotes, but we call them footnotes because that's what kramdown calls them. To create them in markdown, follow the [kramdown syntax for footnotes](https://kramdown.gettalong.org/syntax.html#footnotes):
+- **Endnotes** appear at the end of a document (web page or book chapter). In technical markdown terms, these are called footnotes, because on the web they appear at the bottom of a web page. To create them in markdown, follow the [kramdown syntax for footnotes](https://kramdown.gettalong.org/syntax.html#footnotes):
 	-   put a `[^1]` where the footnote reference should appear (the `1` there can be any numbers or letters, and should be different for each footnote in a document);
 	-   anywhere in the document (we recommend after the paragraph containing the footnote reference), put `[^1]: Your footnote text here.`.
--	**Sidenotes** appear in a box to the right of the text. On wide screens, they might float far right of the text. On narrower screens, the text might wrap around them. In print, the text might wrap around them, too, or they might appear in an otherwise empty sidebar space. To create a sidenote, give the paragraph a `{:.sidenote}` tag. If the sidenote includes more than one paragraph, put them in a `<div class="sidenote" markdown="1"> ... </div>`.
--	**Footer notes**, which in print are sidenotes at the bottom of the page. By adding `.bottom` to the `{:.sidenote}` tag, your sidenote should sit at the bottom of the page rather than on the right with text wrap, replicating a traditional footnote. So the markdown looks like this:
+- **Footnotes** appear at the bottom of the page. To distinguish these from what markdown calls 'footnotes', we sometimes call these 'on-page footnotes'. To create these, use the same syntax as for endnotes (above), but add a `move-to-footnote` class to the footnote text. This section of the samples book demonstrates endnotes with a few on-page footnotes. We only support these in PDF output.
+- **Sidenotes** appear in a box to the right of the text. On wide screens, they might float far right of the text. On narrower screens, the text might wrap around them. In print, the text might wrap around them, too, or they might appear in an otherwise empty sidebar space. To create a sidenote, give the paragraph a `{:.sidenote}` tag. If the sidenote includes more than one paragraph, put them in a `<div class="sidenote" markdown="1"> ... </div>`.
+- **Footer notes**, which in print are sidenotes at the bottom of the page. By adding `.bottom` to the `{:.sidenote}` tag, your sidenote should sit at the bottom of the page rather than on the right with text wrap, replicating a traditional footnote. So the markdown looks like this:
 
 	```md
 	This is a sidenote at the bottom of the page in print.
 	{:.sidenote .bottom}
 	```
 
-	On screen, these might just be regular sidenotes.
+	This only affects PDF output. In other outputs, these remain regular sidenotes.
 
 ### Principles of Network Architecture Emerging from Comparisons of the Cerebral Cortex in Large and Small Brains
 {: title="Principles of Network Architecture" }
@@ -70,14 +71,17 @@ Finally, how a computational device scales may take advantage of how it is made 
 [^1]: Finlay BL, Darlington RB. Linked regularities in the development and evolution of mammalian brains. Science. 1995; 268(5217): 1578–1584. pmid:7777856 doi: 10.1126/science.7777856
 
 [^2]: Miller KD. Canonical computations of cerebral cortex. Current Opinion in Neurobiology, 2016; 37: 75–84. doi: 10.1016/j.conb.2016.01.008. pmid:26868041
+      {:.move-to-footnote}
 
 [^3]: Bastos AM, Usrey WM, Adams RA, Mangun GR, Fries P, Friston KJ. Canonical microcircuits for predictive coding. Neuron, 2012; 76(4): 695–711. doi: 10.1016/j.neuron.2012.10.038. pmid:23177956
+      {:.move-to-footnote}
 
 [^4]: Krubitzer L. In search of a unifying theory of complex brain evolution. Annals NY Acad Sci. 2009: 1156: 44–67. doi: 10.1111/j.1749-6632.2009.04421.x
 
 [^5]: O'Reilly RC, Herd SA, Pauli WM. Computational models of cognitive control. Current Opinion in Neurobiology, 2010; 20(2), 257–261. doi: 10.1016/j.conb.2010.01.008. pmid:20185294
 
 [^6]: Finlay BL, Uchiyama R. Developmental mechanisms channeling cortical evolution. Trends Neurosci. 2015;38(2):69–76. doi: 10.1016/j.tins.2014.11.004. pmid:25497421
+      {:.move-to-footnote}
 
 [^7]: Kaas J. Why is brain size so important: design problems and solutions as neocortex gets bigger or smaller. Brain and Mind. 2000;1:7–23.
 


### PR DESCRIPTION
I missed this when creating EBTv2's merged HTML, so on-page footnotes were broken in PDF output. This fixes that, improves the logic, and adds examples.