### PR TITLE
Fix confusion of MCQs across titles

### DIFF
--- a/_includes/question
+++ b/_includes/question
@@ -11,7 +11,7 @@ of this include on the page. {% endcomment %}
 
 {% comment %}Create a one-file array of question pages
 to look through.{% endcomment %}
-{% capture path-to-question-file %}{% if is-translation %}/{{ language }}{% endif %}/{{ question-file }}.md{% endcapture %}
+{% capture path-to-question-file %}{{ book-directory }}{% if is-translation %}/{{ language }}{% endif %}/{{ question-file }}.md{% endcapture %}
 {% assign questions = site.pages | where_exp: "page", "page.path contains path-to-question-file" %}
 
 {% comment %}Check whether the question-file exists.{% endcomment %}


### PR DESCRIPTION
When two adjacent book folders contain question files with the same filename (e.g. both contain a file called question-01-01.md), the book directory needs to be added to the filepath when checking the question attributes, to ensure that the appropriate correct options are being assigned to each MCQ.