### PR TITLE
EPUB updates

### DIFF
--- a/_sass/template/partials/_epub-copyright-page.scss
+++ b/_sass/template/partials/_epub-copyright-page.scss
@@ -21,6 +21,7 @@ $epub-copyright-page: true !default;
 
         .identifiers {
             list-style-type: none;
+            margin-left: 0;
 
             .identifier-scheme {}
             .identifier-format {}

--- a/_sass/template/partials/_pdf-copyright-page.scss
+++ b/_sass/template/partials/_pdf-copyright-page.scss
@@ -34,6 +34,8 @@ $pdf-copyright-page: true !default;
 
         .identifiers {
             list-style-type: none;
+            margin-left: 0;
+            padding-left: 0;
         }
     }
 }

--- a/_sass/template/partials/_web-copyright-page.scss
+++ b/_sass/template/partials/_web-copyright-page.scss
@@ -16,6 +16,7 @@ $web-copyright-page: true !default;
 
         .identifiers {
             list-style-type: none;
+            margin-left: 0;
 
             .identifier-scheme {}
             .identifier-format {}

--- a/_tools/gulp/transformations/epub/epubAriaDocEndnote.js
+++ b/_tools/gulp/transformations/epub/epubAriaDocEndnote.js
@@ -1,0 +1,9 @@
+// Kramdown adds the ARIA role doc-endnote, but this role
+// is deprecated. Remove it to avoid EPUBCheck warnings.
+function epubAriaDocEndnote ($) {
+  $('[role="doc-endnote"]').each(function () {
+    $(this).removeAttr('role')
+  })
+}
+
+exports.epubAriaDocEndnote = epubAriaDocEndnote

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cordova-windows": "^7.0.1",
     "cross-spawn": "^7.0.3",
     "del": "^6.1.1",
-    "epubchecker": "^4.2.2",
+    "epubchecker": "^5.1.0",
     "file-exists": "^5.0.1",
     "fs-extra": "^10.1.0",
     "gulp": "^4.0.2",


### PR DESCRIPTION
This makes a few updates related to EPUB builds:

- updates to latest EPUBCheck
- cleans kramdown HTML to avoid an EPUBCheck warning about its deprecated attributes
- fixes a minor text-alignment issue that was spotted in EPUB output but could affect PDF and web.
