### PR TITLE
Add `noindex` options

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -175,6 +175,19 @@ web:
   # --------------
   page-tags:
     html-title-divider: " &ndash; "
+  # --------------
+  # SEO
+  # --------------
+  seo:
+    # Use 'noindex' here to prevent Google (etc.) from
+    # including your site in its search results.
+    # The 'live: index' option applies only to builds
+    # that use _config.live.yml. All default and other builds
+    # are 'development' builds. Set 'development: noindex'
+    # to prevent Google (etc.) from indexing those.
+    indexing:
+      development: index
+      live: index
 
 # ----------------------------------------------------------
 # Epub settings

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,8 +19,8 @@
     <meta name="date" content="{{ date }}"/>
     <meta name="generator" content="Electric Book"/>
 
-    {% comment %}If this is a translation with its own styles,
-    load the parent styles first, then translation styles override them.{% endcomment %}
+    {% comment %} If this is a translation with its own styles,
+    load the parent styles first, then translation styles override them. {% endcomment %}
     {% if is-translation and translation-styles-exist %}
         <link rel="stylesheet" type="text/css" href="{{ path-to-parent-styles-directory }}/{{ print-pdf-stylesheet }}" />
     {% endif %}
@@ -69,8 +69,8 @@ separate HTML files are merged into one body element.
     <meta name="date" content="{{ date }}"/>
     <meta name="generator" content="Electric Book"/>
 
-    {% comment %}If this is a translation with its own styles,
-    load the parent styles first, then translation styles override them.{% endcomment %}
+    {% comment %} If this is a translation with its own styles,
+    load the parent styles first, then translation styles override them. {% endcomment %}
     {% if is-translation and translation-styles-exist %}
         <link rel="stylesheet" type="text/css" href="{{ path-to-parent-styles-directory }}/{{ screen-pdf-stylesheet }}" />
     {% endif %}
@@ -102,19 +102,19 @@ separate HTML files are merged into one body element.
 
     <title>{{ html-title }}</title>
 
-    {% comment %}This full meta tag is necessary for Kindle's character encoding to work.{% endcomment %}
+    {% comment %} This full meta tag is necessary for Kindle's character encoding to work. {% endcomment %}
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
-    {% comment %}If this is a translation with its own styles,
-    load the parent styles first, then translation styles override them.{% endcomment %}
+    {% comment %} If this is a translation with its own styles,
+    load the parent styles first, then translation styles override them. {% endcomment %}
     {% if is-translation and translation-styles-exist %}
         <link rel="stylesheet" type="text/css" href="{{ path-to-parent-styles-directory }}/{{ epub-stylesheet }}" />
     {% endif %}
 
     <link rel="stylesheet" type="text/css" href="{{ path-to-styles-directory }}/{{ epub-stylesheet }}" />
 
-    {% comment %}Metadata defined in page frontmatter overrides
-    project metadata, which is the default from `_data/works`.{% endcomment %}
+    {% comment %} Metadata defined in page frontmatter overrides
+    project metadata, which is the default from `_data/works`. {% endcomment %}
     {% if page.title %}{% capture title %}{{ page.title }}{% endcapture %}{% endif %}
     {% if page.language %}{% capture language %}{{ page.language }}{% endcapture %}{% endif %}
     {% if page.creator %}{% capture creator %}{{ page.creator }}{% endcapture %}{% endif %}
@@ -170,8 +170,8 @@ separate HTML files are merged into one body element.
     {% endcomment %}
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com https://fonts.googleapis.com https://www.youtube.com http://player.vimeo.com; style-src 'self' 'unsafe-inline'; media-src * content:; img-src 'self' data: content:;{% if site.mathjax-enabled == true %} script-src 'self' 'unsafe-inline' 'unsafe-eval';{% endif %}">
 
-    {% comment %}OpenGraph metadata. While apps might not use this metadata,
-    descriptions etc. are useful for search indexing.{% endcomment %}
+    {% comment %} OpenGraph metadata. While apps might not use this metadata,
+    descriptions etc. are useful for search indexing. {% endcomment %}
 
     {% include meta-tags.html %}
 
@@ -184,14 +184,14 @@ separate HTML files are merged into one body element.
     {% comment %} Reuse OG description for generic meta description tag {% endcomment %}
     <meta name="description" content="{{ meta-tag-description }}" />
 
-    {% comment %}If we're not in a book subdirectory, load the project stylesheet.
+    {% comment %} If we're not in a book subdirectory, load the project stylesheet.
     Otherwise, load the styles for this book. {% endcomment %}
     {% if is-root-directory == true or page.collection == "docs" or is-translation-root-directory == true %}
         <link rel="stylesheet" type="text/css" media="all" href="{{ path-to-root-directory }}assets/styles/{{ app-stylesheet }}" />
     {% else %}
 
-        {% comment %}If this is a translation with its own styles,
-        load the parent styles first, then translation styles override them.{% endcomment %}
+        {% comment %} If this is a translation with its own styles,
+        load the parent styles first, then translation styles override them. {% endcomment %}
         {% if is-translation and translation-styles-exist %}
             <link rel="stylesheet" type="text/css" href="{{ path-to-parent-styles-directory }}/{{ app-stylesheet }}" />
         {% endif %}
@@ -242,10 +242,10 @@ separate HTML files are merged into one body element.
         <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.canonical-url }}">
     {% endif %}
 
-    {% comment %}Add favicon{% endcomment %}
+    {% comment %} Add favicon {% endcomment %}
     <link rel="icon" type="image/png" href="{{ path-to-root-directory }}assets/images/web/favicon.png">
 
-    {% comment %}OpenGraph metadata{% endcomment %}
+    {% comment %} OpenGraph metadata {% endcomment %}
 
     {% include meta-tags.html %}
 
@@ -258,14 +258,14 @@ separate HTML files are merged into one body element.
     {% comment %} Reuse OG description for generic meta description tag {% endcomment %}
     <meta name="description" content="{{ meta-tag-description }}" />
 
-    {% comment %}If we're not in a book subdirectory, load the project stylesheet.
+    {% comment %} If we're not in a book subdirectory, load the project stylesheet.
     Otherwise, load the styles for this book. {% endcomment %}
     {% if is-root-directory == true or page.collection == "docs" or page.collection == "api" or is-translation-root-directory == true %}
         <link rel="stylesheet" type="text/css" media="all" href="{{ site.baseurl }}/assets/styles/{{ web-stylesheet }}" />
     {% else %}
 
-        {% comment %}If this is a translation with its own styles,
-        load the parent styles first, then translation styles override them.{% endcomment %}
+        {% comment %} If this is a translation with its own styles,
+        load the parent styles first, then translation styles override them. {% endcomment %}
         {% if is-translation and translation-styles-exist %}
             <link rel="stylesheet" type="text/css" href="{{ path-to-parent-styles-directory }}/{{ web-stylesheet }}" />
         {% endif %}
@@ -274,7 +274,7 @@ separate HTML files are merged into one body element.
 
     {% endif %}
 
-    {% comment %}Enable web monetization{% endcomment %}
+    {% comment %} Enable web monetization {% endcomment %}
     {% if site.data.settings.web.monetization.enabled == true %}
         <meta name="monetization" content={{ site.data.settings.web.monetization.ilp-pointer }}>
     {% endif %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -225,6 +225,13 @@ separate HTML files are merged into one body element.
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
+    {% comment %} Prevent search indexing if set in settings.yml {% endcomment %}
+    {% if site.build == "live" and site.data.settings.web.seo.indexing.live == "noindex" %}
+        <meta name="robots" content="noindex">
+    {% elsif site.data.settings.web.seo.indexing.development == "noindex" %}
+        <meta name="robots" content="noindex">
+    {% endif %}
+
     {% comment %}
     Self referencing canonicals help tell search engines
     a specific URL is the master copy of a page avoiding problems


### PR DESCRIPTION
This lets us specify whether a site's `live` or `development` builds should include a `noindex` meta tag that prevents Google from including its pages in search results.

The EBT default allows all builds to be indexed. This is necessary for [the EBT website itself](https://electricbookworks.github.io/electric-book/), and for any site that is deployed directly from the master branch without the ability to specify the `_config.live.yml` config in its build command.

For sites that are deployed live using `_config.live.yml` (e.g. ones [deployed with CodeShip](https://github.com/electricbookworks/electricbook-codeship-ci-cd)), it can be useful to turn off indexing on non-live builds, to prevent accidentally letting Google index preview builds (e.g. if a deploy preview URL were to be posted to the open web where Google's bots could find it).