### PR TITLE
PDF indent fix

### DIFF
--- a/_sass/template/partials/_pdf-base-typography.scss
+++ b/_sass/template/partials/_pdf-base-typography.scss
@@ -98,12 +98,26 @@ $convert-images-to-color-profile: false !default;
                         }
                     }
 
+                    // Don't indent paras visually after headings,
+                    // separated in the DOM by floated elements.
+                    h1, h2, h3, h4, h5, h6 {
+                        & + .#{$class} + .#{$second-sibling-class} + p {
+                            text-indent: 0;
+                        }
+                    }
+
                     @each $third-sibling-class in $floated-element-classes {
                         p + .#{$class} + .#{$second-sibling-class} + .#{$third-sibling-class} + p {
                             text-indent: $paragraph-indent;
 
                             &.first,
                             &.box {
+                                text-indent: 0;
+                            }
+                        }
+
+                        h1, h2, h3, h4, h5, h6 {
+                            & + .#{$class} + .#{$second-sibling-class} + .#{$third-sibling-class} + p {
                                 text-indent: 0;
                             }
                         }

--- a/_sass/template/print-pdf.scss
+++ b/_sass/template/print-pdf.scss
@@ -219,11 +219,6 @@ $opener-image-height: $page-height * 0.4 !default;
 // Remember to tag links to front matter pages in your TOC with {:.frontmatter-reference}
 $frontmatter-reference-style: lower-roman !default; // lower-roman, decimal, see http://www.princexml.com/doc/gen-content/#idp54010640
 
-// Elements that float. When these are surrounded by paragraphs,
-// the following paragraph should be indented when we are not
-// using $spaced-paras.
-$floated-element-classes: sidenote, qr-code !default;
-
 // Title page
 $title-page-logo-width: $paragraph-indent * 3 !default;
 $title-page-logo-font: $font-text-main !default;
@@ -232,7 +227,7 @@ $title-page-logo-font-size: $font-size-default - 1 !default;
 // Elements that float. When these are surrounded by paragraphs,
 // the following paragraph should be indented when we are not
 // using $spaced-paras.
-$floated-element-classes: sidenote !default;
+$floated-element-classes: sidenote, qr-code !default;
 
 // Set the content of headers and footers.
 //


### PR DESCRIPTION
Two small fixes in this PR:

- fixes an issue where a paragraph can appear wrongly indented if it appears visually after a heading, but in the DOM follows a floated paragraph
- fixes accidental duplication of a variable definition.
