### PR TITLE
Add docs, improvements to feature and image handling

### DIFF
--- a/_data/works/samples/default.yml
+++ b/_data/works/samples/default.yml
@@ -227,10 +227,10 @@ products:
         children:
           - label: "Plain images"
             file: "02-01-plain-images"
-            id: "plain-images"
+            id: "21-plain-images"
           - label: "Figures"
             file: "02-02-figures"
-            id: "figures"
+            id: "22-figures"
       - label: "Part 3: Code and mathematics"
         children:
           - label: "Code"
@@ -422,10 +422,10 @@ products:
         children:
           - label: "Plain images"
             file: "02-01-plain-images"
-            id: "plain-images"
+            id: "21-plain-images"
           - label: "Figures"
             file: "02-02-figures"
-            id: "figures"
+            id: "22-figures"
       - label: "Part 3: Code and mathematics"
         children:
           - label: "Code"

--- a/_docs/editing/images.md
+++ b/_docs/editing/images.md
@@ -25,10 +25,17 @@ Instead, to get responsive images, use this image tag:
 
 where `foobar.jpg` is the original filename of the image.
 
-If necessary, you can add `class`, `id` and/or `alt` attributes to the image, too:
+If necessary, you can add extra attributes to the image:
+
+- `class` applies a CSS class to the image
+- `id` applies an HTML ID to the element
+- `alt` adds alt text, which is important for accessibility and SEO
+- `position` defines where to focus on the image when it is cropped (follows [CSS object-position](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) syntax).
+
+For example:
 
 ``` liquid
-{% include image file="foobar.jpg" class="example" alt="An example image." id="anyuniqueid" %}
+{% include image file="foobar.jpg" class="example" alt="An example image." id="anyuniqueid" position="top" %}
 ```
 
 For accessibility, it's important to always include a description of the image as `alt` text, unless the image is purely decorative.

--- a/_docs/layout/opener-images.md
+++ b/_docs/layout/opener-images.md
@@ -7,14 +7,21 @@ order: 3
 
 # Page-opener images
 
-You can add a single, big opening image to each page. This image is set in the page's top-of-page YAML. E.g. the landing page for the template has:
+You can add a single, big opening image to each page. This image is set in the page's top-of-page YAML. You can define:
+
+- the image to use as `opener-image`
+- alt text for the image as `opener-image-alt-text`
+- which area of the image to focus on, when the screen size and shape crops the image, as `opener-image-position`. This follows the properties for [CSS object-position](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position).
+
+For example, the landing page for the template has:
 
 ```YAML
-opener-image: banner-image.jpg
+opener-image: "banner-image.jpg"
 opener-image-alt-text: "An illustration of an enormous book. It is open, and its pages are each filled with an image of a starry sky. Beside the book, a man stands and looks at the pages. The book is bigger than he is."
+opener-image-position: 0 60%;
 ```
 
-While the `opener-image-alt-text` is optional, it's highly recommended for accessibility and SEO.
+While the `opener-image-alt-text` is optional, it's highly recommended for accessibility and SEO. The `opener-image-position` is optional, and defaults to focus on the center of the image.
 
 Images used on pages inside a book folder should be saved in the same place as other images for that book: in the book's `images/_source` folder and then [automatically converted for the various output formats](image-conversions.html).
 

--- a/_docs/layout/opener-images.md
+++ b/_docs/layout/opener-images.md
@@ -18,7 +18,7 @@ For example, the landing page for the template has:
 ```YAML
 opener-image: "banner-image.jpg"
 opener-image-alt-text: "An illustration of an enormous book. It is open, and its pages are each filled with an image of a starry sky. Beside the book, a man stands and looks at the pages. The book is bigger than he is."
-opener-image-position: 0 60%;
+opener-image-position: "0 60%"
 ```
 
 While the `opener-image-alt-text` is optional, it's highly recommended for accessibility and SEO. The `opener-image-position` is optional, and defaults to focus on the center of the image.

--- a/_docs/setup/seo-sharing-social-media.md
+++ b/_docs/setup/seo-sharing-social-media.md
@@ -1,0 +1,32 @@
+---
+title: SEO, social media, and sharing
+categories: setup
+order: 35
+---
+
+# {{ page.title }}
+
+The template supports many of the most important features you need for good search-engine rankings and good visibility when pages are shared on social media.
+
+You do need to make sure the relevant information, text and images are set up. Here are some of the most important.
+
+## Project-wide information
+
+Make sure that your project's information in `_data/project.yml` is complete, and that the image you define there is in `assets/images/_source` and has been [processed](../images/image-conversions.html).
+
+This information is the default fallback for any page without its own information.
+
+## Page-specific information
+
+Each markdown file will be its own web page. At the top of the file, in the top-of-page YAML, you can specify the following information:
+
+- the `title`
+- the `image` that will appear when the page is shared online. For markdown files in a book folder, the image must be among that book's images. For markdown files outside of a book (like the `index.md` home-page and `about.md` page), the image must be among those in `assets/images`.
+- the short `description` that will appear when the page is shared online.
+
+Here you can also define other information that is used in the template and might be used elsewhere in future:
+
+- the `image-position` defines where to focus on the image when it is cropped (this follows [CSS object-position](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) syntax), for example in the [`visual-toc`](../layout/landing-page.html#a-visual-table-of-contents) that you can include on your landing page.
+- the `opener-image` defines the image to use at the top of the page
+- the `opener-image-alt-text` sets the alt text for that opener image
+- the `opener-image-position` sets where to focus on the image when it is cropped.

--- a/_includes/feature-box
+++ b/_includes/feature-box
@@ -7,9 +7,9 @@ will not have any design in PDF or epub books. {% endcomment %}
     {% if include.image and include.image != "" %}
         <div class="feature-box-image-wrapper">
             {% if is-book-directory %}
-                {% include image file=include.image alt=include.image-alt-text %}
+                {% include image file=include.image alt=include.image-alt-text position=include.image-position %}
             {% else %}
-                {% include image file=include.image folder="assets" alt=include.image-alt-text %}
+                {% include image file=include.image folder="assets" alt=include.image-alt-text position=include.image-position %}
             {% endif %}
         </div>
     {% endif %}

--- a/_includes/image
+++ b/_includes/image
@@ -84,7 +84,8 @@ is not available in web output {% endcomment %}
         class="{% if include.class %}{{ include.class }}{% endif %}{% if image-file-extension == 'svg' %} inject-svg{% endif %}"
         {% if include.id %} id="{{ include.id }}"{% endif %}
         {% if image-alt and image-alt !="" %} alt="{{ image-alt }}"{% endif %}
-        {% if image-title and image-title != "" %} title="{{ image-title }}"{% endif %} />
+        {% if image-title and image-title != "" %} title="{{ image-title }}"{% endif %}
+        {% if include.position and include.position != "" %}style="object-position: {{ include.position }}"{% endif %} />
 
 </noscript>
 {% endif %}
@@ -107,6 +108,7 @@ is not available in web output {% endcomment %}
     class="{% if include.class %}{{ include.class }}{% endif %}{% if image-file-extension == 'svg' %} inject-svg{% endif %}"
     {% if include.id %} id="{{ include.id }}"{% endif %}
     {% if image-alt and image-alt !="" %} alt="{{ image-alt }}"{% endif %}
-    {% if image-title and image-title != "" %} title="{{ image-title }}"{% endif %} />
+    {% if image-title and image-title != "" %} title="{{ image-title }}"{% endif %}
+    {% if include.position and include.position != "" %}style="object-position: {{ include.position }}"{% endif %} />
 
 {% endcapture %}{{ image-tag | strip_newlines | strip }}

--- a/_includes/opener-image.html
+++ b/_includes/opener-image.html
@@ -8,9 +8,9 @@
         the book folder from the page path directly. {% endcomment %}
         {% assign book-for-opener-image = page.path | split: "/" | pop %}
 
-        {% include image class="opener-image" file=page.opener-image folder=book-for-opener-image alt=page.opener-image-alt-text %}
+        {% include image class="opener-image" file=page.opener-image folder=book-for-opener-image alt=page.opener-image-alt-text position=page.opener-image-position %}
     {% else %}
-        {% include image class="opener-image" file=page.opener-image folder="assets" alt=page.opener-image-alt-text %}
+        {% include image class="opener-image" file=page.opener-image folder="assets" alt=page.opener-image-alt-text position=page.opener-image-position %}
     {% endif %}
 </div>
 {% endif %}

--- a/_includes/visual-toc
+++ b/_includes/visual-toc
@@ -18,7 +18,7 @@
                         {% if visual-toc-page-object.image and visual-toc-page-object.image != "" %}
                             <div class="visual-toc-chapter-image">
                                 <a href="{{ visual-toc-path-to-file }}.html">
-                                    {% include image file=visual-toc-page-object.image folder=include.book %}
+                                    {% include image file=visual-toc-page-object.image folder=include.book position=visual-toc-page-object.image-position %}
                                 </a>
                             </div>
                         {% endif %}

--- a/_sass/template/partials/_web-boxes.scss
+++ b/_sass/template/partials/_web-boxes.scss
@@ -111,9 +111,41 @@ $web-boxes: true !default;
         }
     }
 
+    .feature-box {
+        @include box($white, $color-light);
+
+        // border-style: dashed;
+        border-color: $color-accent;
+        margin: 0;
+        max-width: calc(#{$max-width-default} * 0.5 - 2rem);
+        padding: 0;
+
+        .feature-box-image-wrapper {
+            background-color: $white;
+            border: $rule-thickness solid $color-accent;
+            border-radius: 5rem;
+            height: 5rem;
+            width: 5rem;
+            margin: -1rem auto 0 auto;
+            padding: 0.75rem;
+            text-align: center;
+
+            img, svg {
+                border-radius: 5rem;
+                object-fit: cover;
+                width: 100%;
+                height: 100%;
+            }
+        }
+
+        .feature-box-text {
+            margin: 1rem;
+        }
+    }
+
     .feature-boxes {
         display: flex;
-        gap: 2rem 1rem;
+        gap: 2rem 2rem;
         flex-wrap: wrap;
         justify-content: center;
         margin: 4rem 0;
@@ -123,38 +155,6 @@ $web-boxes: true !default;
         @media only screen and (min-width: $max-width-default) {
             width: 100vw;
             margin-left: calc(-1 * ((100vw - #{$max-width-default}) * 0.5 + 1rem))
-        }
-
-        .feature-box {
-            @include box($white, $color-light);
-
-            // border-style: dashed;
-            border-color: $color-accent;
-            margin: 0;
-            max-width: calc(#{$max-width-default} * 0.5 - 2rem);
-            padding: 0;
-
-            .feature-box-image-wrapper {
-                background-color: $white;
-                border: $rule-thickness solid $color-accent;
-                border-radius: 5rem;
-                height: 5rem;
-                width: 5rem;
-                margin: -1rem auto 0 auto;
-                padding: 0.75rem;
-                text-align: center;
-
-                img, svg {
-                    border-radius: 5rem;
-                    object-fit: cover;
-                    width: 100%;
-                    height: 100%;
-                }
-            }
-
-            .feature-box-text {
-                margin: 1rem;
-            }
         }
     }
 

--- a/_sass/template/partials/_web-masthead.scss
+++ b/_sass/template/partials/_web-masthead.scss
@@ -74,6 +74,7 @@ $web-masthead: true !default;
                     align-items: center;
                     display: inline-flex;
                     margin: 0 0.25em 0 0;
+                    min-height: $masthead-height - (0.5rem * 2);
 
                     // The divider between project and book title
                     // Should not show if there is only one work,

--- a/_sass/template/partials/_web-openers.scss
+++ b/_sass/template/partials/_web-openers.scss
@@ -19,6 +19,9 @@ $web-openers: true !default;
 
     .opener-image-wrapper {
 
+        // Avoids white space after image
+        line-height: 0;
+
         .opener-image {
             height: $opener-image-height;
             width: 100%;

--- a/index.md
+++ b/index.md
@@ -5,14 +5,13 @@ title: The Electric Book template
 style: home
 opener-image: banner-image.jpg
 opener-image-alt-text: "An illustration of an enormous book. It is open, and its pages are each filled with an image of a starry sky. Beside the book, a man stands and looks at the pages. The book is bigger than he is."
+opener-image-position: "0 60%"
 ---
 
-{% include metadata %}
-
 # Book-making with superpowers
-{:.no_toc}
 
-The Electric Book template produces **web books, ebooks, and print books from a single content source.** It is [packed with features for professional book production](#features), and lets team members collaborate on projects remotely. You're looking at the default website it generates. {% if  output-docs == true %}[Read the docs]({{ site.baseurl }}/docs/){:.button}{% endif %}
+The Electric Book template is a code framework for producing **web books, ebooks, and print books from a single content source.** It is [packed with features for professional book production](#features), and lets team members collaborate on projects remotely. You're looking at the default website it generates. {% if  output-docs == true %}[Read the docs]({{ site.baseurl }}/docs/){:.button}{% endif %}
+
 
 <div class="feature-boxes">
 
@@ -24,6 +23,7 @@ The Electric Book template produces **web books, ebooks, and print books from a 
 {% include feature-box
    text="Learn from [a book of examples](samples/index.html), with a partial [translation](samples/fr/)."
    image="cover.jpg"
+   image-position="0 35%"
 %}
 
 {% if site.output == "web" and output-docs == true %}
@@ -31,6 +31,7 @@ The Electric Book template produces **web books, ebooks, and print books from a 
 {% include feature-box
    text="The template's [documentation](docs/) explains how its features work."
    image="banner-image.jpg"
+   image-position="0 65%"
 %}
 
 {% endif %}
@@ -42,7 +43,6 @@ You'll find [the open-source repository on GitHub](https://github.com/electricbo
 <div class="color-panel background-000 text-fff links-ccc" markdown="1">
 
 ## Skills required
-{:.no_toc}
 
 To make books this way, you need some web-development know-how. You'll edit content in markdown with Liquid template tags; edit data in YAML files; commit your changes with Git; enter commands at the command line; and build and serve a static website. Design is done in Sass. Many features are written in Javascript.
 

--- a/samples/01-00-text.md
+++ b/samples/01-00-text.md
@@ -3,4 +3,4 @@ title: "Text"
 style: part-page page-1
 ---
 
-# Part 1: Text
+# **Part 1**{:.part-number} Text

--- a/samples/02-00-images.md
+++ b/samples/02-00-images.md
@@ -3,4 +3,4 @@ title: "Images"
 style: part-page
 ---
 
-# Part 2: Images
+# **Part 2**{:.part-number} Images

--- a/samples/02-01-plain-images.md
+++ b/samples/02-01-plain-images.md
@@ -1,16 +1,21 @@
 ---
 title: "Plain images"
 image: "count-of-monte-christo-1.jpg"
+image-position: "top"
 description: "A chapter from *The Count of Monte Christo* interspersed with simple images."
+opener-image: "count-of-monte-christo-1.jpg"
+opener-image-alt-text: "An illustration of Edmond Dantés standing on a ship, from the original edition of The Count of Monte Christo. He is well dressed and carries a walking stick."
+opener-image-position: "top"
 ---
 
 {% include metadata %}
 
-## Plain images
+## **2.1**{:.chapter-number} Plain images
+
+For examples of plain images, here's the first chapter of [*The Count of Monte Christo* by Alexandre Dumas](https://www.gutenberg.org/files/1184/1184-h/1184-h.htm){:#count-2}. This and the next chapter also include a chapter number, to show how that is marked up and renders in the EBT.
 
 Also see the docs on [including images in content](https://electricbookworks.github.io/electric-book/docs/editing/images.html) and [adding them to your project](https://electricbookworks.github.io/electric-book/docs/images/adding-image-files.html).
-
-For examples of plain images, here's the first chapter of [*The Count of Monte Christo* by Alexandre Dumas](https://www.gutenberg.org/files/1184/1184-h/1184-h.htm){:#count-2}.
+{:.sidenote}
 
 First, here is a map of Naples, where the story is set.
 

--- a/samples/02-02-figures.md
+++ b/samples/02-02-figures.md
@@ -4,13 +4,14 @@ image: "fradkin-2.jpg"
 description: "A research paper that includes figures with reference numbers, captions and sources."
 ---
 
-## Figures
-
-Also see the [docs on figures](https://electricbookworks.github.io/electric-book/docs/editing/figures.html).
+## **2.2**{:.chapter-number} Figures
 
 Figures, as we refer to them, are images, or similar visual artifacts (including tables) accompanied by a caption.
 
-To ensure EPUB2 compatibility (which requires valid XHTML 1.1), we don't use the HTML `<figure>` tag, but rather use either:
+Also see the [docs on figures](https://electricbookworks.github.io/electric-book/docs/editing/figures.html).
+{:.sidenote}
+
+To ensure EPUB2 compatibility (which requires valid XHTML 1.1), and to give us more flexibility, we don't use the HTML `<figure>` tag, but rather use either:
 
 * for very simple figures, a paragraph with an `image-with-caption` class that starts with an inline image followed by text; or
 * a div with a `figure` class containing both an image and its caption, created with our `figure` include.

--- a/samples/03-00-code-and-maths.md
+++ b/samples/03-00-code-and-maths.md
@@ -3,4 +3,4 @@ title: "Code and mathematics"
 style: part-page
 ---
 
-# Part 3: Code and mathematics
+# **Part 3**{:.part-number} Code and mathematics

--- a/samples/04-00-interactivity.md
+++ b/samples/04-00-interactivity.md
@@ -3,5 +3,5 @@ title: "Interactivity"
 style: part-page
 ---
 
-# Part 4: Interactivity
+# **Part 4**{:.part-number} Interactivity
 

--- a/samples/10-00-indexes.md
+++ b/samples/10-00-indexes.md
@@ -3,4 +3,4 @@ title: "Indexes"
 style: part-page
 ---
 
-# Part 5: Indexes
+# **Part 5**{:.part-number} Indexes


### PR DESCRIPTION
These are improvements spotted while working on a system for pre-designed themes for the EBT. Incudes:

- The ability to set where to focus on an image when it's auto-cropped (e.g. by `object-fit` properties).
- Documentation for that, and other improvements to docs and samples.
- Fixes to links in nav YAML, since recent numbering of some headings.