### PR TITLE
Auto handle named entities in divs

### DIFF
--- a/_tools/gulp/processors/indexes.js
+++ b/_tools/gulp/processors/indexes.js
@@ -13,6 +13,17 @@ const { ebSlugify } = require('../helpers/utilities.js')
 const { format } = require('../helpers/args.js')
 const htmlFilePaths = require('../../run/helpers/paths/htmlFilePaths.js')
 
+// Check whether to use XML mode
+function isXMLMode () {
+  // Note: this needs to return a string,
+  // hence the quotes around 'true' and 'false'.
+  if (format === 'epub') {
+    return 'true'
+  } else {
+    return 'false'
+  }
+}
+
 // Turn HTML comments for book indexes into anchor tags.
 // This is a pre-processing alternative to assets/js/index-targets.js,
 // which dynamically adds index targets in web clients.
@@ -164,7 +175,8 @@ async function renderIndexCommentsAsTargets (done) {
       },
       parserOptions: {
         // XML mode necessary for epub output
-        xmlMode: true
+        // and must be false for PDF output
+        xmlMode: isXMLMode()
       }
     }))
     .pipe(gulp.dest('./'))
@@ -384,7 +396,8 @@ async function renderIndexListReferences (done) {
       },
       parserOptions: {
         // XML mode necessary for epub output
-        xmlMode: true
+        // and must be false for PDF output
+        xmlMode: isXMLMode()
       }
     }))
     .pipe(gulp.dest('./'))

--- a/_tools/run/helpers/helpers.js
+++ b/_tools/run/helpers/helpers.js
@@ -24,6 +24,55 @@ const pathExists = require('./paths/pathExists.js')
 const variantSettings = require('./settings/variantSettings.js')
 const works = require('./paths/works.js')
 const translations = require('./paths/translations.js')
+const entities = require('entities')
+
+// Replaced named entities with numeric entities
+async function replaceNamedEntitiesWithNumeric (filePath) {
+  try {
+    // Read the file content
+    const fileContent = await fs.readFile(filePath, 'utf8')
+
+    // Process the content
+    const processedContent = fileContent
+      // Step 1: Handle escaped entities
+      .replace(/\\(&[a-zA-Z0-9#]+;)/g, (match, entity) => {
+        // Leave escaped entities unchanged
+        return `ESCAPED_ENTITY_${entity}`
+      })
+      // Step 2: Replace non-escaped entities with numeric entities
+      .replace(/&[a-zA-Z0-9#]+;/g, (match) => {
+        // Decode the named entity
+        const decodedChar = entities.decodeHTML(match)
+
+        // Re-encode the character as a numeric (hex) entity
+        return entities.encodeXML(decodedChar)
+      })
+      // Step 3: Restore escaped entities
+      .replace(/ESCAPED_ENTITY_(&[a-zA-Z0-9#]+;)/g, (match, entity) => `\\${entity}`)
+
+    // Write the processed content to the output file
+    await fs.writeFile(filePath, processedContent, 'utf8')
+
+    console.log(`Processed file saved to ${filePath}`)
+  } catch (error) {
+    console.error('Error processing file:', error)
+  }
+}
+
+// Process all HTML content as strings.
+// Useful for simple operations where we don't
+// want to parse the doc as HTML, because
+// rendering it through an AST will break things.
+async function processContent (argv) {
+  // get files
+  const files = await htmlFilePaths(argv)
+
+  // For each one, run processing tasks
+  files.forEach(function (file) {
+    // Replace unescaped named entities with XML entities
+    replaceNamedEntitiesWithNumeric(file)
+  })
+}
 
 // Output spawned-process data to console
 function logProcess (process, processName) {
@@ -1924,6 +1973,7 @@ module.exports = {
   openOutputFile,
   pdfHTMLTransformations,
   processImages,
+  processContent,
   refreshIndexes,
   renderIndexComments,
   renderIndexLinks,

--- a/_tools/run/helpers/output/index.js
+++ b/_tools/run/helpers/output/index.js
@@ -20,6 +20,7 @@ const {
   mathjaxEnabled,
   openOutputFile,
   pdfHTMLTransformations,
+  processContent,
   renderIndexComments,
   renderIndexLinks,
   renderMathjax,
@@ -48,6 +49,7 @@ async function pdf (argv) {
   try {
     await fs.emptyDir(process.cwd() + '/_site')
     await jekyll(argv)
+    await processContent(argv)
     await renderIndexComments(argv)
     await renderIndexLinks(argv)
     await merge(argv)
@@ -67,6 +69,7 @@ async function epub (argv) {
   try {
     await fs.emptyDir(process.cwd() + '/_site')
     await jekyll(argv)
+    await processContent(argv)
     await epubHTMLTransformations(argv)
     await renderIndexComments(argv)
     await renderIndexLinks(argv)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cordova-windows": "^7.0.1",
     "cross-spawn": "^7.0.3",
     "del": "^6.1.1",
+    "entities": "^6.0.0",
     "epubchecker": "^5.1.0",
     "file-exists": "^5.0.1",
     "fs-extra": "^10.1.0",

--- a/samples/01-05-tables.md
+++ b/samples/01-05-tables.md
@@ -22,6 +22,8 @@ That is data from [an actual scientific study](https://www.researchgate.net/publ
 
 Here's a bigger table containing some lists. This table shows the skeletal muscles in your forehead and eyelid.
 
+{% include figure
+html='
 <table>
     <tr>
         <th>Muscle</th>
@@ -34,8 +36,12 @@ Here's a bigger table containing some lists. This table shows the skeletal muscl
         <td>occipitofrontalis</td>
         <td>
             <ul>
-                <li>2 occipital bellies</li>
-                <li>2 frontal bellies</li>
+                <!-- The &nbsp; here are to test that we are
+                correctly processing named entities inside tables,
+                which can be a problem if our process is not
+                managing entities appropriately. -->
+                <li>2&nbsp;occipital bellies</li>
+                <li>2&nbsp;frontal bellies</li>
             </ul>
         </td>
         <td>galea aponeurotica</td>
@@ -51,7 +57,11 @@ Here's a bigger table containing some lists. This table shows the skeletal muscl
             </ul>
         </td>
         <td>galea aponeurotica</td>
-        <td>posterior auricular nerve (facial nerve)</td>
+        <!-- The &nbsp; here are to test that we are
+        correctly processing named entities inside tables,
+        which can be a problem if our process is not
+        managing entities appropriately. -->
+        <td>posterior auricular nerve (facial&nbsp;nerve)</td>
         <td></td>
     </tr>
     <tr>
@@ -94,3 +104,5 @@ Here's a bigger table containing some lists. This table shows the skeletal muscl
         <td>Depresses the eyebrow</td>
     </tr>
 </table>
+'
+%}


### PR DESCRIPTION
Till now, named entities like `&nbsp;` could not be used in tables inside figures. We've had to manually change them to numeric, XML-valid alternatives. This is because our process couldn't re-encode these named entities as numeric ones, since kramdown doesn't 'reach' inside HTML islands. And we need these entities to be valid in XML for epub output, and for processing tools like Cheerio not to break entities in PDF and EPUB output.

So this PR adds a step to our output process that replaces named entities with numeric entities after Jekyll runs, before other processing.

We act on the HTML as a string, and do not try to parse it, because tools that parse the HTML into an AST like parse5, jsdom, or htmlparser2 break XML validity and double-encode entities when they render the HTML back to us.

This processing is not necessary for web and app outputs.

This is currently being tested in a book project at EBW, and should only be merged once it's been field tested in that project.