### PR TITLE
Add margin-bottom to pdf-figures .fixed class

### DIFF
--- a/_sass/template/partials/_pdf-figures.scss
+++ b/_sass/template/partials/_pdf-figures.scss
@@ -132,6 +132,7 @@ $pdf-figures: true !default;
             clear: both;
             float: none;
             margin-top: $line-height-default;
+            margin-bottom: $line-height-default;
         }
 
         // Thumbnail figures


### PR DESCRIPTION
This copies across a change made and tested in the allsa-handbook-of-practical-allergy repo, adding a line space after figures with a class of `fixed`.