### PR TITLE
Update Node for GitPod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -43,19 +43,28 @@ RUN sudo apt-get install -y \
 RUN sudo apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Add node source for new nodejs, instead of old Ubuntu-installed node.
-# https://github.com/nodesource/distributions#installation-instructions
+# https://github.com/nodesource/distributions/wiki/How-to-migrate-to-the-new-repository
 
+# Remove the GPG keyring file associated with the old repository
+RUN sudo rm /etc/apt/keyrings/nodesource.gpg
+# Remove the old repository's list file
+RUN sudo rm /etc/apt/sources.list.d/nodesource.list
+# Define the desired Node.js major version
+RUN NODE_MAJOR=18
+# Update local package index
 RUN sudo apt-get update
+# Install necessary packages for downloading and verifying new repository information
 RUN sudo apt-get install -y ca-certificates curl gnupg
+# Create a directory for the new repository's keyring, if it doesn't exist
 RUN sudo mkdir -p /etc/apt/keyrings
+# Download the new repository's GPG key and save it in the keyring directory
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-
-# Set which version of Node we want
-RUN NODE_MAJOR=20
-
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+# Add the new repository's source list with its GPG key for package verification
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+# Update local package index to recognize the new repository
 RUN sudo apt-get update
-RUN sudo apt-get install nodejs -y
+# Install Node.js from the new repository
+RUN sudo apt-get install -y nodejs
 
 # Install PrinceXML for printing to PDF
 RUN wget https://www.princexml.com/download/prince_11.4-1_ubuntu18.04_amd64.deb && \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -45,13 +45,14 @@ RUN sudo apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 # Add node source for new nodejs, instead of old Ubuntu-installed node.
 # https://github.com/nodesource/distributions#installation-instructions
 
-# Set which version of Node we want
-RUN NODE_MAJOR=18
-
-# Get and install that version
+RUN sudo apt-get update
 RUN sudo apt-get install -y ca-certificates curl gnupg
 RUN sudo mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+
+# Set which version of Node we want
+RUN NODE_MAJOR=20
+
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 RUN sudo apt-get update
 RUN sudo apt-get install nodejs -y

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -45,10 +45,6 @@ RUN sudo apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 # Add node source for new nodejs, instead of old Ubuntu-installed node.
 # https://github.com/nodesource/distributions/wiki/How-to-migrate-to-the-new-repository
 
-# Remove the GPG keyring file associated with the old repository
-RUN sudo rm /etc/apt/keyrings/nodesource.gpg
-# Remove the old repository's list file
-RUN sudo rm /etc/apt/sources.list.d/nodesource.list
 # Define the desired Node.js major version
 RUN NODE_MAJOR=18
 # Update local package index

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -79,7 +79,7 @@ RUN npm install --global gulp-cli
 USER gitpod
 
 # Let gitpod own the NPM cache dir
-RUN sudo chown -R 33333:33333 "$HOME/.npm/CustomCacheDir"
+RUN sudo chown -R 33333:33333 "$HOME/.npm"
 
 # Set paths for Ruby gems
 RUN echo '# Define Ruby Gems path' >> ~/.bashrc

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -78,6 +78,9 @@ RUN npm install --global gulp-cli
 # Switch to the gitpod user
 USER gitpod
 
+# Let gitpod own the NPM cache dir
+RUN sudo chown -R 33333:33333 "$HOME/gitpod/.npm/CustomCacheDir"
+
 # Set paths for Ruby gems
 RUN echo '# Define Ruby Gems path' >> ~/.bashrc
 RUN echo 'export GEM_HOME="$HOME/.rvm/gems/ruby-2.7.6"' >> ~/.bashrc

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -79,7 +79,7 @@ RUN npm install --global gulp-cli
 USER gitpod
 
 # Let gitpod own the NPM cache dir
-RUN sudo chown -R 33333:33333 "$HOME/gitpod/.npm/CustomCacheDir"
+RUN sudo chown -R 33333:33333 "$HOME/.npm/CustomCacheDir"
 
 # Set paths for Ruby gems
 RUN echo '# Define Ruby Gems path' >> ~/.bashrc

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -45,8 +45,6 @@ RUN sudo apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 # Add node source for new nodejs, instead of old Ubuntu-installed node.
 # https://github.com/nodesource/distributions/wiki/How-to-migrate-to-the-new-repository
 
-# Define the desired Node.js major version
-RUN NODE_MAJOR=18
 # Update local package index
 RUN sudo apt-get update
 # Install necessary packages for downloading and verifying new repository information
@@ -56,7 +54,8 @@ RUN sudo mkdir -p /etc/apt/keyrings
 # Download the new repository's GPG key and save it in the keyring directory
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 # Add the new repository's source list with its GPG key for package verification
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+# Note: `node_20` means Node version 20. Update in future as needed.
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 # Update local package index to recognize the new repository
 RUN sudo apt-get update
 # Install Node.js from the new repository

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -43,9 +43,18 @@ RUN sudo apt-get install -y \
 RUN sudo apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Add node source for new nodejs, instead of old Ubuntu-installed node.
-# That install script also prompts to do sudo apt-get install -y nodejs
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
-RUN sudo apt-get install -y nodejs
+# https://github.com/nodesource/distributions#installation-instructions
+
+# Set which version of Node we want
+RUN NODE_MAJOR=18
+
+# Get and install that version
+RUN sudo apt-get install -y ca-certificates curl gnupg
+RUN sudo mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN sudo apt-get update
+RUN sudo apt-get install nodejs -y
 
 # Install PrinceXML for printing to PDF
 RUN wget https://www.princexml.com/download/prince_11.4-1_ubuntu18.04_amd64.deb && \

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,9 +8,8 @@ image:
 tasks:
   - name: Setup and show EB commands
 
-    # We use a custom NPM cache to avoid Docker cache issues
     init: |
-      npm install --cache="/home/gitpod/.npm/CustomCacheDir"
+      npm install
       npm run eb
 
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,8 +7,10 @@ image:
 
 tasks:
   - name: Setup and show EB commands
+
+    # We use a custom NPM cache to avoid Docker cache issues
     init: |
-      npm install
+      npm install --cache="/home/gitpod/.npm/CustomCacheDir"
       npm run eb
 
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,6 @@ image:
 tasks:
   - name: Setup and show EB commands
     init: |
-      npm install
       npm run eb
 
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,8 +10,7 @@ tasks:
 
     # We use a custom NPM cache to avoid Docker cache issues
     init: |
-      export npm_config_cache=/home/gitpod/.npm/CustomCacheDir
-      npm install
+      npm install --cache="/home/gitpod/.npm/CustomCacheDir"
       npm run eb
 
 ports:
@@ -36,13 +35,13 @@ github:
     master: true
 
     # Enable for all branches in this repo (defaults to false)
-    branches: true
+    branches: false
 
     # Enable for pull requests coming from this repo (defaults to true)
-    pullRequests: true
+    pullRequests: false
 
     # Enable for pull requests coming from forks (defaults to false)
-    pullRequestsFromForks: true
+    pullRequestsFromForks: false
 
     # Add a check to pull requests (defaults to true)
     addCheck: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,6 +11,7 @@ tasks:
     # We use a custom NPM cache to avoid Docker cache issues
     init: |
       npm install --cache="/home/gitpod/.npm/CustomCacheDir"
+      sudo chown -R 33333:33333 "/home/gitpod/.npm/CustomCacheDir"
       npm run eb
 
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -35,13 +35,13 @@ github:
     master: true
 
     # Enable for all branches in this repo (defaults to false)
-    branches: false
+    branches: true
 
     # Enable for pull requests coming from this repo (defaults to true)
-    pullRequests: false
+    pullRequests: true
 
     # Enable for pull requests coming from forks (defaults to false)
-    pullRequestsFromForks: false
+    pullRequestsFromForks: true
 
     # Add a check to pull requests (defaults to true)
     addCheck: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,7 @@ tasks:
 
     # We use a custom NPM cache to avoid Docker cache issues
     init: |
-      npm config set cache /home/gitpod/.npm/CustomCacheDir --global
+      export npm_config_cache=/home/gitpod/.npm/CustomCacheDir
       npm install
       npm run eb
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,10 +7,7 @@ image:
 
 tasks:
   - name: Setup and show EB commands
-
-    # We use a custom NPM cache to avoid Docker cache issues
     init: |
-      npm install --cache="/home/gitpod/.npm/CustomCacheDir"
       npm run eb
 
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,8 +10,8 @@ tasks:
 
     # We use a custom NPM cache to avoid Docker cache issues
     init: |
-      npm install --cache="/home/gitpod/.npm/CustomCacheDir"
-      sudo chown -R 33333:33333 "/home/gitpod/.npm/CustomCacheDir"
+      npm config set cache /home/gitpod/.npm/CustomCacheDir --global
+      npm install
       npm run eb
 
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,6 +8,7 @@ image:
 tasks:
   - name: Setup and show EB commands
     init: |
+      npm install
       npm run eb
 
 ports:


### PR DESCRIPTION
This updates the way we install Node with Docker on GitPod, removing a deprecated approach and using the latest version of Node.