### PR TITLE
Allow PDFs to use files in assets folder

### DIFF
--- a/_configs/_config.print-pdf.yml
+++ b/_configs/_config.print-pdf.yml
@@ -68,7 +68,8 @@ exclude:
   - /search.md
   - /sitemap.xml
   - /test.sh
-  - /assets/styles
+  - /assets/styles/app*
+  - /assets/styles/web*
   - /assets/js/accordion.js
   - /assets/js/annotation.js
   - /assets/js/elasticlunr-setup.js

--- a/_configs/_config.screen-pdf.yml
+++ b/_configs/_config.screen-pdf.yml
@@ -68,7 +68,8 @@ exclude:
   - /search.md
   - /sitemap.xml
   - /test.sh
-  - /assets/styles
+  - /assets/styles/app*
+  - /assets/styles/web*
   - /assets/js/accordion.js
   - /assets/js/annotation.js
   - /assets/js/elasticlunr-setup.js


### PR DESCRIPTION
This is necessary if there is a hyphenation dictionary in the `assets` folder, which Prince must be able to find in `_site/assets` when rendering a PDF.