### PR TITLE
Remove epub-contents-page fallback to avoid invalid EPUBs

### DIFF
--- a/_includes/metadata-work.html
+++ b/_includes/metadata-work.html
@@ -365,7 +365,9 @@ we fall back to the value in the work's default.yml.
 {% elsif work.default.products.epub.contents-page and work.default.products.epub.contents-page != "" %}
     {% capture epub-contents-page %}{{ work.default.products.epub.contents-page }}{% endcapture %}
 {% else %}
-    {% capture epub-contents-page %}{{ default-start-page }}{% endcapture %}
+    {% comment %} The epub-contents-page is important for epub validity as the `nav`
+    in package.opf. So if it is not set here, it must not fall back to anything that
+    might not include a valid nav element. {% endcomment %}
 {% endif %}
 
 {% if work[work-variant].products.epub.language and work[work-variant].products.epub.language != "" %}


### PR DESCRIPTION
This removes a faulty fallback for the `epub-contents-page` metadata variable.

The fallback for the `epub-contents-page` metadata variable was set to the `default-start-page`, which by default is the cover file. But the cover has no 'nav' element. So if the `epub-contents-page` is not set explicitly and uses this fallback, and if the cover is processed by the `epub-package` include before the file that actually contains the `nav` and is flagged as such in default.yml with `filename: "toc"`, then `epub-package` incorrectly thinks that the cover file contains a `nav` element. This leads to `package.opf` declaring two files with `nav` elements -- the cover and the real `nav` file -- which causes EPUBCheck to throw errors. A valid EPUB's `package.opf` should declare only one file with a `nav` element, and that `nav` must actually exist in that file.

