### PR TITLE
Fix typo preventing full accessibility metadata

### DIFF
--- a/_data/works/book/default.yml
+++ b/_data/works/book/default.yml
@@ -121,7 +121,7 @@ products:
 
       # Comma-separate possible values, see
       # https://www.w3.org/TR/epub-a11y-tech-11/#accessibilityHazard
-      accessibility-hazard: unknown
+      accessibility-hazards: unknown
 
   # Details about the screen-PDF version of this work
   screen-pdf:

--- a/_data/works/samples/default.yml
+++ b/_data/works/samples/default.yml
@@ -503,7 +503,7 @@ products:
 
       # Comma-separate possible values, see
       # https://www.w3.org/TR/epub-a11y-tech-11/#accessibilityHazard
-      accessibility-hazard: unknown
+      accessibility-hazards: unknown
 
     # Files to include in this format.
     # In the epub files list, add a value to any file


### PR DESCRIPTION
This fixes a misspelling that meant the `accessibilityHazard` metadata was not being generated in EPUBs' `package.opf``.