### PR TITLE
Use null in _config.math-disabled.yml

### DIFF
--- a/_configs/_config.math-disabled.yml
+++ b/_configs/_config.math-disabled.yml
@@ -1,4 +1,4 @@
 # Disable processing of LaTeX for MathJax completely.
 # This will leave `$$E=mc^2$$` in your HTML as in your markdown.
 kramdown:
-  math_engine: nil
+  math_engine: null


### PR DESCRIPTION
We must used `null` not `nil` to avoid a new bug noted in https://github.com/jekyll/jekyll/issues/8256.