### PR TITLE
Ensure blank page after front cover-page

### DIFF
--- a/_sass/template/partials/_pdf-cover.scss
+++ b/_sass/template/partials/_pdf-cover.scss
@@ -12,6 +12,15 @@ $pdf-cover: true !default;
 
         // Add extra verso to retain correct folios
         page-break-after: left;
+
+        // The above property may not work to ensure
+        // a blank page after the cover-page.
+        // So we also target the next wrapper.
+        // This only works when using the default
+        // merged-HTML PDF output.
+        & + .wrapper {
+            break-before: right;
+        }
     }
     p.cover {
         margin: 0;


### PR DESCRIPTION
When using the (default) merged-HTML approach, this ensures that the cover page in a screen PDF is followed by a blank page, retaining the correct recto/verso layout of the book.

This is necessary when a `page-1` page style has not been defined for the first page after the cover.

The French version of the `samples` book in this repo is the example case.