### PR TITLE
Ensure EPUB title-page logo width across readers

### DIFF
--- a/_sass/template/epub.scss
+++ b/_sass/template/epub.scss
@@ -135,8 +135,10 @@ $text-divider-text: "" !default; // Empty leaves space. \2022 is a bullet
 $text-divider-image: "" !default;
 $text-divider-image-width: $line-height-default !default;
 
-// Other features
+// Title page
 $title-page-logo-width: 5rem !default;
+$title-page-logo-font: $font-text-main !default;
+$title-page-logo-font-size: 0.8rem !default;
 
 // Elements that float. When these are surrounded by paragraphs,
 // the following paragraph should be indented when we are not

--- a/_sass/template/partials/_epub-title-pages.scss
+++ b/_sass/template/partials/_epub-title-pages.scss
@@ -3,9 +3,9 @@ $epub-title-pages: true !default;
 
 	// Halftitle-page and title-page
 
-	.titlepage, 
-	.title-page, 
-	.halftitle-page, 
+	.titlepage,
+	.title-page,
+	.halftitle-page,
 	.half-title-page {
 		margin: $start-depth auto 0 auto;
 		text-align: center;
@@ -14,10 +14,10 @@ $epub-title-pages: true !default;
 			hyphens: none;
 			text-align: center;
 		}
-		.half-title-page-title, 
-		.halftitle-page-title, 
-		.halftitlepage-title, 
-		.title-page-title, 
+		.half-title-page-title,
+		.halftitle-page-title,
+		.halftitlepage-title,
+		.title-page-title,
 		.titlepage-title {
 			font-weight: bold;
 			font-family: $font-display-main;
@@ -26,7 +26,7 @@ $epub-title-pages: true !default;
 			margin: 0 0 $line-height-default 0;
 			// string-set: book-title content(); // breaks entire CSS file in Adobe Digital Editions
 		}
-		.title-page-subtitle, 
+		.title-page-subtitle,
 		.titlepage-subtitle {
 			font-family: $font-display-main;
 			font-size: $font-size-default * $font-size-bigger;
@@ -34,30 +34,26 @@ $epub-title-pages: true !default;
 			margin: 0 0 $line-height-default 0;
 			// string-set: book-subtitle content(); // breaks entire CSS file in Adobe Digital Editions
 		}
-		.title-page-author, 
+		.title-page-author,
 		.titlepage-author {
 			font-size: $font-size-default * $font-size-bigger;
 			line-height: 1;
 			margin: 0 0 $line-height-default 0;
 			// string-set: book-author content(); // breaks entire CSS file in Adobe Digital Editions
 		}
-		.title-page-publisher, 
+		.title-page-publisher,
 		.titlepage-publisher {
 			text-indent: 0;
 		}
-		.title-page-logo, 
+		.title-page-logo,
 		.titlepage-logo {
 			display: block; // In case the class is applied to the image, not the paragraph
-			margin: $line-height-default auto 0 auto;
-
-			max-width: 5rem;
-			@if $title-page-logo-width {
-				max-width: none;
-				width: $title-page-logo-width;
-			}
+			font-family: $title-page-logo-font;
+			font-size: $title-page-logo-font-size;
+			margin: ($line-height-default * 3) auto 0 auto;
 
 			img {
-				width: 100%;
+				width: $title-page-logo-width;
 			}
 		}
 	}

--- a/_sass/template/partials/_epub-title-pages.scss
+++ b/_sass/template/partials/_epub-title-pages.scss
@@ -52,7 +52,8 @@ $epub-title-pages: true !default;
 
 			max-width: 5rem;
 			@if $title-page-logo-width {
-				max-width: $title-page-logo-width;
+				max-width: none;
+				width: $title-page-logo-width;
 			}
 
 			img {

--- a/_sass/template/partials/_pdf-title-pages.scss
+++ b/_sass/template/partials/_pdf-title-pages.scss
@@ -53,15 +53,16 @@ $pdf-title-pages: true !default;
 		.title-page-logo, 
 		.titlepage-logo {
 			display: block; // In case the class is applied to the image, not the paragraph
-			width: $title-page-logo-width;
+			font-family: $title-page-logo-font;
+			font-size: $title-page-logo-font-size;
 			position: absolute;
 			text-align: center;
 			bottom: 0;
-		//	Now we'll center the block on the page
+			//	Now we'll center the block on the page
 			transform: translateX(-50%);
 		    margin-left: 50%;
 			img {
-				width: 100%;
+				width: $title-page-logo-width;
 			}
 		}
 	}

--- a/_sass/template/partials/_web-title-pages.scss
+++ b/_sass/template/partials/_web-title-pages.scss
@@ -3,9 +3,9 @@ $web-title-pages: true !default;
 
 	// Halftitle-page and title-page
 
-	.titlepage, 
-	.title-page, 
-	.halftitle-page, 
+	.titlepage,
+	.title-page,
+	.halftitle-page,
 	.half-title-page {
 		.content {
 			margin: $start-depth auto 0 auto;
@@ -16,10 +16,10 @@ $web-title-pages: true !default;
 			hyphens: none;
 			text-align: center;
 		}
-		.half-title-page-title, 
-		.halftitle-page-title, 
-		.halftitlepage-title, 
-		.title-page-title, 
+		.half-title-page-title,
+		.halftitle-page-title,
+		.halftitlepage-title,
+		.title-page-title,
 		.titlepage-title {
 			font-weight: bold;
 			font-family: $font-display-main;
@@ -28,7 +28,7 @@ $web-title-pages: true !default;
 			margin: 0;
 			string-set: book-title content();
 		}
-		.title-page-subtitle, 
+		.title-page-subtitle,
 		.titlepage-subtitle {
 			font-family: $font-display-main;
 			font-size: $font-size-default * $font-size-bigger;
@@ -36,30 +36,28 @@ $web-title-pages: true !default;
 			margin: ($line-height-default / 2) 0 $line-height-default 0;
 			string-set: book-subtitle content();
 		}
-		.title-page-author, 
+		.title-page-author,
 		.titlepage-author {
 			font-size: $font-size-default * $font-size-bigger;
 			line-height: 1;
 			margin: ($line-height-default) 0;
 			string-set: book-author content();
 		}
-		.title-page-publisher, 
+		.title-page-publisher,
 		.titlepage-publisher {
 			text-indent: 0;
 			margin: 0 0 $line-height-default 0;
 			line-height: 1;
 		}
-		.title-page-logo, 
+		.title-page-logo,
 		.titlepage-logo {
 			display: block; // In case the class is applied to the image, not the paragraph
-
-			max-width: 5rem;
-			@if $title-page-logo-width {
-				max-width: $title-page-logo-width;
-			}
+			font-family: $title-page-logo-font;
+			font-size: $title-page-logo-font-size;
+			margin: ($line-height-default * 3) auto 0 auto;
 
 			img {
-				width: 100%;
+				width: $title-page-logo-width;
 			}
 		}
 	}

--- a/_sass/template/print-pdf.scss
+++ b/_sass/template/print-pdf.scss
@@ -215,8 +215,10 @@ $frontmatter-reference-style: lower-roman !default; // lower-roman, decimal, see
 // using $spaced-paras.
 $floated-element-classes: sidenote, qr-code !default;
 
-// Other PDF features
+// Title page
 $title-page-logo-width: $paragraph-indent * 3 !default;
+$title-page-logo-font: $font-text-main !default;
+$title-page-logo-font-size: $font-size-default - 1 !default;
 
 // Elements that float. When these are surrounded by paragraphs,
 // the following paragraph should be indented when we are not

--- a/_sass/template/web.scss
+++ b/_sass/template/web.scss
@@ -166,8 +166,10 @@ $text-divider-text: "" !default; // Empty leaves space. \2022 is a bullet
 $text-divider-image: "" !default;
 $text-divider-image-width: $line-height-default * 2 !default;
 
-// Other book features
+// Title page
 $title-page-logo-width: 5rem !default;
+$title-page-logo-font: $font-text-main !default;
+$title-page-logo-font-size: 0.8rem !default;
 
 // Elements that float. When these are surrounded by paragraphs,
 // the following paragraph should be indented when we are not


### PR DESCRIPTION
Not all readers (e.g. iBooks, ADE) support the `max-width` property we were using for the logo on EPUB title pages.
This change uses `width` instead, while retaining some flexibility in the event that a width is not set in Sass vars.

UPDATE: I've added some further refinements we realised were necessary while working on a publisher project today.