### PR TITLE
CSS enhancements: title pages, PDF opener images

### DIFF
--- a/_sass/template/partials/_epub-title-pages.scss
+++ b/_sass/template/partials/_epub-title-pages.scss
@@ -52,9 +52,16 @@ $epub-title-pages: true !default;
 			font-size: $title-page-logo-font-size;
 			margin: ($line-height-default * 3) auto 0 auto;
 
-			img {
+			img, svg {
 				width: $title-page-logo-width;
 			}
+		}
+
+		// If the class is applied to the image directly,
+		// rather than its container
+		img.title-page-logo,
+		svg.titlepage-logo {
+			width: $title-page-logo-width;
 		}
 	}
 }

--- a/_sass/template/partials/_pdf-openers.scss
+++ b/_sass/template/partials/_pdf-openers.scss
@@ -24,4 +24,21 @@ $pdf-openers: true !default;
             width: 100%;
         }
     }
+
+    // If the opener-image-wrapper is on a page
+    // that has a start-depth, account for that extra depth.
+    // Prince collapses the margin-tops on the .wrapper
+    // and the .opener-image-wrapper, so we just replace
+    // $margin-top with $start-depth below, if the
+    // $start-depth is greater than the $margin-top.
+
+    @if $start-depth > $margin-top {
+        @each $page-style in $start-depth-page-styles {
+            .#{$page-style} {
+                .opener-image-wrapper {
+                    margin-top: -($start-depth + $bleed-print);
+                }
+            }
+        }
+    }
 }

--- a/_sass/template/partials/_pdf-title-pages.scss
+++ b/_sass/template/partials/_pdf-title-pages.scss
@@ -61,9 +61,17 @@ $pdf-title-pages: true !default;
 			//	Now we'll center the block on the page
 			transform: translateX(-50%);
 		    margin-left: 50%;
-			img {
+
+			img, svg {
 				width: $title-page-logo-width;
 			}
+		}
+
+		// If the class is applied to the image directly,
+		// rather than its container
+		img.title-page-logo,
+		svg.titlepage-logo {
+			width: $title-page-logo-width;
 		}
 	}
 

--- a/_sass/template/partials/_web-title-pages.scss
+++ b/_sass/template/partials/_web-title-pages.scss
@@ -56,9 +56,16 @@ $web-title-pages: true !default;
 			font-size: $title-page-logo-font-size;
 			margin: ($line-height-default * 3) auto 0 auto;
 
-			img {
+			img, svg {
 				width: $title-page-logo-width;
 			}
+		}
+
+		// If the class is applied to the image directly,
+		// rather than its container
+		img.title-page-logo,
+		svg.titlepage-logo {
+			width: $title-page-logo-width;
 		}
 	}
 


### PR DESCRIPTION
Two fixes/enhancements here:

- Some publishers use a combination of logo image and text for their branding on title pages. These changes ensure that the width
we set for the logo is applied correctly whether `.title-page-logo` class is applied to the container or the image, and whether the image is an SVG or regular image.
- Fixes a bug where a `$start-depth` greater than the `$margin-top` made chapter-opener images in PDF sit too low on the page.
