### PR TITLE
Epub fixes

### DIFF
--- a/_includes/epub-navmap.html
+++ b/_includes/epub-navmap.html
@@ -39,7 +39,6 @@ Otherwise, the toc-branch should be the children called by this include recursiv
 
 {% if toc-branch == nil %}
     {% assign toc-branch = toc %}
-    {% assign ncx-depth = 1 %}
     {% assign navpoint-id = 0 %}
 {% endif %}
 

--- a/_includes/epub-package.html
+++ b/_includes/epub-package.html
@@ -226,7 +226,8 @@
         {% endif %}
 
         {% comment %}If a toc.ncx exists, add it{% endcomment %}
-        {% assign ncx-check = site.pages | where_exp: "file", "file.path contains '/toc.ncx'" %}
+        {% capture path-to-epub-ncx %}{{ book-directory }}/{% if is-translation %}{{ book-subdirectory }}/{% endif %}toc.ncx{% endcapture %}
+        {% assign ncx-check = site.pages | where_exp: "file", "file.path contains path-to-epub-ncx" %}
         {% if ncx-check.size > 0 %}
             <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
         {% endif %}

--- a/_tools/gulp/processors/epub.js
+++ b/_tools/gulp/processors/epub.js
@@ -8,6 +8,7 @@ const gulp = require('gulp')
 const iconv = require('iconv-lite')
 const rename = require('gulp-rename')
 const fsPath = require('path')
+const fsExtra = require('fs-extra')
 
 // Local helpers
 const { book, language } = require('../helpers/args.js')
@@ -49,7 +50,12 @@ function epubXhtmlLinks (done) {
     ncxFile = '_site/' + book + '/' + language + '/toc.ncx'
   }
 
-  gulp.src([paths.epub.src, opfFile, ncxFile], { base: './' })
+  const pathsToProcess = [paths.epub.src, opfFile]
+  if (fsExtra.existsSync(fsPath.normalize(ncxFile))) {
+    pathsToProcess.push(ncxFile)
+  }
+
+  gulp.src(pathsToProcess, { base: './' })
     .pipe(cheerio({
       run: function ($) {
         let target, asciiTarget, newTarget

--- a/_tools/run/helpers/requirements.js
+++ b/_tools/run/helpers/requirements.js
@@ -16,7 +16,7 @@ async function checkYAML () {
       'gulp',
       ['yaml', '--silent']
     )
-    let outcome = await helpers.logProcess(gulpProcess, 'Checking YAML')
+    const outcome = await helpers.logProcess(gulpProcess, 'Checking YAML')
     if (outcome === true) {
       return true
     } else {
@@ -40,11 +40,11 @@ async function checkRequiredPaths () {
   // Get the names of the project images for checking
   try {
     const projectYAMLPath = fsPath.normalize(process.cwd() + '/_data/project.yml')
-    const projectYAML = await yaml.load(fsExtra.readFileSync(projectYAMLPath), 'utf8');
+    const projectYAML = await yaml.load(fsExtra.readFileSync(projectYAMLPath), 'utf8')
     projectLogo = projectYAML.logo
     projectImage = projectYAML.image
   } catch (e) {
-    console.log(e);
+    console.log(e)
   }
 
   const globalRequirements = [
@@ -131,7 +131,7 @@ async function checkRequiredPaths () {
     {
       path: 'assets/images/_source/' + projectLogo,
       type: 'optional',
-      description: "A logo for the project and website as a whole."
+      description: 'A logo for the project and website as a whole.'
     },
     {
       path: 'assets/fonts',
@@ -308,8 +308,7 @@ async function checkRequiredPaths () {
 // file is complex to parse, but the files listed are the same as
 // the `store` in search-engine.js, which uses _includes/files-listed.html,
 // which itself parses _data/works for its files lists.
-async function checkAPIContent() {
-
+async function checkAPIContent () {
   console.log('Checking content API...')
 
   const pathToSearchStore = fsPath.normalize(process.cwd() +
@@ -317,14 +316,12 @@ async function checkAPIContent() {
   const searchStoreExists = await fsExtra.pathExists(pathToSearchStore)
 
   if (searchStoreExists) {
-
     const searchStore = await require(pathToSearchStore).store
     let missingFiles = false
     let i
     for (i = 0; i < searchStore.length; i += 1) {
-
-      const apiContentPath = process.cwd() + '/_api/content/'
-          + searchStore[i].url.replace(/\.html$/, '') + '/index.json'
+      const apiContentPath = process.cwd() + '/_api/content/' +
+          searchStore[i].url.replace(/\.html$/, '') + '/index.json'
 
       const apiContentFileExists = await fsExtra.pathExists(fsPath.normalize(apiContentPath))
 
@@ -341,8 +338,8 @@ async function checkAPIContent() {
       console.log(chalk.red('\nPlease update the project web index to refresh API content.\n'))
       return false
     } else {
-      console.log('Content API includes all built files. '
-          + 'You may still want to run the index update.\n')
+      console.log('Content API includes all built content files. ' +
+          'You may still want to run the index update to refresh it.\n')
       return true
     }
   } else {

--- a/_tools/run/helpers/requirements.js
+++ b/_tools/run/helpers/requirements.js
@@ -328,7 +328,8 @@ async function checkAPIContent() {
 
       const apiContentFileExists = await fsExtra.pathExists(fsPath.normalize(apiContentPath))
 
-      if (!apiContentFileExists) {
+      // Don't check for docs files, those are not in the API
+      if (!apiContentFileExists && !searchStore[i].url.startsWith('docs/')) {
         missingFiles = true
         console.log(chalk.red('Warning') + ': API content is missing ' + searchStore[i].url)
       }


### PR DESCRIPTION
This improves handling of toc.ncx files, making our approach to them consistent. They are optional, and our epub manifest and file-renaming processes will adapt accordingly.

This also fixes an issue with the `npm run eb -- check` command, which reported falsely that docs were missing from the content API. Since using `check` is often part of epub debugging, I fixed this here to get cleaner `check` output.