### PR TITLE
Prevent local loading of images, to speed up indexing

### DIFF
--- a/assets/js/render-book-index.js
+++ b/assets/js/render-book-index.js
@@ -53,6 +53,15 @@ function generateTargetsIndex () {
         })
       }
 
+      // Ignore requests to images, to speed up page loads
+      page.on('request', (req) => {
+        if (req.resourceType() === 'image') {
+          req.abort()
+        } else {
+          req.continue()
+        }
+      })
+
       // Go to the page path.
       // Puppeteer requires the protocol (file://) on OSX.
       await page.goto('file://' + path)

--- a/assets/js/render-search-index.js
+++ b/assets/js/render-search-index.js
@@ -43,6 +43,17 @@ function generateIndex () {
         })
       }
 
+      // Ignore requests to images, to speed up page loads
+      await page.setRequestInterception(true)
+
+      page.on('request', (req) => {
+        if (req.resourceType() === 'image') {
+          req.abort()
+        } else {
+          req.continue()
+        }
+      })
+
       // Go to the page URL
       await page.goto(url)
 


### PR DESCRIPTION
Ignore requests by puppeteer to load images during creation of dynamic and search indexes, to speed up index rendering.