### PR TITLE
Stretch cover in PDF to fill the page

### DIFF
--- a/_sass/template/partials/_pdf-cover.scss
+++ b/_sass/template/partials/_pdf-cover.scss
@@ -20,6 +20,12 @@ $pdf-cover: true !default;
     }
     img.cover {
         height: 100%;
+        max-width: none;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
         width: 100%;
     }
 


### PR DESCRIPTION
Till now, your cover.jpg had to be exactly the right aspect ratio as your page size to fill the PDF page -- usually the first page of a screen PDF. This change stretches the cover to fill the page.

Pros: even if your cover image isn't quite the right aspect ratio for your page, it will fill the first page of a screen PDF. This is fine and useful when your cover.jpg is only slightly off.

Cons: if your aspect ratio is way off, your image will look stretched, and you might not spot the problem.
