### PR TITLE
Improve figure-rotation in PDF

### DIFF
--- a/_sass/template/partials/_pdf-figures.scss
+++ b/_sass/template/partials/_pdf-figures.scss
@@ -209,7 +209,7 @@ $pdf-figures: true !default;
     // Get the proportions we need
     $rotator-content-width: $page-width - $margin-inside - $margin-outside;
     $rotator-content-height: $page-height - $margin-top - $margin-bottom;
-    $rotator-content-wh-ratio: (1 - $rotator-content-width/$rotator-content-height) * 100%;
+    $rotator-content-sidebar-width: $sidebar-content-width + $sidebar-gap-width;
 
     .figure-rotator-wrapper {
         // First we float the wrapper to the top of the page,
@@ -217,19 +217,31 @@ $pdf-figures: true !default;
         float: top;
         height: $rotator-content-height;
         width: $rotator-content-width;
+        break-before: verso;
+        break-after: page;
+
+        // When extending into the sidebar, add its width
+        &.pdf-wide {
+            float: sidenote;
+            width: $rotator-content-width + $rotator-content-sidebar-width;
+
+            .figure-rotator {
+                height: $rotator-content-width + $rotator-content-sidebar-width;
+            }
+        }
 
         .figure-rotator {
             // First we reverse the rotating div's proportions.
             height: $rotator-content-width;
-            width: $rotator-content-height;
+            width: $rotator-content-height; // may be overridden by greater specifity above
             // Then we get this div into its new position:
-            // 1. We choose to rotate from the bottom-left corner.
-            transform-origin: bottom left;
+            // 1. We choose to rotate from the top-left corner.
+            transform-origin: top left;
             // 2. Rotate the div anti-clockwise 90%.
-            // 3. Shift the div right by its own (now) width.
-            // 4. Shift the div down by the proportion of the content area's width:height.
+            // 4. Shift the div down by the content area's height,
+            //    rememebering that, rotated, 'down' is x not y.
             // Now it's exactly in position.
-            transform: rotate(-90deg) translatey(100%) translatex(-($rotator-content-wh-ratio));
+            transform: rotate(-90deg) translatex(-($rotator-content-height));
             // Finally we set it to display: table, for the vertical centering to come below.
             display: table;
 
@@ -242,7 +254,7 @@ $pdf-figures: true !default;
                 width: $rotator-content-height;
                 // Center the figure on the page ('vertically' if you're looking sideways!).
                 display: table-cell;
-                vertical-align: middle;
+                vertical-align: top;
 
                 .figure-body {
 
@@ -250,6 +262,10 @@ $pdf-figures: true !default;
                         // Adjust the margins that tables in figures inherit.
                         margin: 0 0 $line-height-default 0; // overrides inherited margin
                     }
+                }
+
+                &.vertical-align-bottom {
+                    vertical-align: bottom;
                 }
             }
         }


### PR DESCRIPTION
This is necessary to handle recent changes to the way sidebars work with figure rotation.

Rotating figures can still be a bit hit-and-miss from book to book.