### PR TITLE
Allow more reliable Puppeteer in containers

### DIFF
--- a/_tools/run/helpers/reindex/build-reference-index.js
+++ b/_tools/run/helpers/reindex/build-reference-index.js
@@ -12,7 +12,13 @@ async function buildReferenceIndex (outputFormat, filesData) {
   const targetsIndex = []
 
   // Launch the browser.
-  const browser = await puppeteer.launch({ headless: true })
+  // Run with no sandbox which is necessary for
+  // containerized environments like Docker,
+  // and only safe in development environments.
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  })
 
   let i
   let count = 0

--- a/_tools/run/helpers/reindex/build-search-index.js
+++ b/_tools/run/helpers/reindex/build-search-index.js
@@ -43,7 +43,13 @@ async function buildSearchIndex (outputFormat, filesData) {
   await fsExtra.emptyDir(fsPath.normalize(process.cwd() + '/_api/content'))
 
   // Launch the browser
-  const browser = await puppeteer.launch({ headless: true })
+  // Run with no sandbox which is necessary for
+  // containerized environments like Docker,
+  // and only safe in development environments.
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  })
 
   let i
   let count = 0


### PR DESCRIPTION
On some virtual IDEs (e.g. Codespaces), our indexing process fails if Puppeteer can't run because of a
kernel issue. Running in `--no-sandbox` mode gets around this. This is safe in a dev env like ours.