### PR TITLE
Clarify how to enable/disable collections

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -60,17 +60,30 @@ mathjax-enabled: true
 
 # Jekyll collections
 # ------------------
-# docs:      Documentation is built into the Electric Book template.
-#            These docs build along with your books, so they are available
-#            as you work. To turn off the docs, comment out its lines below.
-# api:       The template generates data about your web output by default.
-#            To turn off the api, comment out its lines below.
-# app, epub: The app and epub collections are off by default, and
-#            turned on by those formats' _config files.
-# Note:      If no collection is set to `output: true`, also comment out
-#            the `collections:` line to ensure this file is valid YAML.
-#            Setting a collection to `output: false` does not have any effect
-#            when listing multiple collections.
+# We use collections for the docs, the api, and epub and app outputs.
+# For faster builds, we don't want unnecessary collections to be processed.
+# This means adding them to the `exclude` list below,
+# and using a `collections` node below with only the collections you need
+# set to `output: true`.
+# - Note:      - If no collection is set to `output: true`, also comment out
+#                the `collections:` line to ensure this file is valid YAML.
+#              - Setting a collection to `output: false` does not have any effect
+#                when listing multiple collections.
+#              - On output, other config files may load, e.g. _config.epub.yml.
+#                Any `collections:` node in a subsequent config file will entirely
+#                override any `collections:` nodes in earlier config files.
+#              - To override the default `collections` below, subsequent configs
+#                must include a `collections:` node, even if it contains
+#                a single collection set to `output: false`.
+#              - There are known issues with Jekyll behaviour here,
+#                e.g. https://github.com/jekyll/jekyll/issues/7504.
+# - docs:      Documentation is built into the Electric Book template.
+#              These docs build along with your books, so they are available
+#              as you work. To turn off the docs, comment out its lines below.
+# - api:       The template generates data about your web output by default.
+#              To turn off the api, comment out its lines below.
+# - app, epub: The app and epub collections are off by default, and
+#              turned on by those formats' _config files.
 collections:
   docs:
     output: true

--- a/_config.yml
+++ b/_config.yml
@@ -62,9 +62,15 @@ mathjax-enabled: true
 # ------------------
 # docs:      Documentation is built into the Electric Book template.
 #            These docs build along with your books, so they are available
-#            as you work. To turn off the docs, change output to false.
+#            as you work. To turn off the docs, comment out its lines below.
+# api:       The template generates data about your web output by default.
+#            To turn off the api, comment out its lines below.
 # app, epub: The app and epub collections are off by default, and
 #            turned on by those formats' _config files.
+# Note:      If no collection is set to `output: true`, also comment out
+#            the `collections:` line to ensure this file is valid YAML.
+#            Setting a collection to `output: false` does not have any effect
+#            when listing multiple collections.
 collections:
   docs:
     output: true

--- a/_config.yml
+++ b/_config.yml
@@ -62,27 +62,30 @@ mathjax-enabled: true
 # ------------------
 # We use collections for the docs, the api, and epub and app outputs.
 # For faster builds, we don't want unnecessary collections to be processed.
-# This means adding them to the `exclude` list below,
-# and using a `collections` node below with only the collections you need
-# set to `output: true`.
-# - Note:      - If no collection is set to `output: true`, also comment out
-#                the `collections:` line to ensure this file is valid YAML.
-#              - Setting a collection to `output: false` does not have any effect
-#                when listing multiple collections.
-#              - On output, other config files may load, e.g. _config.epub.yml.
-#                Any `collections:` node in a subsequent config file will entirely
-#                override any `collections:` nodes in earlier config files.
-#              - To override the default `collections` below, subsequent configs
-#                must include a `collections:` node, even if it contains
-#                a single collection set to `output: false`.
-#              - There are known issues with Jekyll behaviour here,
-#                e.g. https://github.com/jekyll/jekyll/issues/7504.
-# - docs:      Documentation is built into the Electric Book template.
+# This means adding them to the `exclude` list below, and using a
+# `collections` node below with only the collections you need set to
+# `output: true`.
+#
+# - If no collection is set to `output: true`, also comment out
+#   the `collections:` line to ensure this file is valid YAML.
+# - Setting a collection to `output: false` does not have any effect
+#   when listing multiple collections.
+# - On output, other config files may load, e.g. _config.epub.yml.
+#   Any `collections:` node in a subsequent config file will entirely
+#   override any `collections:` nodes in earlier config files.
+# - To override the default `collections` below, subsequent configs
+#   must include a `collections:` node, even if it contains
+#   a single collection set to `output: false`.
+# - There are known issues with Jekyll behaviour here,
+#   e.g. https://github.com/jekyll/jekyll/issues/7504.
+# - Collections:
+#
+#   docs:      Documentation is built into the Electric Book template.
 #              These docs build along with your books, so they are available
 #              as you work. To turn off the docs, comment out its lines below.
-# - api:       The template generates data about your web output by default.
+#   api:       The template generates data about your web output by default.
 #              To turn off the api, comment out its lines below.
-# - app, epub: The app and epub collections are off by default, and
+#   app, epub: The app and epub collections are off by default, and
 #              turned on by those formats' _config files.
 collections:
   docs:

--- a/_configs/_config.app.yml
+++ b/_configs/_config.app.yml
@@ -4,9 +4,8 @@ output: "app"
 # Set site.image-set == "images/app"
 image-set: "images/app"
 
-# Turn off docs by not specifying `output: true`.
-# Setting `output: false` actually doesn't work,
-# see https://github.com/jekyll/jekyll/issues/7504
+# Only the `app` collection should render.
+# See _config.yml for notes on collections.
 collections:
   app:
     output: true
@@ -64,11 +63,13 @@ exclude:
   - /assets/js/page-reference.js
   - /assets/js/bookmarks.js
 
-  # Collections that must not render
+  # Collections that must not be processed
+  # for this output format
   - _docs
+  - _api
+  - _epub
 
   # Things we don't need for an app
-  - _api
   - deploy.sh
   - fr
   - netlify.toml

--- a/_configs/_config.app.yml
+++ b/_configs/_config.app.yml
@@ -4,15 +4,10 @@ output: "app"
 # Set site.image-set == "images/app"
 image-set: "images/app"
 
-# Turn off documentation
-# Setting output: false actually doesn't work,
+# Turn off docs by not specifying `output: true`.
+# Setting `output: false` actually doesn't work,
 # see https://github.com/jekyll/jekyll/issues/7504
-# so we also exclude the _docs below.
 collections:
-  docs:
-    output: false
-  api:
-    output: false
   app:
     output: true
 

--- a/_configs/_config.epub.yml
+++ b/_configs/_config.epub.yml
@@ -1,11 +1,15 @@
 # Set site.output == "epub"
 output: "epub"
+
 # Set site.image-set == "images/epub"
 image-set: "images/epub"
-# Enable and only use the epub collection
+
+# Only the `epub` collection should render.
+# See _config.yml for notes on collections.
 collections:
   epub:
     output: true
+
 exclude:
   # The usual excludes from _config.yml
   - run.js
@@ -54,8 +58,13 @@ exclude:
   - /assets/js/page-reference.js
   - /assets/js/bookmarks.js
 
-  # Exclude files we don't need for epub
+  # Collections that must not be processed
+  # for this output format
   - _api
+  - _app
+  - _docs
+
+  # Exclude files we don't need for epub
   - deploy.sh
   - fr
   - netlify.toml

--- a/_configs/_config.epub.yml
+++ b/_configs/_config.epub.yml
@@ -2,12 +2,8 @@
 output: "epub"
 # Set site.image-set == "images/epub"
 image-set: "images/epub"
-# Turn off documentation and activate epub collection
+# Enable and only use the epub collection
 collections:
-  docs:
-    output: false
-  api:
-    output: false
   epub:
     output: true
 exclude:

--- a/_configs/_config.live.yml
+++ b/_configs/_config.live.yml
@@ -69,8 +69,10 @@ exclude:
   - /assets/js/page-reference.js
   - /assets/js/bookmarks.js
 
-  # Collections that must not render
+  # Collections that must not be processed
+  - _app
   - _docs
+  - _epub
 
   # Colour profiles for conversions
   - /assets/profiles

--- a/_configs/_config.live.yml
+++ b/_configs/_config.live.yml
@@ -8,14 +8,17 @@ build: live
 canonical-url: "https://example.com"
 baseurl: "/example"
 
-# Turn off collections not needed for live.
-# Setting output: false actually doesn't work:
-# see https://github.com/jekyll/jekyll/issues/7504
-# `output: false` doesn't work for multiple
-# collections, but does for a single collection.
+# Only the `api` collection should render by default.
+# See _config.yml for notes on collections.
+# To turn off all collections, including _api,
+# you must include a `collections:` node that will
+# override the default in _config.yml. You can use:
+# collections:
+#   docs:
+#     output: false
 collections:
-  docs:
-    output: false
+  api:
+    output: true
 
 # Exclude list
 exclude:

--- a/_configs/_config.live.yml
+++ b/_configs/_config.live.yml
@@ -8,10 +8,11 @@ build: live
 canonical-url: "https://example.com"
 baseurl: "/example"
 
-# Turn off docs.
-# Setting output: false actually doesn't work,
+# Turn off collections not needed for live.
+# Setting output: false actually doesn't work:
 # see https://github.com/jekyll/jekyll/issues/7504
-# so we also exclude the _docs below.
+# `output: false` doesn't work for multiple
+# collections, but does for a single collection.
 collections:
   docs:
     output: false

--- a/_configs/_config.print-pdf.yml
+++ b/_configs/_config.print-pdf.yml
@@ -1,13 +1,19 @@
 # Set site.output == "print-pdf"
 output: "print-pdf"
+
 # Set site.image-set == "images/print-pdf"
 image-set: "images/print-pdf"
-# Turn off collections not needed for print.
-# `output: false` doesn't work for multiple
-# collections, but does for a single collection.
+
+# No collections should be processed for this output.
+# See _config.yml for notes on collections.
+# To turn off all collections, we must include
+# a `collections:` node to override the default
+# in _config.yml, even if it lists a collection
+# that we exclude in the `exclude` list below.
 collections:
   docs:
     output: false
+
 exclude:
   # The usual excludes from _config.yml
   - run.js
@@ -57,8 +63,14 @@ exclude:
   - /assets/js/page-reference.js
   - /assets/js/bookmarks.js
 
-  # Exclude files we don't need for print-pdf
+  # Collections that must not be processed
+  # for this output format
   - _api
+  - _app
+  - _docs
+  - _epub
+
+  # Exclude files we don't need for print-pdf
   - /about.md
   - /contact.md
   - /deploy.sh

--- a/_configs/_config.print-pdf.yml
+++ b/_configs/_config.print-pdf.yml
@@ -2,11 +2,11 @@
 output: "print-pdf"
 # Set site.image-set == "images/print-pdf"
 image-set: "images/print-pdf"
-# Turn off documentation
+# Turn off collections not needed for print.
+# `output: false` doesn't work for multiple
+# collections, but does for a single collection.
 collections:
   docs:
-    output: false
-  api:
     output: false
 exclude:
   # The usual excludes from _config.yml

--- a/_configs/_config.screen-pdf.yml
+++ b/_configs/_config.screen-pdf.yml
@@ -1,13 +1,19 @@
 # Set site.output == "screen-pdf"
 output: "screen-pdf"
+
 # Set site.image-set == "images/screen-pdf"
 image-set: "images/screen-pdf"
-# Turn off collections not needed for print.
-# `output: false` doesn't work for multiple
-# collections, but does for a single collection.
+
+# No collections should be processed for this output.
+# See _config.yml for notes on collections.
+# To turn off all collections, we must include
+# a `collections:` node to override the default
+# in _config.yml, even if it lists a collection
+# that we exclude in the `exclude` list below.
 collections:
   docs:
     output: false
+
 exclude:
   # The usual excludes from _config.yml
   - run.js
@@ -57,8 +63,14 @@ exclude:
   - /assets/js/page-reference.js
   - /assets/js/bookmarks.js
 
-  # Exclude files we don't need for screen-pdf
+  # Collections that must not be processed
+  # for this output format
   - _api
+  - _app
+  - _docs
+  - _epub
+
+  # Exclude files we don't need for screen-pdf
   - /about.md
   - /contact.md
   - /deploy.sh

--- a/_configs/_config.screen-pdf.yml
+++ b/_configs/_config.screen-pdf.yml
@@ -2,11 +2,11 @@
 output: "screen-pdf"
 # Set site.image-set == "images/screen-pdf"
 image-set: "images/screen-pdf"
-# Turn off documentation
+# Turn off collections not needed for print.
+# `output: false` doesn't work for multiple
+# collections, but does for a single collection.
 collections:
   docs:
-    output: false
-  api:
     output: false
 exclude:
   # The usual excludes from _config.yml


### PR DESCRIPTION
The aim here is to avoid having Jekyll process collections that we don't need for a given format, so that build times are shorter.

Turning on and off multiple collections is a quite poorly and confusingly documented area in Jekyll. So my code comments and template configs here are based on forum discussions and my own testing.