### PR TITLE
Use more reliable nav sorting syntax

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -103,7 +103,8 @@
             {% comment %}If there is only one book, don't include its title{% endcomment %}
             {% if number-of-works == 1 %}
 
-                {% for work in site.data.works | sort: "order" %}
+                {% assign site-data-works = site.data.works | sort %}
+                {% for work in site-data-works %}
 
                     {% comment %} Assume the _data/works book dir is named
                     the same as the book directory. {% endcomment %}
@@ -148,7 +149,8 @@
             {% else %}
 
                 <ol class="nav-book-list">
-                    {% for work in site.data.works | sort: "order" %}
+                    {% assign site-data-works = site.data.works | sort %}
+                    {% for work in site-data-works %}
 
                         {% comment %} Assume the _data/works book dir is named
                         the same as the book directory. {% endcomment %}


### PR DESCRIPTION
I noticed (on the Bettercare project) that on some infrastructure, specifically CodeShip, the nav list is sorted backwards. I can't debug whether this has something to do with a Ruby or gem version, or another factor. I have established that the change in this PR seems to avoid the issue, so it seems worth using in the template.