### PR TITLE
Lazyload when dynamic indexing is off

### DIFF
--- a/assets/js/lazyload.js
+++ b/assets/js/lazyload.js
@@ -89,7 +89,7 @@ function ebPrepareForLazyLoading () {
   const lazyImagesObserver = new MutationObserver(function (mutations) {
     mutations.forEach(function (mutation) {
       if (mutation.type === 'attributes') {
-        if (document.body.getAttribute('data-index-targets') &&
+        if ((settings.dynamicIndexing === false || document.body.getAttribute('data-index-targets')) &&
                         document.body.getAttribute('data-ids-assigned')) {
           ebLazyLoadImages()
         }


### PR DESCRIPTION
This fixes a bug where, if dynamic indexing is off in settings, images never get loaded, because the body element never gets a `data-index-targets` attribute.