### PR TITLE
Refine video: remove unreliable play arrow, improve CSS

### DIFF
--- a/_sass/template/partials/_epub-video.scss
+++ b/_sass/template/partials/_epub-video.scss
@@ -6,54 +6,47 @@ $epub-video: true !default;
 
     .video {
         font-family: $font-text-secondary;
-        margin: 0 0 1em 0;
-        position: relative; // positions child element play button correctly
+        margin: $line-height-default 0;
+        position: relative;
+
         img {
             width: 100%;
         }
-        .video-link {}
+
+        .video-link {
+            display: block;
+            height: 100%;
+        }
+
         .video-description {
             margin-top: $line-height-default;
             text-align: left;
         }
+
         .video-wrapper {
             position: relative;
+
             a {
                 // Show URL on e-ink devices
                 @include show-url();
             }
-            // Add play button before iframe loads
-            &:before {
-                content: "\25b6";
-                position: relative;
-                // position: absolute; // not supported in epub yet
-                font-size: $font-size-default * 3;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%);
-                -webkit-transform: translate(-50%, -50%);
-                color: white;
-                opacity: 0.5;
-            }
+
             // Create placeholder with 16:9 aspect ratio
             // when there is no image to display
             &.video-no-image {
-                width: 100%;
-                padding-bottom: 56.25%;
-                background-color: $color-mid;
+                aspect-ratio: 16/9;
+                background-color: $color-accent;
                 border-radius: $box-border-radius;
+                width: 100%;
             }
+
             // JS will add an iframe here; when it does:
             &.contains-iframe {
-            float: none;
-            clear: both;
-            width: 100%;
-            // Give the iframe an intrinsic ratio on all screens
-            // Credit to https://alistapart.com/article/creating-intrinsic-ratios-for-video
-            position: relative;
-            padding-bottom: 56.25%;
-            padding-top: 25px;
-            height: 0;
+                aspect-ratio: 16/9;
+                float: none;
+                clear: both;
+                width: 100%;
+
                 iframe {
                     // position: absolute; // not supported in epub yet
                     top: 0;
@@ -63,6 +56,7 @@ $epub-video: true !default;
                 }
             }
         }
+
         // Don't indent a paragraph after a video.
         & + p {
             text-indent: 0;

--- a/_sass/template/partials/_pdf-video.scss
+++ b/_sass/template/partials/_pdf-video.scss
@@ -6,39 +6,41 @@ $pdf-video: true !default;
 
     .video {
         font-family: $font-text-secondary;
-        margin: 1em 0;
-        position: relative; // positions child element play button correctly
+        margin: $line-height-default 0;
+        position: relative;
+
         img {
             width: 100%;
         }
-        .video-link {}
+
         .video-description {
             font-size: $font-size-default * 0.8;
             margin: ($line-height-default / 2) 0;
             text-align: left;
         }
+
         .video-wrapper {
-            position: relative;
-            // Add play button before iframe loads
-            &:before {
-                content: "\25b6";
-                position: absolute;
-                font-size: $font-size-default * 3;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%);
-                -webkit-transform: translate(-50%, -50%);
-                color: white;
-            }
+
             // Create placeholder with 16:9 aspect ratio
             // when there is no image to display
             &.video-no-image {
                 width: 100%;
-                padding-bottom: 56.25%;
-                background-color: $color-mid;
+                background-color: $color-accent;
                 border-radius: $box-border-radius;
+
+                .video-link {
+                    display: block;
+
+                    // We use this technique to create a 16/9
+                    // aspect ratio because the aspect-ratio property
+                    // is not supported in Prince yet.
+                    // https://www.princexml.com/forum/topic/4935/aspect-ratio-property
+                    height: 0;
+                    padding-top: 56.25%;
+                }
             }
         }
+
         // Don't indent a paragraph after a video.
         & + p {
             text-indent: 0;

--- a/_sass/template/partials/_web-video.scss
+++ b/_sass/template/partials/_web-video.scss
@@ -6,14 +6,17 @@ $web-video: true !default;
 
     .video {
         font-family: $font-text-secondary;
-        margin: 0 0 1em 0;
-        position: relative; // positions child element play button correctly
+        margin: 0 0 $line-height-default 0;
+        position: relative;
 
         img {
             width: 100%;
         }
 
-        .video-link {}
+        .video-link {
+            display: block;
+            height: 100%;
+        }
 
         .video-description {
             margin-top: $line-height-default;
@@ -27,27 +30,13 @@ $web-video: true !default;
         .video-wrapper {
             position: relative;
 
-            // Add play button before iframe loads
-            &:before {
-                content: "\25b6";
-                cursor: pointer;
-                position: absolute;
-                font-size: $font-size-default * 3;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%);
-                -webkit-transform: translate(-50%, -50%);
-                color: white;
-                opacity: 0.5;
-            }
-
             // Create placeholder with 16:9 aspect ratio
             // when there is no image to display
             &.video-no-image {
-                width: 100%;
-                padding-bottom: 56.25%;
-                background-color: $color-mid;
+                aspect-ratio: 16/9;
+                background-color: $color-accent;
                 border-radius: $box-border-radius;
+                width: 100%;
             }
 
             // JS will add an iframe here; when it does:
@@ -55,13 +44,8 @@ $web-video: true !default;
                 float: none;
                 clear: both;
                 width: 100%;
+                aspect-ratio: 16/9;
 
-                // Give the iframe an intrinsic ratio on all screens
-                // Credit to https://alistapart.com/article/creating-intrinsic-ratios-for-video
-                position: relative;
-                padding-bottom: 56.25%;
-                padding-top: 25px;
-                height: 0;
 
                 iframe {
                     position: absolute;

--- a/samples/04-02-video.md
+++ b/samples/04-02-video.md
@@ -10,8 +10,8 @@ The Electric Book template includes a tag for easily inserting videos from YouTu
 
 In this example, we have a YouTube video, without a description, set to start 14 seconds in. There's an option to watch it elsewhere, too, which won't show on PDF by default.
 
-{% include video id="OJWJE0x7T4Q" start="14" options="
-[Watch on Bilibili](https://www.bilibili.com/video/BV1zE411X76t/)" %}
+{% include video id="oXkSfqmzG1o" start="14" options="
+[Watch on Bilibili](https://www.bilibili.com/video/BV1tG4y1L7u2/)" %}
 
 And a Vimeo one, set to start 5 seconds in.
 


### PR DESCRIPTION
The position of the 'play' arrow our template floated over video thumbnails has been unreliable, and is often unnecessary anyway when in real projects we add a video thumbnail that does the work of indicating a clickable video. So I've removed it.

I've also used more modern CSS for web, app and epub outputs, which also fixes an issue where the video thumbnail was not clickable.

I've also replaced the example video we were using, since good old Sledgehammer is no longer playable when embedded.
