### PR TITLE
Run HTML transforms after MathJax rendering

### DIFF
--- a/_tools/run/helpers/output/index.js
+++ b/_tools/run/helpers/output/index.js
@@ -51,8 +51,8 @@ async function pdf (argv) {
     await renderIndexComments(argv)
     await renderIndexLinks(argv)
     await merge(argv)
-    await pdfHTMLTransformations(argv)
     await renderMathjax(argv)
+    await pdfHTMLTransformations(argv)
     await runPrince(argv)
     openOutputFile(argv)
   } catch (error) {


### PR DESCRIPTION
Otherwise HTML transformations break MathJax before it can be processed. It makes more sense to run HTML transformations as the last step before the HTML is passed to Prince.