### PR TITLE
Allow for `chapter` pages with no sidebar

### DIFF
--- a/_sass/template/partials/_pdf-columns.scss
+++ b/_sass/template/partials/_pdf-columns.scss
@@ -15,6 +15,17 @@ $pdf-columns: true !default;
     .content {
         column-count: $columns-default;
         column-gap: $columns-gap-default;
+
+        // When column-count is 1, Prince collapses
+        // margin-top on the first heading in a div,
+        // which we don't want. So we use auto,
+        // which should default to one column anyway,
+        // but doesn't cause the unexpected behaviour.
+
+        @if $columns-default == 1 {
+            column-count: auto;
+        }
+
         // column-fill: auto; // do not balance columns
         // Allow document-level overrides by
         // columns-x class on body element

--- a/_sass/template/partials/_pdf-page-setup.scss
+++ b/_sass/template/partials/_pdf-page-setup.scss
@@ -15,39 +15,13 @@ $pdf-page-setup: true !default;
 		prince-pdf-page-colorspace: $colorspace;
 	}
 
-	// Name our book-part styles as divs.
-	// PrinceXML needs the pages named for @page rules.
-	.cover {
-		page: cover;
-	}
-	.halftitle-page, .half-title-page {
-		page: halftitle-page;
-	}
-	.title-page {
-		page: title-page;
-	}
-	.previous-publications-page {
-		page: previous-publications-page;
-	}
-	.copyright-page {
-		page: copyright-page;
-	}
-	.dedication-page {
-		page: dedication-page;
-	}
-	.frontispiece-page {
-		page: frontispiece-page;
-	}
-	.contents-page {
-		page: contents-page;
-	}
-	.frontmatter {
-		page: frontmatter; // Use for any other frontmatter
-	}
-	.part-page {
-		page: part-page;
-	}
-	.chapter {
-		page: chapter;
+	// Give names to pages
+
+	$named-page-styles: cover, halftitle-page, half-title-page, title-page, previous-publications-page, copyright-page, dedication-page, frontispiece-page, contents-page, frontmatter, part-page, chapter, $pages-with-sidebar, $pages-without-sidebar;
+
+	@each $page-style in $named-page-styles {
+		.wrapper.#{$page-style} {
+			page: $page-style;
+		}
 	}
 }

--- a/_sass/template/partials/_pdf-sidebar.scss
+++ b/_sass/template/partials/_pdf-sidebar.scss
@@ -19,4 +19,21 @@ $pdf-sidebar: true !default;
             }
         }
     }
+
+    @each $page-style in $pages-without-sidebar {
+        @page #{$page-style}:left {
+            @leftnote {
+                padding-right: 0;
+                width: 0;
+            }
+        }
+
+        @page #{$page-style}:right {
+            @rightnote {
+                box-sizing: border-box;
+                padding-left: 0;
+                width: 0;
+            }
+        }
+    }
 }

--- a/_sass/template/print-pdf.scss
+++ b/_sass/template/print-pdf.scss
@@ -58,6 +58,11 @@ $sidebar-gap-width: 5mm;
 // Which page styles have a sidebar? These correspond to
 // the styles used in markdown YAML frontmatter as `page: ""`
 $pages-with-sidebar: frontmatter, chapter;
+// Which pages should not have a sidebar?
+// This is for overriding sidebars on pages that
+// would be included in $pages-with-sidebar,
+// were it not for this page style.
+$pages-without-sidebar: index-page;
 
 // Colours
 $colorspace: cmyk !default; // auto | none | rgb | cmyk | gray

--- a/_sass/template/print-pdf.scss
+++ b/_sass/template/print-pdf.scss
@@ -149,7 +149,7 @@ $start-on: right !default; // right | left | auto
 // Set the default start-depth of pages.
 // This is the distance from the top of the page to the first element on the first page.
 // Set it in multiples of $line-height-default to preserve your baseline grid.
-$start-depth: $line-height-default * 6 !default;
+$start-depth: 0 !default;
 
 // Style of page numbers on frontmatter pages
 // Remember to tag links to front matter pages in your TOC with {:.frontmatter-reference}

--- a/_sass/template/print-pdf.scss
+++ b/_sass/template/print-pdf.scss
@@ -139,7 +139,7 @@ $text-divider-image-height: $line-height-default !default;
 // Should chapters start on a right-hand page (recto) or on any page?
 // This setting applies to the frontmatter, dedication-page, epigraph-page and chapter page styles.
 // (The halftitle-page, title-page and contents-page page styles always start on a recto.)
-$start-on: right !default; // right or auto or left ()
+$start-on: right !default; // right | left | auto
 
 // Set the default start-depth of pages.
 // This is the distance from the top of the page to the first element on the first page.

--- a/samples/10-01-traditional-index.md
+++ b/samples/10-01-traditional-index.md
@@ -1,5 +1,6 @@
 ---
 title: "Traditional index"
+style: chapter index-page
 ---
 
 ## Traditional index

--- a/samples/10-02-dynamic-index.md
+++ b/samples/10-02-dynamic-index.md
@@ -1,5 +1,6 @@
 ---
 title: "Dynamic index"
+style: chapter index-page
 ---
 
 ## Dynamic index


### PR DESCRIPTION
This lets us specify page styles that don't have a sidebar. In our `samples` book, for instance, we don't need a sidebar in the back-of-book index.

This also includes a couple of small CSS fixes.
