### PR TITLE
Accessibility improvements

### DIFF
--- a/_data/locales.yml
+++ b/_data/locales.yml
@@ -200,6 +200,7 @@ en:
     language-select: "Select language"
   video:
     options-button: "Other video options"
+    play-video: "Play video"
   copy:
     copy: "Copy"
     copied: "Copied"
@@ -322,6 +323,7 @@ fr:
     language-select: "Sélectionnez la langue"
   video:
     options-button: "Autres options vidéo"
+    play-video: "Lire la vidéo"
   copy:
     copy: "Copie"
     copied: "Copié"
@@ -724,6 +726,7 @@ es:
     language-select: "Seleccione idioma"
   video:
     options-button: "Otras opciones de vídeo"
+    play-video: "Reproduce el video"
   copy:
     copy: "Copiar"
     copied: "Copiado"

--- a/_data/works/book/default.yml
+++ b/_data/works/book/default.yml
@@ -96,6 +96,27 @@ products:
     # e.g. Paperback, Digital download, Digital online
     format: "Ebook" # e.g. Paperback, Digital download, Digital online
 
+    # Accessibility metadata to inform users
+    # about the accessibility features in this epub.
+    accessibility:
+
+      # A summary statement, see
+      # https://www.w3.org/TR/epub-a11y-tech-11/#accessibilitySummary
+      summary: "This publication conforms to WCAG 2.0 Level AA."
+
+      # Comma-separate textual, visual, auditory, tactile. See
+      # https://www.w3.org/TR/epub-a11y-tech-11/#accessMode
+      access-mode: textual, visual
+      access-mode-sufficient: textual
+
+      # Comma-separate possible values, see
+      # https://www.w3.org/TR/epub-a11y-tech-11/#accessibilityFeature
+      accessibility-features: tableOfContents
+
+      # Comma-separate possible values, see
+      # https://www.w3.org/TR/epub-a11y-tech-11/#accessibilityHazard
+      accessibility-hazard: unknown
+
   # Details about the screen-PDF version of this work
   screen-pdf:
 

--- a/_data/works/samples/default.yml
+++ b/_data/works/samples/default.yml
@@ -484,6 +484,27 @@ products:
     # The epub's cover image
     image: "cover.jpg"
 
+    # Accessibility metadata to inform users
+    # about the accessibility features in this epub.
+    accessibility:
+
+      # A summary statement, see
+      # https://www.w3.org/TR/epub-a11y-tech-11/#accessibilitySummary
+      summary: "This publication conforms to WCAG 2.0 Level AA."
+
+      # Comma-separate textual, visual, auditory, tactile. See
+      # https://www.w3.org/TR/epub-a11y-tech-11/#accessMode
+      access-mode: textual, visual
+      access-mode-sufficient: textual
+
+      # Comma-separate possible values, see
+      # https://www.w3.org/TR/epub-a11y-tech-11/#accessibilityFeature
+      accessibility-features: tableOfContents
+
+      # Comma-separate possible values, see
+      # https://www.w3.org/TR/epub-a11y-tech-11/#accessibilityHazard
+      accessibility-hazard: unknown
+
     # Files to include in this format.
     # In the epub files list, add a value to any file
     # to set any of the guide types listed in

--- a/_includes/epub-package.html
+++ b/_includes/epub-package.html
@@ -63,22 +63,41 @@
         <dc:type>{{ type | escape }}</dc:type>
     {% endif %}
 
-    {% comment %} Accessibility metadata.
-    Note that these values might not apply to your projects. {% endcomment %}
-        <meta property="schema:accessibilitySummary">
-            This publication conforms to WCAG 2.0 Level AA.
-        </meta>
-        <meta property="schema:accessMode">textual</meta>
-        <meta property="schema:accessMode">visual</meta>
-        <meta property="schema:accessModeSufficient">textual,visual</meta>
-        <meta property="schema:accessModeSufficient">textual</meta>
-        <meta property="schema:accessibilityFeature">structuralNavigation</meta>
-        <meta property="schema:accessibilityFeature">alternativeText</meta>
-        <meta property="schema:accessibilityFeature">longDescription</meta>
-        <meta property="schema:accessibilityHazard">noFlashingHazard</meta>
-        <meta property="schema:accessibilityHazard">noSoundHazard</meta>
-        <meta property="schema:accessibilityHazard">noMotionSimulationHazard</meta>
+    {% comment %} Accessibility metadata. {% endcomment %}
 
+    {% if epub-accessibility.summary and epub-accessibility.summary != "" %}
+        <meta property="schema:accessibilitySummary">
+            {{ epub-accessibility.summary }}
+        </meta>
+    {% endif %}
+
+    {% if epub-accessibility.access-mode and epub-accessibility.access-mode != "" %}
+        {% assign accessibility-access-modes = epub-accessibility.access-mode | remove: " " | split: "," %}
+        {% for value in accessibility-access-modes %}
+            <meta property="schema:accessMode">{{ value }}</meta>
+        {% endfor %}
+    {% endif %}
+
+    {% if epub-accessibility.access-mode-sufficient and epub-accessibility.access-mode-sufficient != "" %}
+        {% assign accessibility-sufficient-access-modes = epub-accessibility.access-mode-sufficient | remove: " " | split: "," %}
+        {% for value in accessibility-sufficient-access-modes %}
+        <meta property="schema:accessModeSufficient">{{ value }}</meta>
+        {% endfor %}
+    {% endif %}
+
+    {% if epub-accessibility.accessibility-features and epub-accessibility.accessibility-features != "" %}
+        {% assign accessibility-features = epub-accessibility.accessibility-features | remove: " " | split: "," %}
+        {% for value in accessibility-features %}
+            <meta property="schema:accessibilityFeature">{{ value }}</meta>
+        {% endfor %}
+    {% endif %}
+
+    {% if epub-accessibility.accessibility-hazards and epub-accessibility.accessibility-hazards != "" %}
+        {% assign accessibility-hazards = epub-accessibility.accessibility-hazards | remove: " " | split: "," %}
+        {% for value in accessibility-hazards %}
+            <meta property="schema:accessibilityHazard">{{ value }}</meta>
+        {% endfor %}
+    {% endif %}
     </metadata>
 
     <manifest>

--- a/_includes/image
+++ b/_includes/image
@@ -86,7 +86,7 @@ is not available in web output {% endcomment %}
 
         class="{% if include.class %}{{ include.class }}{% endif %}{% if image-file-extension == 'svg' %} inject-svg{% endif %}"
         {% if include.id %} id="{{ include.id }}"{% endif %}
-        {% if image-alt and image-alt !="" %} alt="{{ image-alt }}"{% endif %}
+        {% if image-alt and image-alt !="" %} alt="{{ image-alt }}"{% else %} role="presentation"{% endif %}
         {% if image-title and image-title != "" %} title="{{ image-title }}"{% endif %}
         {% if include.position and include.position != "" %}style="object-position: {{ include.position }}"{% endif %} />
 
@@ -113,7 +113,7 @@ is not available in web output {% endcomment %}
 
     class="{% if include.class %}{{ include.class }}{% endif %}{% if image-file-extension == 'svg' %} inject-svg{% endif %}"
     {% if include.id %} id="{{ include.id }}"{% endif %}
-    {% if image-alt and image-alt !="" %} alt="{{ image-alt }}"{% endif %}
+    {% if image-alt and image-alt !="" %} alt="{{ image-alt }}"{% else %} role="presentation"{% endif %}
     {% if image-title and image-title != "" %} title="{{ image-title }}"{% endif %}
     {% if include.position and include.position != "" %}style="object-position: {{ include.position }}"{% endif %} />
 

--- a/_includes/metadata-work.html
+++ b/_includes/metadata-work.html
@@ -334,6 +334,12 @@ we fall back to the value in the work's default.yml.
     {% capture epub-image %}{{ image }}{% endcapture %}
 {% endif %}
 
+{% if work[work-variant].products.epub.accessibility and work[work-variant].products.epub.accessibility != "" %}
+    {% assign epub-accessibility  = work[work-variant].products.epub.accessibility %}
+{% elsif work.default.products.epub.accessibility and work.default.products.epub.accessibility != "" %}
+    {% assign epub-accessibility = work.default.products.epub.accessibility %}
+{% endif %}
+
 {% if work[work-variant].products.epub.files and work[work-variant].products.epub.files != "" %}
     {% assign epub-file-list = work[work-variant].products.epub.files %}
 {% elsif work.default.products.epub.files and work.default.products.epub.files != "" %}

--- a/_includes/video
+++ b/_includes/video
@@ -64,6 +64,8 @@ So an image must be specified to get a placeholder image.{% endcomment %}
 <div class="video {{ video-host }}{% if include.class %} {{ include.class }}{% endif %}" id="{{ include.id }}" data-video-id="{{ include.id }}" data-video-language="{{ video-language }}" {% if include.subtitles == "true" %}data-video-subtitles="true"{% endif %}{% if include.start %} data-video-timestamp="{{ include.start }}"{% endif %}>
     <div class="video-wrapper{% if include.image == nil or include.image == "" %} video-no-image{% endif %}">
         <a class="video-link" href="{{ video-link }}{{ video-timestamp }}">
+        <a class="video-link" href="{{ video-link }}{{ video-timestamp }}"
+            title="{{ locale.video.play-video }}">
             {% if include.image and include.image != "" %}
                 {% if include.folder and include.folder != "" %}
                     {% include image file=include.image folder=include.folder %}

--- a/_includes/video
+++ b/_includes/video
@@ -62,8 +62,13 @@ So an image must be specified to get a placeholder image.{% endcomment %}
 {% endif %}
 
 <div class="video {{ video-host }}{% if include.class %} {{ include.class }}{% endif %}" id="{{ include.id }}" data-video-id="{{ include.id }}" data-video-language="{{ video-language }}" {% if include.subtitles == "true" %}data-video-subtitles="true"{% endif %}{% if include.start %} data-video-timestamp="{{ include.start }}"{% endif %}>
-    <div class="video-wrapper{% if include.image == nil or include.image == "" %} video-no-image{% endif %}">
-        <a class="video-link" href="{{ video-link }}{{ video-timestamp }}">
+    <div class="video-wrapper
+        {% if include.image == nil or include.image == "" %}
+            {% unless site.output == "web" and video-host == "youtube" %}
+                video-no-image
+            {% endunless %}
+        {% endif %}">
+
         <a class="video-link" href="{{ video-link }}{{ video-timestamp }}"
             title="{{ locale.video.play-video }}">
             {% if include.image and include.image != "" %}

--- a/assets/js/svg-management.js
+++ b/assets/js/svg-management.js
@@ -80,11 +80,12 @@ function ebSVGInjectImageData (img) {
   // - otherwise use alt text as the title, and omit the desc,
   //   which would simply duplicate the title.
 
-  let title, desc
+  let title, desc, role
 
   // Get a description for the SVG <desc>
   if (img.alt) {
     desc = img.alt
+    role = 'img'
   }
 
   // Get text for the SVG <title>
@@ -96,11 +97,14 @@ function ebSVGInjectImageData (img) {
   } else if (img.alt) {
     title = img.alt
     desc = ''
+  } else {
+    role = 'presentation'
   }
 
   return {
     title,
-    desc
+    desc,
+    role
   }
 }
 
@@ -138,6 +142,22 @@ function ebSVGInjectTitleDesc (svg, imgData) {
     const titleElement = document.createElementNS('http://www.w3.org/2000/svg', 'title')
     titleElement.textContent = imgData.title
     svg.insertAdjacentElement('afterbegin', titleElement)
+  }
+
+  if (imgData.role) {
+    // If the img tag has a role="" attribute,
+    // apply that to the SVG element, too
+    if (!svg.getAttribute('role')) {
+      svg.setAttribute('role', imgData.role)
+
+      // We can't use aria-labelledby=title here, because
+      // we don't have a way to assign an ID to the title
+      // that will definitely be unique in the surrounding document.
+      // So we use aria-label, risking screen-reading duplication.
+      if (imgData.title) {
+        svg.setAttribute('aria-label', imgData.title)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This makes some improvements to accessibility:

- Add title text to the clickable image links that are placeholders for videos, since there is no link text that makes them screen-readable otherwise.
- Automatically assign role=presentation to images with no alt text, assuming they are decorative.
- Add appropriate role and aria-label attributes to inline SVGs.
- Make epub accessibility metadata editable, rather than hard-coding this into our default package.opf.
