### PR TITLE
Template CSS refinements

### DIFF
--- a/_sass/template/partials/_epub-code.scss
+++ b/_sass/template/partials/_epub-code.scss
@@ -7,7 +7,6 @@ $epub-code: true !default;
 
     code {
         font-family: $font-code;
-        font-size: 90%;
         line-height: $line-height-default;
         white-space: pre-wrap;
         padding: 0.1em 0.3em;

--- a/_sass/template/partials/_epub-tables.scss
+++ b/_sass/template/partials/_epub-tables.scss
@@ -9,7 +9,7 @@ $epub-tables: true !default;
 		font-size: $font-size-default * $font-size-smaller;
 		width: 100%;
 	}
-	thead, th, .table-subhead {
+	thead, th {
 		page-break-after: avoid;
 		font-weight: bold;
 	}

--- a/_sass/template/partials/_pdf-code.scss
+++ b/_sass/template/partials/_pdf-code.scss
@@ -7,7 +7,6 @@ $pdf-code: true !default;
 
     code {
         font-family: $font-code;
-        font-size: 90%;
         line-height: 1;
         white-space: pre-wrap;
         padding: 0.1em 0.3em;

--- a/_sass/template/partials/_pdf-tables.scss
+++ b/_sass/template/partials/_pdf-tables.scss
@@ -10,7 +10,7 @@ $pdf-tables: true !default;
 		width: 100%;
 		max-width: $page-width - $margin-inside - $margin-outside;
 	}
-	thead, th, .table-subhead {
+	thead, th {
 		font-weight: bold;
 		page-break-after: avoid;
 	}

--- a/_sass/template/partials/_web-code.scss
+++ b/_sass/template/partials/_web-code.scss
@@ -7,7 +7,6 @@ $web-code: true !default;
 
     code {
         font-family: $font-code;
-        font-size: 90%;
         line-height: $line-height-default;
         white-space: pre-wrap;
         padding: 0.1em 0.3em;

--- a/_sass/template/partials/_web-tables.scss
+++ b/_sass/template/partials/_web-tables.scss
@@ -19,7 +19,8 @@ $web-tables: true !default;
 			overflow-x: auto;
 		}
 	}
-	thead, th, .table-subhead {
+
+	thead, th {
 		page-break-after: avoid;
 		font-weight: bold;
 	}


### PR DESCRIPTION
This makes two small changes to template CSS:

- Removes opinionated font-size adjustment on code: While it's likely that most font combinations will need the monospaced font's size to be reduced, this should be a custom-theme choice, not built into the template.
- Removes non-accessible class to define table subheads. We should not be encouraging non-semantic ways to define table subheads when `thead` exists.
