### PR TITLE
Adjust canonical URL, baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ language: en
 # include the url where this site will live when it's live (production).
 # E.g. canonical-url: "https://example.com"
 # In Open Graph metadata, the base URL will be appended.
-canonical-url: "https://electricbookworks.github.io/electric-book"
+canonical-url: "https://electricbookworks.github.io"
 
 # Base URL
 # --------

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -239,7 +239,7 @@ separate HTML files are merged into one body element.
     https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls
     {% endcomment %}
     {% if site.canonical-url and site.canonical-url != "" %}
-        <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.canonical-url }}">
+        <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.canonical-url }}">
     {% endif %}
 
     {% comment %} Add favicon {% endcomment %}


### PR DESCRIPTION
- Remove the duplicate `/electric-book` from the canonical URL in _config.yml
- Include the baseurl in the construction of the canonical URL in head.html