### PR TITLE
Support interactive MCQs in epub

### DIFF
--- a/_sass/template/partials/_epub-questions.scss
+++ b/_sass/template/partials/_epub-questions.scss
@@ -199,6 +199,7 @@ $epub-questions: true !default;
                 // position: absolute; // not valid in epub
                 top: $line-height-default / 2;
                 left: $paragraph-indent;
+                position: absolute;
             }
             li {
                 display: none;

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -119,7 +119,9 @@ have different behaviour for web or app. {% endcomment %}
 
     {% endunless %}
 
-{% comment %} Scripts for epub output. {% endcomment %}
+{% comment %} Scripts for epub output.
+Do not expect support in many readers. {% endcomment %}
 {% if site.output == "epub" %}
+    {% include_relative mcqs.js %}
     {% include_relative show-hide.js %}
 {% endif %}

--- a/assets/js/mcqs.js
+++ b/assets/js/mcqs.js
@@ -1,8 +1,8 @@
-/* global locales, pageLanguage, XMLHttpRequest */
+/* global locales, pageLanguage, settings, XMLHttpRequest */
 
 // -----------------------------
 // Options
-// 1. If you're pining scores to a Wordpress database,
+// 1. If you're pinging scores to a Wordpress database,
 //    enter the name of the cookie it leaves here.
 const wordpressCookieName = 'mywpcookie'
 // -----------------------------
@@ -476,8 +476,11 @@ function ebMCQsButtonClicks () {
       }
 
       // now send it all to WordPress
-      const quizNumber = mcqsToCheckName.replace('question-', '')
-      ebMCQsSendtoWordPress(quizNumber, score)
+      // if this is a website or an app
+      if (settings.site.output === 'web' || settings.site.output === 'app') {
+        const quizNumber = mcqsToCheckName.replace('question-', '')
+        ebMCQsSendtoWordPress(quizNumber, score)
+      }
     })
   })
 }
@@ -490,7 +493,10 @@ function ebMCQs () {
   }
 
   // add the WordPress account button
-  ebMCQsAddWordPressAccountButton()
+  // if this is a website
+  if (settings.site.output === 'web') {
+    ebMCQsAddWordPressAccountButton()
+  }
 
   // mark the document, to use the class in CSS
   document.documentElement.classList.add('js-mcq')


### PR DESCRIPTION
While JS support in epub readers is patchy, it is possible to have interactive MCQs in some readers. This adds that support.

In real projects, it may need to be removed (in `bundle.js`) it if causes issues with specific, prioritised epub readers.
