### PR TITLE
Prevent PDF page breaks after index targets

### DIFF
--- a/_sass/template/partials/_pdf-index.scss
+++ b/_sass/template/partials/_pdf-index.scss
@@ -12,15 +12,18 @@ $pdf-index: true !default;
 		columns: 2;
 		font-size: $font-size-default * $font-size-smaller;
 		margin: $line-height-default 0 0 0;
+
 		li {
 			list-style-type: none;
 			margin: 0 0 0 ($paragraph-indent * 1);
 			text-indent: $paragraph-indent * (-1);
 			text-align: left;
+
 			li {
 				margin: 0 0 0 ($paragraph-indent / 2);
 			}
 		}
+
 		a {
 			// content: target-counter(attr(href), page);
 
@@ -47,15 +50,31 @@ $pdf-index: true !default;
 				content: prince-script(indexPageReference, target-counter(attr(href), page), 'to', '\2013');
 			}
 		}
+
 		// To hide but not delete duplicate entries.
 		.duplicate {
 			display: none;
 		}
 	}
+
 	// For links in main body text that jump to index.
 	a.indexed {
 		color: inherit;
 		text-decoration: none;
 	}
 
+	.index-target {
+
+		// Don't break a page between an index target
+		// and the text that it targets.
+		break-after: avoid;
+	}
+
+	// Don't break between headings and their preceding index targets
+	h1, h2, h3, h4, h5, h6 {
+
+		.index-target + & {
+			break-before: avoid;
+		}
+	}
 }


### PR DESCRIPTION
In PDF output, an index target can get separated from the text it relates to by a page break. 

This can also cause unexpecte dbehaviour when an index target relates to the heading of a box: the box can appear to start on one page, containing no text, and then continue on the next page with its first heading. This is because to Prince the index target is the first thing in the box, and therefore the box appears to start empty but contains an invisible index target.

These CSS changes aim to avoid that.
