### PR TITLE
Allow for same image settings for all books

### DIFF
--- a/_data/images.yml
+++ b/_data/images.yml
@@ -1,7 +1,7 @@
 # Image settings
 # --------------
 # This file sets non-default settings for specific images.
-# Add your book directory, then each image at a "-".
+# Add your book directory (or '_all' for all books), then each image at a "-".
 # For each image, you can set a colorspace (e.g. "gray", "cmyk")
 # or set it to not be modified by automated image processessing.
 # Possible formats: print-pdf, screen-pdf, web, epub, app

--- a/_docs/images/image-conversions.md
+++ b/_docs/images/image-conversions.md
@@ -94,16 +94,27 @@ samples:
       colorspace: "gray"
 ```
 
-To change a setting for all images in a format, you can use 'all' instead of the image filename:
+To change a setting for all images in a format, you can use '_all' instead of the image filename:
 
 ```yaml
 book:
-  - file: "all"
+  - file: "_all"
     print-pdf:
       colorspace: "gray"
 ```
 
-If you have set an image to be grayscale, but your PDF has a CMYK or RGB output intent (as the template's defaults do), Prince will still convert the image to RGB or CMYK, which you probably don't want. To prevent Prince from converting an image's colour profile to match the output intent, add the class `prince-pdf-color-conversion-none` to the image.
+To change a setting for all images in all books, you can use '_all' instead of the book directory name:
+
+```yaml
+_all:
+  - file: "_all"
+    print-pdf:
+      colorspace: "gray"
+```
+
+The underscores avoid potential clashes should you name an actual book folder or image 'all'.
+
+If you have set an image to be grayscale, but your PDF has a CMYK or RGB output intent (as the template's defaults do), Prince will still convert the image to RGB or CMYK, which you probably don't want. To prevent Prince from converting an image's colour profile to match the output intent, add the class `prince-pdf-color-conversion-none` to the image in markdown.
 
 Note that the above color settings *do not change SVGs*. SVGs are processed differently from bitmap-based images like JPGs. If you want to make SVGs grayscale, you may need to use an [SVG filter](https://www.w3.org/TR/filter-effects-1/#grayscaleEquivalent) ([here's an example](https://stackoverflow.com/a/23255391/1781075)) or use print-PDF-specific CSS.
 {:.box}
@@ -122,12 +133,12 @@ samples:
 
 Now the output in print-PDF will be the same as the image in the `_source` folder, with none of the default print-PDF modifications.
 
-You can also use `all` to set an option for all formats.
+You can also use `_all` to set an option for all formats.
 
 ```yaml
 samples:
   - file: "fradkin-1.jpg"
-    all:
+    _all:
       modify: no
 ```
 

--- a/_tools/gulp/helpers/utilities.js
+++ b/_tools/gulp/helpers/utilities.js
@@ -30,8 +30,18 @@ function modifyImageCheck (filename, format) {
     format = 'all'
   }
 
-  if (imageSettings[book]) {
-    imageSettings[book].forEach(function (image) {
+  if (imageSettings && (imageSettings._all || imageSettings[book])) {
+    let settings
+
+    // If there are settings for all books, use those.
+    // Otherwise, use the settings for this book.
+    if (imageSettings._all) {
+      settings = imageSettings._all
+    } else {
+      settings = imageSettings[book]
+    }
+
+    settings.forEach(function (image) {
       if (image.file === filename) {
         // User feedback for images not being modified
         const noModifyFeedback = filename + ' not modified for ' + format + ' format(s), as specified in images.yml'
@@ -51,10 +61,10 @@ function modifyImageCheck (filename, format) {
 
         // If an image has a 'modify' setting for this or all formats...
         if (image.modify || (image[format] && image[format].modify) ||
-                        (image.all && image.all.modify)) {
+                        (image._all && image._all.modify)) {
           // ... and it's set to no, do not modify.
           if (image.modify === 'no' || (image[format] && image[format].modify === 'no') ||
-                            (image.all && image.all.modify === 'no')) {
+                            (image._all && image._all.modify === 'no')) {
             console.log(noModifyFeedback)
             modifyImage = false
           }
@@ -100,9 +110,19 @@ function lookupColorSettings (gmfile,
   const filename = getFilenameFromPath(gmfile.source)
 
   // Look up image settings
-  if (imageSettings[book]) {
-    imageSettings[book].forEach(function (image) {
-      if (image.file === filename || image.file === 'all') {
+  if (imageSettings && (imageSettings._all || imageSettings[book])) {
+    let settings
+
+    // If there are settings for all books, use those.
+    // Otherwise, use the settings for this book.
+    if (imageSettings._all) {
+      settings = imageSettings._all
+    } else {
+      settings = imageSettings[book]
+    }
+
+    settings.forEach(function (image) {
+      if (image.file === filename || image.file === '_all') {
         if (image[outputFormat] && image[outputFormat].colorspace === 'gray') {
           colorProfile = colorProfileGrayscale
           colorSpace = colorSpaceGrayscale


### PR DESCRIPTION
In some projects, we want the same image settings for all books. This change lets us do that.

We no longer have to remember to add each new book to the settings in `images.yml` if all books need the same image settings.