### PR TITLE
Support and use Prince for Books

### DIFF
--- a/_docs/setup/princexml.md
+++ b/_docs/setup/princexml.md
@@ -21,6 +21,25 @@ It is important for everyone working on a project to use the same version of Pri
   }
 ```
 
+### Non-semver Prince versions
+
+Prince for Books and prince latest builds do not use semantic versioning. If you want to use those, you need a slightly different syntax for setting the Prince version.
+
+For Prince for books, use `books-YYYMMDD`, e.g.:
+
+```json
+  "prince": {
+    "version": "books-20220701"
+  }
+```
+
+For a latest build, use `YYYMMDD`, e.g.:
+
+```json
+  "prince": {
+    "version": "20220701"
+  }
+```
 
 ## Adding a Prince license
 

--- a/_sass/template/partials/_epub-boxes.scss
+++ b/_sass/template/partials/_epub-boxes.scss
@@ -10,7 +10,9 @@
     border: $rule-thickness solid $border-color;
     margin: $line-height-default 0;
     padding: ($line-height-default / 2);
-    & p:last-of-type {
+    & p:last-of-type,
+    & ol:last-of-type,
+    & ul:last-of-type {
         margin-bottom: 0;
     }
     // No text-indent on paragraphs after boxes

--- a/_sass/template/partials/_epub-code.scss
+++ b/_sass/template/partials/_epub-code.scss
@@ -13,14 +13,17 @@ $epub-code: true !default;
         padding: 0.1em 0.3em;
         border-radius: 0.2em;
     }
+
     pre {
         border-radius: 0.2em;
         margin: $line-height-default 0;
-        padding: $line-height-default / 2;
+        padding: 0 $paragraph-indent;
         clear: left;
+
         code {
             padding: 0;
         }
+
         & + p {
            text-indent: 0;
         }

--- a/_sass/template/partials/_epub-mixins--sidenotes.scss
+++ b/_sass/template/partials/_epub-mixins--sidenotes.scss
@@ -44,4 +44,18 @@
             text-indent: 0;
         }
     }
+
+    h1, h2, h3, h4, h5, h6 {
+
+        &:first-child {
+            margin-top: 0;
+        }
+    }
+
+    p, ul, ol, dl {
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
 }

--- a/_sass/template/partials/_epub-toc.scss
+++ b/_sass/template/partials/_epub-toc.scss
@@ -23,7 +23,7 @@ $epub-toc: true !default;
 					}
 				}
 			}
-		} // #content
+		} // .content
 	} // .contents-page
 
 	// TOCs in individual pages, created in kramdown

--- a/_sass/template/partials/_print-code.scss
+++ b/_sass/template/partials/_print-code.scss
@@ -13,13 +13,16 @@ $print-code: true !default;
     	padding: 0.1em 0.3em;
     	border-radius: 0.2em;
     }
+
     pre {
         border-radius: 0.2em;
         margin: $line-height-default 0;
-        padding: $line-height-default / 2;
+        padding: 0 $paragraph-indent;
+
         code {
         	padding: 0;
         }
+
         & + p {
            text-indent: 0;
         }

--- a/_sass/template/partials/_print-page-headers-footers-content.scss
+++ b/_sass/template/partials/_print-page-headers-footers-content.scss
@@ -19,7 +19,7 @@ $print-page-headers-footers-content: true !default;
   }
 
   // Assign strings to use in headers and footers for each level of heading (h1-h6),
-  // to be called by the header and footer variables ($verso-top-center etc.).
+  // to be called by the header and footer variables ($verso-top-right etc.).
   // For each heading, we use the title attribute, with the heading text as fallback.
   // h1 also sets the string for h2, in case there is no h2 on the page yet.
   //

--- a/_sass/template/partials/_print-page-setup.scss
+++ b/_sass/template/partials/_print-page-setup.scss
@@ -14,7 +14,9 @@ $print-page-setup: true !default;
 		prince-trim: $trim;
 		prince-pdf-page-colorspace: $colorspace;
 	}
-	/* Name our book-part styles as divs. PrinceXML needs the pages named for @page rules. */
+
+	// Name our book-part styles as divs.
+	// PrinceXML needs the pages named for @page rules.
 	.cover {
 		page: cover;
 	}
@@ -40,7 +42,7 @@ $print-page-setup: true !default;
 		page: contents-page;
 	}
 	.frontmatter {
-		page: frontmatter; /* Use for any other frontmatter */
+		page: frontmatter; // Use for any other frontmatter
 	}
 	.part-page {
 		page: part-page;
@@ -48,5 +50,4 @@ $print-page-setup: true !default;
 	.chapter {
 		page: chapter;
 	}
-
 }

--- a/_sass/template/partials/_web-base-typography.scss
+++ b/_sass/template/partials/_web-base-typography.scss
@@ -80,7 +80,12 @@ $web-base-typography: true !default;
 
     ol, ul {
         list-style-position: outside;
-        margin: 0 0 $line-height-default $paragraph-indent;
+
+        // We have to use a large left margin to prevent
+        // markers from disappearing off the browser window.
+        // Lists inherit zero padding from the body element.
+        // See https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Lists_and_Counters/Consistent_list_indentation
+        margin: 0 0 $line-height-default ($paragraph-indent * 2);
     }
     ol {
         list-style-type: decimal;

--- a/_sass/template/partials/_web-boxes.scss
+++ b/_sass/template/partials/_web-boxes.scss
@@ -10,7 +10,9 @@
     border: $rule-thickness solid $border-color;
     margin: $line-height-default 0;
     padding: ($line-height-default / 2);
-    & p:last-of-type {
+    & p:last-of-type,
+    & ol:last-of-type,
+    & ul:last-of-type {
         margin-bottom: 0;
     }
     // No text-indent on paragraphs after boxes

--- a/_sass/template/partials/_web-code.scss
+++ b/_sass/template/partials/_web-code.scss
@@ -13,14 +13,17 @@ $web-code: true !default;
         padding: 0.1em 0.3em;
         border-radius: 0.2em;
     }
+
     pre {
         border-radius: 0.2em;
         margin: $line-height-default 0;
-        padding: $line-height-default / 2;
+        padding: 0 $paragraph-indent;
         clear: left;
+
         code {
             padding: 0;
         }
+
         & + p {
            text-indent: 0;
         }

--- a/_sass/template/partials/_web-mixins--sidenotes.scss
+++ b/_sass/template/partials/_web-mixins--sidenotes.scss
@@ -76,4 +76,18 @@
             margin-right: inherit;
         }
     }
+
+    h1, h2, h3, h4, h5, h6 {
+
+        &:first-child {
+            margin-top: 0;
+        }
+    }
+
+    p, ul, ol, dl {
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
 }

--- a/_sass/template/partials/_web-toc.scss
+++ b/_sass/template/partials/_web-toc.scss
@@ -25,7 +25,7 @@ $web-toc: true !default;
 					}
 				}
 			}
-		} // #content
+		} // .content
 	} // .contents-page
 
 
@@ -69,6 +69,6 @@ $web-toc: true !default;
 				}
 			}
 		} // #markdown-toc
-	} // #content
+	} //.content
 
 }

--- a/_tools/gulp/processors/svgs.js
+++ b/_tools/gulp/processors/svgs.js
@@ -102,6 +102,7 @@ function svgProcess (outputFormat) {
           name: 'preset-default',
           params: {
             overrides: {
+              cleanupEnableBackground: true,
               cleanupIDs: {prefix: prefix + '-', minify: true},
               cleanupListOfValues: true,
               convertShapeToPath: false,

--- a/assets/js/shift-elements.js
+++ b/assets/js/shift-elements.js
@@ -66,20 +66,14 @@ function ebShiftDown(element) {
     }
 }
 
-window.onload = function () {
-    'use strict';
+var elementsToShiftUp = document.querySelectorAll('[class*="shift-up"]');
+var i;
+for (i = 0; i < elementsToShiftUp.length; i += 1) {
+    ebShiftUp(elementsToShiftUp[i]);
+}
 
-    console.log('Checking for elements to shift...');
-
-    var elementsToShiftUp = document.querySelectorAll('[class*="shift-up"]');
-    var i;
-    for (i = 0; i < elementsToShiftUp.length; i += 1) {
-        ebShiftUp(elementsToShiftUp[i]);
-    }
-
-    var elementsToShiftDown = document.querySelectorAll('[class*="shift-down"]');
-    var j;
-    for (j = 0; j < elementsToShiftDown.length; j += 1) {
-        ebShiftDown(elementsToShiftDown[j]);
-    }
-};
+var elementsToShiftDown = document.querySelectorAll('[class*="shift-down"]');
+var j;
+for (j = 0; j < elementsToShiftDown.length; j += 1) {
+    ebShiftDown(elementsToShiftDown[j]);
+}

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     ]
   },
   "prince": {
-    "version": "11.4",
+    "version": "books-20220701",
     "license": "_prince/license.dat"
   }
 }

--- a/samples/styles/print-pdf-variant.scss
+++ b/samples/styles/print-pdf-variant.scss
@@ -1,0 +1,7 @@
+---
+# Example variant stylesheet for print PDF
+---
+
+@import "print-pdf.css";
+
+// Add variant styles here.


### PR DESCRIPTION
In addition to some CSS fixes implemented during testing, this supports and implements using Prince for Books as the default Prince version for PDF output. This is associated with https://github.com/electricbookworks/node-prince/pull/4.

One important change here is that we now pass the book's stylesheet to Prince as a 'user stylesheet'. The advantage of this is that Prince will apply the stylesheet to any SVGs referenced in the document with `img src="*.svg"`. In previous Prince versions, it was already the case that the book's CSS would apply to SVGs. This had the advantage of letting us apply the parent document's fonts to SVGs. The potential downside of loading the styles as a user stylesheet is that this appears to replace (not just 'extend') the CSS loaded by `style` tags in the HTML. For our use case, this is fine since we only ever load one stylesheet, but in theory one could reference multiple stylesheets in HTML, which may then be ignored when we load a user stylesheet. I think this is worth it, given the importance of loading fonts correctly in SVGs, without having to define font styles and paths to font files in individual SVG files.

The current version of Prince for Books appears to be based on Prince 14. We may soon switch to Prince 15 instead, given its [support for a proper @sidenotes area](https://css4.pub/2023/sidenotes/). There is not yet a Prince for Books based on Prince 15.