### PR TITLE
Fix button colour on colour-switched pages

### DIFF
--- a/_sass/template/partials/_web-color-switches.scss
+++ b/_sass/template/partials/_web-color-switches.scss
@@ -14,8 +14,11 @@ $web-color-switches: true !default;
                     color: $color-headings-switched;
                 }
 
-                a {
-                    color: $color-links-switched;
+                // Links except for buttons
+                :not(.button) {
+                    > a {
+                        color: $color-links-switched;
+                    }
                 }
 
                 // Do not switch color of headings


### PR DESCRIPTION
In the template, this is any button added to the home page, which is colour-switched in CSS variables by default.

To test, add a button to the home page with:

```
[Test me](#testme)
{:.button}
```

Since the home page is a 'colour switched page' in `_sass/template/web.scss`

```
$color-switched-pages: home !default;
```

the colour of the button text needs this fix due to CSS specificity issues.
