### PR TITLE
Support visual-TOC numbers as icons

### DIFF
--- a/_docs/layout/landing-page.md
+++ b/_docs/layout/landing-page.md
@@ -55,6 +55,12 @@ To gather multiple feature boxes as siblings, wrap one or more of these tags in 
 ```
 {% endraw %}
 
+Since your images are likely to be cropped automatically, you can also adjust where to focus on your image once cropped, by adding an `image-position` argument. This uses the same syntax as the [CSS `object-position` property](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position). For example, this will focus on the upper area of the image:
+
+```
+image-position="50% 20%"
+```
+
 The images used in feature boxes should be in `assets/images/_source` and [converted for the template's output formats](image-conversions.html).
 
 ## Full-width coloured panels
@@ -122,3 +128,29 @@ image: "fradkin-2.jpg"
 description: "A research paper that includes figures with reference numbers, captions and sources."
 ---
 ```
+
+If your page titles start with numbers, e.g:
+
+```
+title: "1. Setting Up"
+```
+
+you can choose to use those numbers as your chapter icons instead of images. To do this, add the argument `thumbnails="numbers"` to your include tag:
+
+{% raw %}
+{% include visual-toc
+   book="samples"
+   files="
+   * 00-05-contents-page
+   * 01-01-plain-text-1
+   * 01-10-questions
+   * 02-01-plain-images
+   * 02-02-figures
+   * 03-02-maths
+   * 04-02-video
+   * 10-02-dynamic-index
+"
+  thumbnails="numbers"
+%}
+```
+{% endraw %}

--- a/_includes/visual-toc
+++ b/_includes/visual-toc
@@ -4,7 +4,8 @@
 
     {% assign visual-toc-files = include.files | strip_newlines | remove: " " | split: "*" %}
 
-    <ul class="visual-toc-list">
+    <ul class="visual-toc-list
+        {% if include.thumbnails == "numbers" %}visual-toc-list-numbered{% endif %}">
         {% for visual-toc-file in visual-toc-files %}
             {% if visual-toc-file and visual-toc-file !="" %}
 
@@ -20,14 +21,29 @@
                         {% if visual-toc-page-object.image and visual-toc-page-object.image != "" %}
                             <div class="visual-toc-chapter-image">
                                 <a href="{{ visual-toc-path-to-file }}.html" aria-label="{{ locale.visual-toc.link-to-page-assistive-text }}">
-                                    {% include image file=visual-toc-page-object.image folder=include.book position=visual-toc-page-object.image-position %}
+                                    {% if include.thumbnails == "numbers" %}
+                                        {% capture thumbnail-initial %}{{visual-toc-page-object.title | split: "." | first }}{% endcapture %}
+                                        <div class="visual-toc-thumbnail-initial">{{ thumbnail-initial }}</div>
+                                    {% else %}
+                                        {% include image file=visual-toc-page-object.image folder=include.book position=visual-toc-page-object.image-position %}
+                                    {% endif %}
                                 </a>
                             </div>
                         {% endif %}
 
                         <div class="visual-toc-chapter-title">
                             <a href="{{ visual-toc-path-to-file }}.html">
-                                {{ visual-toc-page-object.title | markdownify | remove: "<p>" | remove: "</p>" }}
+
+                                {% comment %} If the titles start with numbers, e.g. '1. The Dog Bus',
+                                we can use those numbers as the thumbnails instead of images
+                                by specifying 'thumbnails="numbers"' in the include tag.
+                                Otherwise, escape the . so that the title isn't a markdown ol > li {% endcomment %}
+
+                                {% if include.thumbnails == "numbers" %}
+                                    {{ visual-toc-page-object.title | markdownify | remove: "<p>" | remove: "</p>" }}
+                                {% else %}
+                                    {{ visual-toc-page-object.title | replace: ".", "\." | markdownify | remove: "<p>" | remove: "</p>" }}
+                                {% endif %}
                             </a>
                         </div>
 

--- a/_sass/template/partials/_web-visual-toc.scss
+++ b/_sass/template/partials/_web-visual-toc.scss
@@ -29,7 +29,9 @@ $web-visual-toc: true !default;
             margin: 0;
             padding: 0;
 
-            li {
+            & > li {
+
+                margin-bottom: 2rem;
 
                 @media only screen and (min-width: $max-width-default) {
                     display: grid;
@@ -37,9 +39,6 @@ $web-visual-toc: true !default;
                     grid-template-rows: max-content 1fr;
                     margin-bottom: 0;
                 }
-
-                clear: both;
-                margin-bottom: 2rem;
 
                 // Ensure element expands to the height`
                 // of its floated child (the image)
@@ -74,13 +73,25 @@ $web-visual-toc: true !default;
                         width: 8rem;
                         object-fit: cover;
                     }
+
+                    .visual-toc-thumbnail-initial {
+                        width: 100%;
+                        height: 100%;
+                        text-align: center;
+                        font-size: 4rem;
+                        padding: 2.5rem 0;
+                        background-color: $color-accent;
+                        color: $white;
+                    }
                 }
 
                 .visual-toc-chapter-title {
                     font-weight: bold;
+                    margin-top: 0.5rem;
 
                     @media only screen and (min-width: $max-width-default) {
                         grid-column-start: 3;
+                        margin-top: 0;
                     }
                 }
 
@@ -89,6 +100,17 @@ $web-visual-toc: true !default;
                     @media only screen and (min-width: $max-width-default) {
                         grid-column-start: 3;
                     }
+                }
+            }
+
+            // If using numbers as chapter icons,
+            // don't display numbers created by
+            // markdown ordered lists.
+            &.visual-toc-list-numbered {
+
+                ol {
+                    list-style-type: none;
+                    margin: 0;
                 }
             }
         }


### PR DESCRIPTION
As the new docs here explain, this enables using file/chapter/page numbering in `title`s as icons in the landing-page visual TOC.

Also adds support for setting `image-position` on visual-TOC icon images.