### PR TITLE
Fix support when dynamic indexing is disabled

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -39,7 +39,17 @@ Do not add classes to <body>, because in PDF output
 separate HTML files are merged into one body element.
 {% endcomment %}
 
-<body>
+<body
+
+    {% comment %} Some scripts wait for `data-index-targets` to be ready.
+    If we are not using a dynamic index, index targets
+    will never be loaded, so we confirm that here. {% endcomment %}
+    {% if site.data.settings.dynamic-indexing == false %}
+        data-index-targets="none"
+    {% endif %}
+
+    >
+
     <div class="wrapper {{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}"
         {% if page.header %}data-header="{{ page.header }}"{% else %} data-header="{{ page.title }}"{% endif %}
         {% if page.header-left %} data-header-left="{{ page.header-left }}"{% else %} data-header-left="{{ page.title }}"{% endif %}
@@ -84,7 +94,10 @@ separate HTML files are merged into one body element.
     {% include head-elements.html %}
 
 </head>
-<body>
+<body
+    {% if site.data.settings.dynamic-indexing == false %}
+        data-index-targets="none"
+    {% endif %}>
     <div class="wrapper {{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}"
         {% if page.header %} data-header="{{ page.header }}"{% else %} data-header="{{ page.title }}"{% endif %}
         {% if page.header-left %} data-header-left="{{ page.header-left }}"{% else %} data-header-left="{{ page.title }}"{% endif %}
@@ -143,7 +156,10 @@ separate HTML files are merged into one body element.
     {% include head-elements.html %}
 
 </head>
-<body>
+<body
+    {% if site.data.settings.dynamic-indexing == false %}
+        data-index-targets="none"
+    {% endif %}>
     <div class="wrapper {{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}"
         data-title="{% if book-title %}{{ book-title }}{% else %}{{ page.title }}{% endif %}"
         data-book-directory="{{ book-directory }}"
@@ -210,7 +226,10 @@ separate HTML files are merged into one body element.
     {% include head-elements.html %}
 
     </head>
-    <body>
+    <body
+        {% if site.data.settings.dynamic-indexing == false %}
+            data-index-targets="none"
+        {% endif %}>
         <div class="wrapper {{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}{% if is-search == true %} search-page{% endif %}{% if is-project-search == true %} project-search-page{% endif %}{% if is-book-search == true %} book-search-page{% endif %}"
         {% if page.accordion %}data-accordion-page="{{ page.accordion }}"{% endif %}
         {% if page.accordion-level and page.accordion-level != "" %}data-accordion-level="{{ page.accordion-level }}"{% endif %}
@@ -293,7 +312,10 @@ separate HTML files are merged into one body element.
     {% include head-elements.html %}
 
 </head>
-<body>
+<body
+    {% if site.data.settings.dynamic-indexing == false %}
+        data-index-targets="none"
+    {% endif %}>
     <div class="wrapper {{ book-directory }} {{ page.style }}{% if is-homepage == true %} home{% endif %}{% if is-search == true %} search-page{% endif %}{% if is-project-search == true %} project-search-page{% endif %}{% if is-book-search == true %} book-search-page{% endif %}"
         {% if page.accordion %}data-accordion-page="{{ page.accordion }}"{% endif %}
         {% if page.accordion-level and page.accordion-level != "" %}data-accordion-level="{{ page.accordion-level }}"{% endif %}

--- a/assets/js/bookmarks.js
+++ b/assets/js/bookmarks.js
@@ -1185,29 +1185,41 @@ function ebBookmarksInit () {
   }
 }
 
+// A check if the document is ready for bookmarks
+function ebReadyForBookmarks () {
+  const readyForBookmarks = document.body.getAttribute('data-ids-assigned') &&
+                            document.body.getAttribute('data-fingerprints-assigned')
+  if (readyForBookmarks) {
+    return true
+  } else {
+    return false
+  }
+}
+
 // Wait for IDs and fingerprints to be loaded
 // and IDs to be assigned
 // before applying the accordion.
 function ebPrepareForBookmarks () {
   'use strict'
 
-  const bookmarksObserver = new MutationObserver(function (mutations) {
-    let readyForBookmarks = false
-    mutations.forEach(function (mutation) {
-      if (mutation.type === 'attributes' && readyForBookmarks === false) {
-        if (document.body.getAttribute('data-ids-assigned') &&
-                        document.body.getAttribute('data-fingerprints-assigned')) {
-          readyForBookmarks = true
+  // If the doc is ready for bookmarks, go for it …
+  //  … otherwise, watch for when it is ready.
+  if (ebReadyForBookmarks()) {
+    ebBookmarksInit()
+  } else {
+    const bookmarksObserver = new MutationObserver(function (mutations) {
+      mutations.forEach(function (mutation) {
+        if (mutation.type === 'attributes' && ebReadyForBookmarks()) {
           ebBookmarksInit()
           bookmarksObserver.disconnect()
         }
-      }
+      })
     })
-  })
 
-  bookmarksObserver.observe(document.body, {
-    attributes: true // listen for attribute changes
-  })
+    bookmarksObserver.observe(document.body, {
+      attributes: true // listen for attribute changes
+    })
+  }
 }
 
 if (settings.web.bookmarks.enabled) {

--- a/assets/js/lazyload.js
+++ b/assets/js/lazyload.js
@@ -80,10 +80,10 @@ function ebLazyLoadImages () {
 }
 
 // Check if the document is ready for lazyloading
-function ebReadyForLazyloading () {
-  const readyForLazyloading = document.body.getAttribute('data-index-targets') &&
+function ebReadyForLazyLoading () {
+  const readyForLazyLoading = document.body.getAttribute('data-index-targets') &&
                             document.body.getAttribute('data-ids-assigned')
-  if (readyForLazyloading) {
+  if (readyForLazyLoading) {
     return true
   } else {
     return false
@@ -97,12 +97,12 @@ function ebReadyForLazyloading () {
 function ebPrepareForLazyLoading () {
   'use strict'
 
-  if (ebReadyForLazyloading()) {
+  if (ebReadyForLazyLoading()) {
     ebLazyLoadImages()
   } else {
     const lazyImagesObserver = new MutationObserver(function (mutations) {
       mutations.forEach(function (mutation) {
-        if (mutation.type === 'attributes' && ebReadyForLazyloading()) {
+        if (mutation.type === 'attributes' && ebReadyForLazyLoading()) {
           ebLazyLoadImages()
           lazyImagesObserver.disconnect()
         }

--- a/assets/js/lazyload.js
+++ b/assets/js/lazyload.js
@@ -79,6 +79,17 @@ function ebLazyLoadImages () {
   }
 }
 
+// Check if the document is ready for lazyloading
+function ebReadyForLazyloading () {
+  const readyForLazyloading = document.body.getAttribute('data-index-targets') &&
+                            document.body.getAttribute('data-ids-assigned')
+  if (readyForLazyloading) {
+    return true
+  } else {
+    return false
+  }
+}
+
 // Wait for data-index-targets to be loaded
 // and IDs to be assigned before lazyloading.
 // Otherwise intersectionObserver can miss images,
@@ -86,20 +97,22 @@ function ebLazyLoadImages () {
 function ebPrepareForLazyLoading () {
   'use strict'
 
-  const lazyImagesObserver = new MutationObserver(function (mutations) {
-    mutations.forEach(function (mutation) {
-      if (mutation.type === 'attributes') {
-        if ((settings.dynamicIndexing === false || document.body.getAttribute('data-index-targets')) &&
-                        document.body.getAttribute('data-ids-assigned')) {
+  if (ebReadyForLazyloading()) {
+    ebLazyLoadImages()
+  } else {
+    const lazyImagesObserver = new MutationObserver(function (mutations) {
+      mutations.forEach(function (mutation) {
+        if (mutation.type === 'attributes' && ebReadyForLazyloading()) {
           ebLazyLoadImages()
+          lazyImagesObserver.disconnect()
         }
-      }
+      })
     })
-  })
 
-  lazyImagesObserver.observe(document.body, {
-    attributes: true // listen for attribute changes
-  })
+    lazyImagesObserver.observe(document.body, {
+      attributes: true // listen for attribute changes
+    })
+  }
 }
 
 ebPrepareForLazyLoading()

--- a/assets/js/svg-management.js
+++ b/assets/js/svg-management.js
@@ -189,28 +189,38 @@ function ebInjectSVGs () {
   })
 }
 
+// Check if the document is ready for testing images
+function ebReadyForTestingImages () {
+  const readyForTestingImages = document.body.getAttribute('data-testing-images')
+  if (readyForTestingImages) {
+    return true
+  } else {
+    return false
+  }
+}
+
 // Wait for testing images to be loaded
 function ebWaitForTestingImages () {
   'use strict'
   console.log('Waiting for any test images to load ...')
 
-  const testingImagesObserver = new MutationObserver(function (mutations) {
-    let ready = false
-    mutations.forEach(function (mutation) {
-      if (mutation.type === 'attributes' && ready === false) {
-        if (document.body.getAttribute('data-testing-images')) {
-          ready = true
+  if (ebReadyForTestingImages()) {
+    ebInjectSVGs()
+  } else {
+    const testingImagesObserver = new MutationObserver(function (mutations) {
+      mutations.forEach(function (mutation) {
+        if (mutation.type === 'attributes' && ebReadyForTestingImages()) {
           console.log('Testing images loaded. Starting SVG injection.')
           ebInjectSVGs()
           testingImagesObserver.disconnect()
         }
-      }
+      })
     })
-  })
 
-  testingImagesObserver.observe(document.body, {
-    attributes: true // listen for attribute changes
-  })
+    testingImagesObserver.observe(document.body, {
+      attributes: true // listen for attribute changes
+    })
+  }
 }
 
 // Go


### PR DESCRIPTION
This fixes and improves code consistency for image lazy-loading, bookmarks, and SVG management when dynamic indexing is turned off in `_data/settings.yml`.
