### PR TITLE
Do not process PDF HTML with Cheerio in XML mode

### DIFF
--- a/_tools/gulp/processors/epub.js
+++ b/_tools/gulp/processors/epub.js
@@ -27,6 +27,7 @@ function runEpubTransformations (done) {
         })
       },
       parserOptions: {
+        // XML mode necessary for epub output
         xmlMode: true
       }
     }))
@@ -92,6 +93,7 @@ function epubXhtmlLinks (done) {
         })
       },
       parserOptions: {
+        // XML mode necessary for epub output
         xmlMode: true
       }
     }))

--- a/_tools/gulp/processors/pdf.js
+++ b/_tools/gulp/processors/pdf.js
@@ -32,7 +32,9 @@ function runPDFTransformations (done) {
         })
       },
       parserOptions: {
-        xmlMode: true
+        // XML mode causes problems with duplicating line breaks;
+        // avoid except where necessary for epub output.
+        xmlMode: false
       }
     }))
     .pipe(debug({ title: 'Performing HTML transformations ...' }))


### PR DESCRIPTION
While Cheerio's XML mode is necessary for epub output, I can't remember why we're using it for PDF output. Hopefully it is not important, so we should keep an eye on this.

What is a problem is that when a paragraph contains more than about two lines that end in linebreak elements (`<br/>`), Cheerio (version 0.*) in XML mode incorrectly adds extra linebreaks to the end of the paragraph. This is common on copyright pages.
